### PR TITLE
Address obsoletion warning

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceClientException.cs
+++ b/src/Microsoft.OData.Client/DataServiceClientException.cs
@@ -7,19 +7,15 @@
 namespace Microsoft.OData.Client
 {
     using System;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Runtime.Serialization;
-    using System.Security.Permissions;
 
     /// <summary>
     /// The exception that is thrown when the server returns an error.
     /// </summary>
-    [Serializable]
     [System.Diagnostics.DebuggerDisplay("{Message}")]
-    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors", Justification = "No longer relevant after .NET 4 introduction of SerializeObjectState event and ISafeSerializationData interface.")]
     public sealed class DataServiceClientException : InvalidOperationException
     {
         private readonly int statusCode;
+
         #region Constructors
 
         /// <summary>Initializes a new instance of the <see cref="Microsoft.OData.Client.DataServiceClientException" /> class with a system-supplied message that describes the error. </summary>
@@ -61,12 +57,6 @@ namespace Microsoft.OData.Client
             this.statusCode = statusCode;
         }
 
-        private DataServiceClientException(SerializationInfo info, StreamingContext context)
-: base(info, context)
-        {
-            this.statusCode = info.GetInt32("StatusCode");
-        }
-
         #endregion Constructors
 
 
@@ -80,20 +70,5 @@ namespace Microsoft.OData.Client
         }
 
         #endregion Public properties
-
-        [SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
-        public override void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
-
-            info.AddValue("StatusCode", this.statusCode);
-
-            // MUST call through to the base class to let it save its own state
-            base.GetObjectData(info, context);
-        }
-
     }
 }

--- a/src/Microsoft.OData.Client/DataServiceClientException.cs
+++ b/src/Microsoft.OData.Client/DataServiceClientException.cs
@@ -7,11 +7,12 @@
 namespace Microsoft.OData.Client
 {
     using System;
+    using System.Diagnostics;
 
     /// <summary>
     /// The exception that is thrown when the server returns an error.
     /// </summary>
-    [System.Diagnostics.DebuggerDisplay("{Message}")]
+    [DebuggerDisplay("{Message}")]
     public sealed class DataServiceClientException : InvalidOperationException
     {
         private readonly int statusCode;

--- a/src/Microsoft.OData.Client/DataServiceQueryException.cs
+++ b/src/Microsoft.OData.Client/DataServiceQueryException.cs
@@ -7,10 +7,10 @@
 namespace Microsoft.OData.Client
 {
     using System;
+    using System.Diagnostics;
 
     /// <summary>Exception that indicates an error occurred while querying the data service. </summary>
-    [Serializable]
-    [System.Diagnostics.DebuggerDisplay("{Message}")]
+    [DebuggerDisplay("{Message}")]
     public sealed class DataServiceQueryException : InvalidOperationException
     {
         #region Private fields
@@ -23,20 +23,20 @@ namespace Microsoft.OData.Client
 
         #region Constructors
 
-        /// <summary>Initializes a new instance of the <see cref="Microsoft.OData.Client.DataServiceQueryException" /> class with a system-supplied message that describes the error. </summary>
+        /// <summary>Initializes a new instance of the <see cref="DataServiceQueryException" /> class with a system-supplied message that describes the error. </summary>
         public DataServiceQueryException()
             : base(SRResources.DataServiceException_GeneralError)
         {
         }
 
-        /// <summary>Initializes a new instance of the <see cref="Microsoft.OData.Client.DataServiceQueryException" /> class with a specified message that describes the error. </summary>
+        /// <summary>Initializes a new instance of the <see cref="DataServiceQueryException" /> class with a specified message that describes the error. </summary>
         /// <param name="message">The message that describes the exception. The caller of this constructor is required to ensure that this string has been localized for the current system culture.The string value that the contains error message.</param>
         public DataServiceQueryException(string message)
             : base(message)
         {
         }
 
-        /// <summary>Initializes a new instance of the <see cref="Microsoft.OData.Client.DataServiceQueryException" /> class with a specified error message and a reference to the inner exception that is the cause of this exception. </summary>
+        /// <summary>Initializes a new instance of the <see cref="DataServiceQueryException" /> class with a specified error message and a reference to the inner exception that is the cause of this exception. </summary>
         /// <param name="message">The message that describes the exception. The caller of this constructor is required to ensure that this string has been localized for the current system culture. The string value that contains the error message.</param>
         /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException" /> parameter is not null, the current exception is raised in a catch block that handles the inner exception. The inner exception object.</param>
         public DataServiceQueryException(string message, Exception innerException)
@@ -44,41 +44,22 @@ namespace Microsoft.OData.Client
         {
         }
 
-        /// <summary>Initializes a new instance of the <see cref="Microsoft.OData.Client.DataServiceQueryException" /> class. </summary>
+        /// <summary>Initializes a new instance of the <see cref="DataServiceQueryException" /> class. </summary>
         /// <param name="message">The string value that contains the error message.</param>
         /// <param name="innerException">The inner exception object.</param>
-        /// <param name="response">The <see cref="Microsoft.OData.Client.QueryOperationResponse" /> object.</param>
+        /// <param name="response">The <see cref="QueryOperationResponse" /> object.</param>
         public DataServiceQueryException(string message, Exception innerException, QueryOperationResponse response)
             : base(message, innerException)
         {
             this.response = response;
         }
 
-#pragma warning disable 0628
-        /// <summary>
-        /// Initializes a new instance of the DataServiceQueryException class from the
-        /// specified SerializationInfo and StreamingContext instances.
-        /// </summary>
-        /// <param name="info">
-        /// A SerializationInfo containing the information required to serialize
-        /// the new DataServiceQueryException.</param>
-        /// <param name="context">
-        /// A StreamingContext containing the source of the serialized stream
-        /// associated with the new DataServiceQueryException.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1047", Justification = "Follows serialization info pattern.")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1032", Justification = "Follows serialization info pattern.")]
-        protected DataServiceQueryException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
-        {
-        }
-#pragma warning restore 0628
-
         #endregion Constructors
 
         #region Public properties
 
-        /// <summary>Gets the <see cref="Microsoft.OData.Client.QueryOperationResponse" /> that indicates the exception results.</summary>
-        /// <returns>A <see cref="Microsoft.OData.Client.QueryOperationResponse" /> object that indicates the exception results.</returns>
+        /// <summary>Gets the <see cref="QueryOperationResponse" /> that indicates the exception results.</summary>
+        /// <returns>A <see cref="QueryOperationResponse" /> object that indicates the exception results.</returns>
         public QueryOperationResponse Response
         {
             get { return this.response; }

--- a/src/Microsoft.OData.Client/DataServiceRequestException.cs
+++ b/src/Microsoft.OData.Client/DataServiceRequestException.cs
@@ -7,10 +7,10 @@
 namespace Microsoft.OData.Client
 {
     using System;
+    using System.Diagnostics;
 
     /// <summary>Represents the error thrown if the data service returns a response code less than 200 or greater than 299, or the top-level element in the response is &lt;error&gt;. This class cannot be inherited.</summary>
-    [Serializable]
-    [System.Diagnostics.DebuggerDisplay("{Message}")]
+    [DebuggerDisplay("{Message}")]
     public sealed class DataServiceRequestException : InvalidOperationException
     {
         /// <summary>Actual response object.</summary>
@@ -19,20 +19,20 @@ namespace Microsoft.OData.Client
 
         #region Constructors
 
-        /// <summary>Initializes a new instance of the <see cref="Microsoft.OData.Client.DataServiceRequestException" /> class with a system-supplied message that describes the error. </summary>
+        /// <summary>Initializes a new instance of the <see cref="DataServiceRequestException" /> class with a system-supplied message that describes the error. </summary>
         public DataServiceRequestException()
             : base(SRResources.DataServiceException_GeneralError)
         {
         }
 
-        /// <summary>Initializes a new instance of the <see cref="Microsoft.OData.Client.DataServiceRequestException" /> class with a specified message that describes the error. </summary>
+        /// <summary>Initializes a new instance of the <see cref="DataServiceRequestException" /> class with a specified message that describes the error. </summary>
         /// <param name="message">The message that describes the exception. The caller of this constructor is required to ensure that this string has been localized for the current system culture.The error message text.</param>
         public DataServiceRequestException(string message)
             : base(message)
         {
         }
 
-        /// <summary>Initializes a new instance of the <see cref="Microsoft.OData.Client.DataServiceRequestException" /> class with a specified error message and a reference to the inner exception that is the cause of this exception. </summary>
+        /// <summary>Initializes a new instance of the <see cref="DataServiceRequestException" /> class with a specified error message and a reference to the inner exception that is the cause of this exception. </summary>
         /// <param name="message">The message that describes the exception. The caller of this constructor is required to ensure that this string has been localized for the current system culture. </param>
         /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException" /> parameter is not null, the current exception is raised in a catch block that handles the inner exception. </param>
         public DataServiceRequestException(string message, Exception innerException)
@@ -40,41 +40,22 @@ namespace Microsoft.OData.Client
         {
         }
 
-        /// <summary>Initializes a new instance of the <see cref="Microsoft.OData.Client.DataServiceRequestException" /> class. </summary>
+        /// <summary>Initializes a new instance of the <see cref="DataServiceRequestException" /> class. </summary>
         /// <param name="message">Error message text.</param>
         /// <param name="innerException">Exception object that contains the inner exception.</param>
-        /// <param name="response"><see cref="Microsoft.OData.Client.DataServiceResponse" /> object.</param>
+        /// <param name="response"><see cref="DataServiceResponse" /> object.</param>
         public DataServiceRequestException(string message, Exception innerException, DataServiceResponse response)
             : base(message, innerException)
         {
             this.response = response;
         }
 
-#pragma warning disable 0628
-        /// <summary>
-        /// Initializes a new instance of the DataServiceQueryException class from the
-        /// specified SerializationInfo and StreamingContext instances.
-        /// </summary>
-        /// <param name="info">
-        /// A SerializationInfo containing the information required to serialize
-        /// the new DataServiceException.</param>
-        /// <param name="context">
-        /// A StreamingContext containing the source of the serialized stream
-        /// associated with the new DataServiceException.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1047", Justification = "Follows serialization info pattern.")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1032", Justification = "Follows serialization info pattern.")]
-        protected DataServiceRequestException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
-        {
-        }
-#pragma warning restore 0628
-
         #endregion Constructors
 
         #region Public properties
 
-        /// <summary>Gets the response as a <see cref="Microsoft.OData.Client.DataServiceResponse" /> object. </summary>
-        /// <returns>A <see cref="Microsoft.OData.Client.DataServiceResponse" /> object.</returns>
+        /// <summary>Gets the response as a <see cref="DataServiceResponse" /> object. </summary>
+        /// <returns>A <see cref="DataServiceResponse" /> object.</returns>
         public DataServiceResponse Response
         {
             get { return this.response; }

--- a/src/Microsoft.OData.Client/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -454,7 +454,6 @@ Microsoft.OData.Client.DataServiceStreamResponse.Headers.get -> System.Collectio
 Microsoft.OData.Client.DataServiceStreamResponse.Stream.get -> System.IO.Stream
 Microsoft.OData.Client.DataServiceTransportException
 Microsoft.OData.Client.DataServiceTransportException.DataServiceTransportException(Microsoft.OData.IODataResponseMessage response, System.Exception innerException) -> void
-Microsoft.OData.Client.DataServiceTransportException.DataServiceTransportException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 Microsoft.OData.Client.DataServiceTransportException.Response.get -> Microsoft.OData.IODataResponseMessage
 Microsoft.OData.Client.DataServiceUrlKeyDelimiter
 Microsoft.OData.Client.DeleteLinkUriOption
@@ -755,7 +754,6 @@ override Microsoft.OData.Client.DataServiceQueryContinuation.ToString() -> strin
 override Microsoft.OData.Client.DataServiceRequest<TElement>.ElementType.get -> System.Type
 override Microsoft.OData.Client.DataServiceRequest<TElement>.RequestUri.get -> System.Uri
 override Microsoft.OData.Client.DataServiceRequest<TElement>.ToString() -> string
-override Microsoft.OData.Client.DataServiceTransportException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 override Microsoft.OData.Client.HttpClientRequestMessage.Abort() -> void
 override Microsoft.OData.Client.HttpClientRequestMessage.BeginGetRequestStream(System.AsyncCallback callback, object state) -> System.IAsyncResult
 override Microsoft.OData.Client.HttpClientRequestMessage.BeginGetResponse(System.AsyncCallback callback, object state) -> System.IAsyncResult

--- a/src/Microsoft.OData.Client/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -745,7 +745,6 @@ override Microsoft.OData.Client.ALinq.UriParser.SystemToken.Identifier.get -> st
 override Microsoft.OData.Client.ALinq.UriParser.SystemToken.IsNamespaceOrContainerQualified() -> bool
 override Microsoft.OData.Client.ALinq.UriParser.UnaryOperatorToken.Accept<T>(Microsoft.OData.Client.ALinq.UriParser.ISyntacticTreeVisitor<T> visitor) -> T
 override Microsoft.OData.Client.ALinq.UriParser.UnaryOperatorToken.Kind.get -> Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind
-override Microsoft.OData.Client.DataServiceClientException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 override Microsoft.OData.Client.DataServiceCollection<T>.InsertItem(int index, T item) -> void
 override Microsoft.OData.Client.DataServiceQuery<TElement>.ElementType.get -> System.Type
 override Microsoft.OData.Client.DataServiceQuery<TElement>.Expression.get -> System.Linq.Expressions.Expression


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3181.*

### Description

The following kinds of APIs are obsolete, starting in .NET 8. Calling them in code generates warning [SYSLIB0051](https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0051) at compile time.

All public or protected serialization constructors that follow the pattern .ctor(SerializationInfo, StreamingContext). An example of such a constructor is [Exception(SerializationInfo, StreamingContext)](https://learn.microsoft.com/en-us/dotnet/api/system.exception.-ctor#system-exception-ctor(system-runtime-serialization-serializationinfo-system-runtime-serialization-streamingcontext)).
All implicit implementations of the [ISerializable.GetObjectData(SerializationInfo, StreamingContext)](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.iserializable.getobjectdata#system-runtime-serialization-iserializable-getobjectdata(system-runtime-serialization-serializationinfo-system-runtime-serialization-streamingcontext)) method, for example, [System.Exception.GetObjectData(SerializationInfo, StreamingContext)](https://learn.microsoft.com/en-us/dotnet/api/system.exception.getobjectdata#system-exception-getobjectdata(system-runtime-serialization-serializationinfo-system-runtime-serialization-streamingcontext)).
All implicit implementations of the [IObjectReference.GetRealObject(StreamingContext)](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.iobjectreference.getrealobject#system-runtime-serialization-iobjectreference-getrealobject(system-runtime-serialization-streamingcontext)) method, for example, [System.Reflection.ParameterInfo.GetRealObject(StreamingContext)](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.parameterinfo.getrealobject#system-reflection-parameterinfo-getrealobject(system-runtime-serialization-streamingcontext)).

This pull request addresses the obsoletion warnings.

### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
