### PR TITLE
Troubleshoot nuget.org access failures

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -35,6 +35,8 @@ variables:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Preferred,Nuget.org # Change to Good,Nuget.org if it gets too restrictive
     pool:
       name: MSSecurity-1ES-Build-Agents-Pool
       image: MSSecurity-1ES-Windows-2022

--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -37,6 +37,8 @@ variables:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Preferred,Nuget.org # Change to Good,Nuget.org if it gets too restrictive
     pool:
       name: MSSecurity-1ES-Build-Agents-Pool
       image: MSSecurity-1ES-Windows-2022


### PR DESCRIPTION
### Description

Troubleshoot nuget.org access failures. Network isolation changes applied to 1ES pipelines caused builds to start failing.

### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*
