### PR TITLE
Remove pruned references

### DIFF
--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -123,10 +123,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.ComponentModel" Version="4.3.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Security.Permissions" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -47,10 +47,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
   
- <ItemGroup >
+ <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.3" />
   </ItemGroup>

--- a/src/Microsoft.OData.Core/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,8 @@
+Microsoft.OData.UriParser.CustomQueryOptionNode
+Microsoft.OData.UriParser.CustomQueryOptionNode.CustomQueryOptionNode(string name, string value) -> void
+Microsoft.OData.UriParser.CustomQueryOptionNode.Name.get -> string
+Microsoft.OData.UriParser.CustomQueryOptionNode.Value.get -> string
+Microsoft.OData.UriParser.QueryNodeKind.CustomQueryOption = 35 -> Microsoft.OData.UriParser.QueryNodeKind
+override Microsoft.OData.UriParser.CustomQueryOptionNode.Accept<T>(Microsoft.OData.UriParser.QueryNodeVisitor<T> visitor) -> T
+override Microsoft.OData.UriParser.CustomQueryOptionNode.Kind.get -> Microsoft.OData.UriParser.QueryNodeKind
+virtual Microsoft.OData.UriParser.QueryNodeVisitor<T>.Visit(Microsoft.OData.UriParser.CustomQueryOptionNode nodeIn) -> T

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Microsoft.OData.Client.Tests.csproj
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Microsoft.OData.Client.Tests.csproj
@@ -43,7 +43,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
@@ -22,8 +22,6 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <Import Project="..\Build.props" />

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/Microsoft.OData.Edm.Tests.csproj
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/Microsoft.OData.Edm.Tests.csproj
@@ -40,8 +40,6 @@
 
   <ItemGroup>
      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
    
   <ItemGroup>

--- a/test/UnitTests/Microsoft.Spatial.Tests/Microsoft.Spatial.Tests.csproj
+++ b/test/UnitTests/Microsoft.Spatial.Tests/Microsoft.Spatial.Tests.csproj
@@ -34,8 +34,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

This pull request removes the following pruned references to get rid of existing build warnings:
- System.Het.Http
- System.ValueTuple
- System.ComponentModel
- System.ComponentModel.Annotations
- System.Text.RegularExpressions
- System.Buffers

The pull request also updates 9.0 public API

### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*
