### PR TITLE
Treat unencoded `/` inside quoted literals as data (not separators)

### DIFF
--- a/src/Microsoft.OData.Core/SRResources.Designer.cs
+++ b/src/Microsoft.OData.Core/SRResources.Designer.cs
@@ -6958,6 +6958,15 @@ namespace Microsoft.OData.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This operation is not supported for a relative URI. (parameter: &apos;{0}&apos;)..
+        /// </summary>
+        internal static string UriUtils_RequiresAbsoluteUri {
+            get {
+                return ResourceManager.GetString("UriUtils_RequiresAbsoluteUri", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The UrlValidator used to validate an ODataUri must use the same Model as the ODataUriParser..
         /// </summary>
         internal static string UriValidator_ValidatorMustUseSameModelAsParser {

--- a/src/Microsoft.OData.Core/SRResources.resx
+++ b/src/Microsoft.OData.Core/SRResources.resx
@@ -2612,4 +2612,7 @@
   <data name="TypeUtils_TypeNameIsNotQualified" xml:space="preserve">
     <value>The value '{0}' is not a qualified type name. A qualified type name is expected.</value>
   </data>
+  <data name="UriUtils_RequiresAbsoluteUri" xml:space="preserve">
+    <value>This operation is not supported for a relative URI. (parameter: '{0}').</value>
+  </data>
 </root>

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriPathParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriPathParser.cs
@@ -4,10 +4,11 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using Microsoft.OData.Core;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
+using Microsoft.OData.Core;
 
 namespace Microsoft.OData.UriParser
 {
@@ -38,11 +39,28 @@ namespace Microsoft.OData.UriParser
         /// <returns>List of unescaped segments.</returns>
         public virtual ICollection<string> ParsePathIntoSegments(Uri fullUri, Uri serviceBaseUri)
         {
+            // Necessary: UriUtils.UriInvariantInsensitiveIsBaseOf relies on absolute/non-null; Debug.Assert is no-op in release.
+            ExceptionUtils.CheckArgumentNotNull(fullUri, nameof(fullUri));
+
             if (serviceBaseUri == null)
             {
                 Debug.Assert(!fullUri.IsAbsoluteUri, "fullUri must be relative Uri");
-                serviceBaseUri = UriUtils.CreateMockAbsoluteUri();
-                fullUri = UriUtils.CreateMockAbsoluteUri(fullUri);
+                serviceBaseUri = UriUtils.CreateMockAbsoluteUri(); // -> "http://host/"
+                fullUri = UriUtils.CreateMockAbsoluteUri(fullUri); // -> absolute
+            }
+            else
+            {
+                // Ensure absolute URIs before base-of validation; otherwise
+                // UriUtils.UriInvariantInsensitiveIsBaseOf can throw when given relative URIs.
+                if (!serviceBaseUri.IsAbsoluteUri)
+                {
+                    serviceBaseUri = UriUtils.CreateMockAbsoluteUri(serviceBaseUri);
+                }
+
+                if (!fullUri.IsAbsoluteUri)
+                {
+                    fullUri = UriUtils.CreateMockAbsoluteUri(fullUri);
+                }
             }
 
             if (!UriUtils.UriInvariantInsensitiveIsBaseOf(serviceBaseUri, fullUri))
@@ -50,54 +68,169 @@ namespace Microsoft.OData.UriParser
                 throw new ODataException(Error.Format(SRResources.UriQueryPathParser_RequestUriDoesNotHaveTheCorrectBaseUri, fullUri, serviceBaseUri));
             }
 
-            // COMPAT 29: Slash in key lookup breaks URI parser
-            // TODO: The code below has a bug that / in the named values will be considered a segment separator
-            //   so for example /Customers('abc/pqr') is treated as two segments, which is wrong.
             try
             {
-                Uri uri = fullUri;
-                int numberOfSegmentsToSkip = 0;
+                // Work with the encoded path so we can detect "%27" reliably
+                // AbsolutePath is the path component (percent-encoded where applicable)
+                string fullPath = fullUri.AbsolutePath;
+                string basePath = serviceBaseUri.AbsolutePath;
 
-                // Skip over the base URI segments
-                // need to calculate the number of segments to skip in the full
-                // uri (so that we can skip over http://blah.com/basePath for example,
-                // get only the odata specific parts of the path).
-                //
-                // because of differences in system.uri between portable lib and
-                // the desktop library, we need to handle this differently.
-                // in this case we get the number of segments to skip as simply
-                // then number of tokens in the serviceBaseUri split on slash, with
-                // length - 1 since its a zero based array.
-                numberOfSegmentsToSkip = serviceBaseUri.AbsolutePath.Split('/').Length - 1;
-                string[] uriSegments = uri.AbsolutePath.Split('/');
-
-                List<string> segments = new List<string>();
-                for (int i = numberOfSegmentsToSkip; i < uriSegments.Length; i++)
+                // Compute the starting index in fullPath right after the basePath
+                // The base-of check above guarantees this relation
+                int startIndex = 0;
+                // base-of check normalizes to uppercase and effectively does an OrdinalIgnoreCase comparison
+                if (fullPath.StartsWith(basePath, StringComparison.OrdinalIgnoreCase))
                 {
-                    string segment = uriSegments[i];
+                    startIndex = basePath.Length;
+                }
+                else
+                {
+                    // Should not happen if base-of passed and both are absolute
+                    throw new ODataException(SRResources.UriQueryPathParser_RequestUriDoesNotHaveTheCorrectBaseUri);
+                }
 
-                    // Skip the empty segment or the "/" segment
-                    if (segment.Length == 0 || segment == "/")
+                List<string> segments = new List<string>(4);
+                StringBuilder sb = new StringBuilder(Math.Min(256, Math.Max(0, fullPath.Length - startIndex)));
+                bool inQuotes = false;
+                bool hasEscapedSequence = false;
+
+                // Local helpers
+                static bool IsPercent27(string s, int i) // %27 = single quote encoded
+                {
+                    // Matches "%27" at position i
+                    return i + 2 < s.Length
+                        && s[i] == '%'
+                        && s[i + 1] == '2'
+                        && s[i + 2] == '7';
+                }
+
+                static bool IsDoublePercent27(string s, int i)
+                {
+                    return IsPercent27(s, i) && IsPercent27(s, i + 3);
+                }
+
+                void AddSegmentIfAny()
+                {
+                    if (sb.Length == 0)
                     {
+                        return;
+                    }
+
+                    // Depending on internal implementation, Uri.UnescapeDataString when there's no
+                    // escaping might result into two strings so we optimize for that case, i.e.,
+                    // one allocation for sb.ToString() and for Uri.UnescapeDataString
+                    string rawString = sb.ToString();
+                    // Unescape percent-encoded characters for the final segment if necessary
+                    string segment = hasEscapedSequence ? Uri.UnescapeDataString(rawString) : rawString;
+
+                    // Skip empties and any stray "/" segment
+                    if (segment.Length > 0 && segment != "/")
+                    {
+                        if (segments.Count >= this.maxSegments)
+                        {
+                            throw new ODataException(SRResources.UriQueryPathParser_TooManySegments);
+                        }
+
+                        segments.Add(segment);
+                    }
+
+                    sb.Clear();
+                    hasEscapedSequence = false; // Reset for next segment
+                }
+
+                // Walk the path after the basePath and split on unquoted '/'
+                for (int i = startIndex; i < fullPath.Length;)
+                {
+                    char c = fullPath[i];
+
+                    // Per the OData V4 spec, forward slashes that are not path separators must be percent-encoded,
+                    // even when inside quoted literals. This would allow simple parsing by splitting on '/'.
+                    // Spec reference: https://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#_Toc453752335
+                    //
+                    // In practice, some clients (e.g., Excel or other external integrations) emit unencoded slashes inside quoted literals.
+                    // To ensure compatibility, we must handle both encoded and unencoded cases.
+
+                    // Treat '/' as path segment separators only when not inside quotes
+                    if (!inQuotes && c == '/')
+                    {
+                        AddSegmentIfAny();
+                        i++; // Consume path segment separator
                         continue;
                     }
 
-                    // When we use "uri.Segments" to get the segments,
-                    // The segment element includes the "/", we should remove that.
-                    if (segment[segment.Length - 1] == '/')
+                    // Literal quote handling (e.g., People('foo/bar'))
+                    if (c == '\'')
                     {
-                        segment = segment.Substring(0, segment.Length - 1);
+                        // OData escape inside quotes: double single-quote (e.g. People('O''Neal'))
+                        if (inQuotes && i + 1 < fullPath.Length && fullPath[i + 1] == '\'')
+                        {
+                            sb.Append('\'').Append('\''); // Zero string allocations; Better than: sb.Append("''");
+                            i += 2; // Consume both quotes
+                            continue;
+                        }
+
+                        inQuotes = !inQuotes; // Toggle quote state
+                        sb.Append(c); // Keep the quote in the segment
+                        i++; // Consume quote
+                        continue;
                     }
 
-                    if (segments.Count == this.maxSegments)
+                    // Percent-encoded single quote handling (e.g., People(%27foo/bar%27))
+                    if (c == '%')
                     {
-                        throw new ODataException(SRResources.UriQueryPathParser_TooManySegments);
+                        // Double-encoded quote: %27%27 = '' (escaped single quote inside quoted literal - e.g. People(%27O%27%27Neil%27) or People('O%27%27Neil'))
+                        if (IsDoublePercent27(fullPath, i))
+                        {
+                            // Preserve as-is; don't toggle quote state
+                            sb.Append(fullPath, i, 6); // Copy %27%27 directly from source
+                            i += 6; // Consume both %27
+                            hasEscapedSequence = true; // Mark that we saw an escape sequence
+                            continue;
+                        }
+
+                        // Single-encoded quote: %27 = ' (quote start/end - e.g. People(%27foo/bar%27))
+                        if (IsPercent27(fullPath, i))
+                        {
+                            inQuotes = !inQuotes; // Toggle quote state
+                            sb.Append(fullPath, i, 3); // Copy %27 directly from source
+                            i += 3; // Consume %27
+                            hasEscapedSequence = true; // Mark that we saw an escape sequence
+                            continue;
+                        }
+
+                        // Any other percent-escape (e.g., %2F for '/') - just append as-is
+                        if (i + 2 < fullPath.Length)
+                        {
+                            sb.Append(fullPath, i, 3);
+                            i += 3; // Consume entire escape sequence
+                            hasEscapedSequence = true; // Mark that we saw an escape sequence
+                            continue;
+                        }
+                        else
+                        {
+                            // Malformed percent-escape - be conservative and append what remains. Let Uri.UnescapeDataString handle any errors.
+                            sb.Append(c);
+                            i++; // Consume '%'
+                            hasEscapedSequence = true; // To ensure that UnescapeDataString runs and throws
+                            continue;
+                        }
                     }
 
-                    segments.Add(Uri.UnescapeDataString(segment));
+                    // Regular character - just append
+                    sb.Append(c);
+                    i++; // Consume character
                 }
 
-                return segments.ToArray();
+                // Flush last segment
+                AddSegmentIfAny();
+
+                // If we ended while still in quotes, that's a syntax error
+                if (inQuotes)
+                {
+                    throw new ODataException(SRResources.UriQueryPathParser_SyntaxError);
+                }
+
+                return segments;
             }
             catch (FormatException uriFormatException)
             {

--- a/src/Microsoft.OData.Core/UriUtils.cs
+++ b/src/Microsoft.OData.Core/UriUtils.cs
@@ -20,6 +20,8 @@ namespace Microsoft.OData
     /// </summary>
     internal static class UriUtils
     {
+        private static readonly Uri DefaultMockBase = new("http://host/");
+
         /// <summary>
         /// Returns an absolute URI constructed from the specified base URI and a relative URI
         /// </summary>
@@ -74,6 +76,10 @@ namespace Microsoft.OData
         {
             Debug.Assert(uri != null, "uri != null");
 
+            // TODO: AbsoluteUri is escaped, OriginalString is not escaped
+            // Doc comment says: "Return the unescaped string representation of the Uri" We'd need to use
+            // Uri.UnescapeDataString on GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped) to achieve that for absolute Uris.
+            // Fixing this would be a breaking change?
             return uri.IsAbsoluteUri ? uri.AbsoluteUri : uri.OriginalString;
         }
 
@@ -121,25 +127,63 @@ namespace Microsoft.OData
         }
 
         /// <summary>
-        /// Determines whether the <paramref name="baseUri"/> Uri instance is a
-        /// base of the specified Uri instance.
+        /// Determines whether the <paramref name="baseUri"/> Uri instance is a base of the specified Uri instance.
         /// </summary>
         /// <remarks>
-        /// The check is host agnostic. For example, "http://host1.com/Service.svc" is a valid base Uri of "https://host2.org/Service.svc/Bla"
-        /// but is not a valid base for "http://host1.com/OtherService.svc/Bla".
+        /// The check is host agnostic. For example, "http://host1.com/Service.svc" is a valid base Uri of
+        /// "https://host2.org/Service.svc/Bla" but is not a valid base for "http://host1.com/OtherService.svc/Bla".
+        /// Path comparison is case-insensitive and segment-aware to align with OData path name resolution.
         /// </remarks>
         /// <param name="baseUri">The candidate base URI.</param>
         /// <param name="uri">The specified Uri instance to test.</param>
         /// <returns>true if the baseUri Uri instance is a base of uri; otherwise false.</returns>
         internal static bool UriInvariantInsensitiveIsBaseOf(Uri baseUri, Uri uri)
         {
-            Debug.Assert(baseUri != null, "baseUri != null");
-            Debug.Assert(uri != null, "uri != null");
+            ExceptionUtils.CheckArgumentNotNull(baseUri, nameof(baseUri));
+            ExceptionUtils.CheckArgumentNotNull(uri, nameof(uri));
 
-            Uri upperCurrent = CreateBaseComparableUri(baseUri);
-            Uri upperUri = CreateBaseComparableUri(uri);
+            // Require both Uris to be absolute
+            if (!baseUri.IsAbsoluteUri)
+            {
+                throw new InvalidOperationException(Error.Format(SRResources.UriUtils_RequiresAbsoluteUri, nameof(baseUri)));
+            }
 
-            return upperCurrent.IsBaseOf(upperUri);
+            if (!uri.IsAbsoluteUri)
+            {
+                throw new InvalidOperationException(Error.Format(SRResources.UriUtils_RequiresAbsoluteUri, nameof(uri)));
+            }
+
+            Uri absBase = baseUri.IsAbsoluteUri ? baseUri : new Uri(DefaultMockBase, baseUri);
+            Uri absUri = uri.IsAbsoluteUri ? uri : new Uri(DefaultMockBase, uri);
+
+            // Host-agnostic path comparison (escaped, OrdinalIgnoreCase)
+            ReadOnlySpan<char> basePath = absBase.GetComponents(UriComponents.Path, UriFormat.UriEscaped);
+            ReadOnlySpan<char> uriPath = absUri.GetComponents(UriComponents.Path, UriFormat.UriEscaped);
+
+            basePath = TrimSingleLeadingSlash(basePath);
+            uriPath = TrimSingleLeadingSlash(uriPath);
+
+            // Treat empty or root base path as a base of any path on any host
+            if (basePath.Length == 0)
+            {
+                return true;
+            }
+
+            // Fast prefix check (case-insensitive)
+            if (!uriPath.StartsWith(basePath, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // If equal length, it's an exact match => base-of
+            if (uriPath.Length == basePath.Length)
+            {
+                return true;
+            }
+
+            // Boundary check: "/odata" is not a base of "/odata2"
+            // If base ends with '/', it represents a complete segment; otherwise the next char must be '/'.
+            return basePath[^1] == '/' || uriPath[basePath.Length] == '/';
         }
 
         /// <summary>
@@ -229,37 +273,19 @@ namespace Microsoft.OData
         /// <returns>The mock Uri, the base Uri if given <paramref name="uri"/> is null</returns>
         internal static Uri CreateMockAbsoluteUri(Uri uri = null)
         {
-            Uri BaseMockUri = new Uri("http://host/");
-
             if (uri == null)
             {
-                return BaseMockUri;
+                return DefaultMockBase;
             }
 
-            if (uri.IsAbsoluteUri)
-            {
-                return uri;
-            }
-            else
-            {
-                return new Uri(BaseMockUri, uri);
-            }
+            return uri.IsAbsoluteUri ? uri : new Uri(DefaultMockBase, uri);
         }
 
-        /// <summary>Creates a URI suitable for host-agnostic comparison purposes.</summary>
-        /// <param name="uri">URI to compare.</param>
-        /// <returns>URI suitable for comparison.</returns>
-        private static Uri CreateBaseComparableUri(Uri uri)
+        private static ReadOnlySpan<char> TrimSingleLeadingSlash(ReadOnlySpan<char> input)
         {
-            Debug.Assert(uri != null, "uri != null");
-
-            uri = new Uri(UriUtils.UriToString(uri).ToUpperInvariant(), UriKind.RelativeOrAbsolute);
-
-            UriBuilder builder = new UriBuilder(uri);
-            builder.Host = "h";
-            builder.Port = 80;
-            builder.Scheme = "http";
-            return builder.Uri;
+            // GetComponents(Path, Escaped) typically returns a leading slash for absolute URIs.
+            // We can normalize away a single leading slash to make boundary logic simpler.
+            return input.Length > 0 && input[0] == '/' ? input.Slice(1) : input;
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

## Issues

*This pull request fixes https://github.com/OData/AspNetCoreOData/issues/709, fixes https://github.com/OData/odata.net/issues/2292, fixes https://github.com/OData/WebApi/issues/2309, fixes https://github.com/OData/WebApi/issues/1964, fixes https://github.com/OData/odata.net/issues/2477, fixes https://github.com/OData/odata.net/issues/735, fixes https://github.com/OData/odata.net/issues/1708, fixes https://github.com/OData/odata.net/issues/3327

## Description

This change updates `ParsePathIntoSegments` to:

- Parse the escaped path and split only on unquoted `/`, preserving any unencoded slashes inside quoted literals as part of the same segment for compatibility with some external clients - **reported case referred to Excel as one such integration https://github.com/OData/AspNetCoreOData/issues/709**.  
- Keep the existing behavior for properly **percent‑encoded** slashes (`%2F`) and for balanced quotes (including doubled single quotes for escaping).  
- Preserve prior error behavior for malformed percent escapes and unbalanced quotes.  

This aligns segment parsing with the [OData URL Conventions](http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#_Toc453752335) (slashes that are part of a literal/key **must** be percent‑encoded) and avoids producing OData‑inapplicable segment shapes when a client violates that rule. 

### Motivation & Standards Alignment

- **OData 4.01 URL Conventions** require that forward slashes in key value segments be percent‑encoded. If a client sends `/People('foo/bar')`, the slash inside the literal should have been `%2F`. When this is not respected, treating the raw `/` as a separator results in segments that **do not correspond to any valid OData path tokenization**. This PR handles that non‑conformance more gracefully by preserving the literal as a single segment.   
- **RFC 3986** defines `/` as a path segment delimiter. Parsing should use the escaped path so that `%2F` stays data while raw `/` remains a separator. This change does exactly that: we operate on the escaped path and only treat unquoted `/` as a separator. 

### Behavior change: before vs after

#### Before (current behavior with non‑conformant clients)
- Request:  
  `GET /Service.svc/People('foo/bar')` *(slash not encoded within the literal)*
- Parsed segments:  
  `["People('foo", "bar')"]` <-- Two segments that are not meaningful OData segments.

#### After (this PR)
- Same request:  
  `GET /Service.svc/People('foo/bar')`
- Parsed segments:  
  `["People('foo/bar')"]`  <-- Single segment, quote‑consistent and usable for OData path handling.

#### No change for conformant inputs
- Request:  
  `GET /Service.svc/People('foo%2Fbar')`
- Parsed segments (before and after):  
  `["People('foo%2Fbar')"]`  <-- slash remains within the literal; downstream can unescape as needed.  
  *(OData 4.01 explicitly requires this encoding.)* 

### Is this a breaking change?

**Technically, yes**  - code that intentionally depended on the previously split result (`["People('foo", "bar')"]`) would now see a single segment. However:

- That two‑segment result was an inapplicable outcome for OData: neither segment is a valid OData path segment on its own; routing, model binding, and `ODataUriParser` semantics do not interpret `"People('foo"` or `"bar')"` as meaningful tokens. In other words, the prior behavior produced an invalid tokenization of an already non‑conformant URL. 
- The new behavior does not loosen standards: it continues to treat raw `/` as a separator, but only when outside a quoted literal. It simply avoids making the situation *worse* when a client neglected to encode the slash that is clearly intended as data. This better matches the intent of RFC 3986’s delimiter rules and keeps `%2F` vs `/` semantics intact. 

**Conclusion:** While “breaking” in a narrow sense, the previous result was not a useful contract to depend on. The new behavior is a corrective change that improves interoperability without changing the meaning of any valid OData URL.

### Additional arguments in favor

1. **Spec‑conformant by default; robust by necessity**  
   We continue to encourage clients to percent‑encode slashes inside literals (as required by OData 4.01). But servers in the wild must interoperate with clients that don’t always follow this strictly. Preserving the literal as a single segment is the most faithful interpretation of the client’s intent and avoids nonsensical segmentation. 

2. **No ambiguity introduced**  
   - We only treat `/` as a separator outside quotes.  
   - Within quotes, we preserve the raw text (including any `/`) and still honor `%27` / `%27%27` and doubled `'` escaping semantics.  
   - Balance checks ensure we error on unbalanced quotes or malformed `%` sequences as before.  
   This makes the change predictable and bounded to a well‑defined compatibility corner case. *(RFC 3986 supports component‑aware parsing; we apply it at the path level.)* 

3. **No change for encoded data**  
   Any client already sending `%2F` inside the literal is unaffected (same result before and after). 

### Risk analysis

**Who might be affected?**
- Downstream code that *explicitly relied* on the old, split behavior (e.g., custom middleware that expects two segments when encountering a raw `/` inside quotes) could observe different segment counts.  
- Security posture: By treating the entire quoted token as one segment, we’re not widening traversal or normalization issues; we still operate on the escaped path and only accept `/` as a separator outside quotes. This reduces ambiguous parses compared to the old behavior that split mid‑literal. 

**Likelihood & impact**
- Likelihood: low - the previous two‑segment shape was not a valid OData path tokenization, so relying on it was unlikely and fragile.  
- Impact: low‑to‑moderate - if such reliance exists, migration is straightforward (treat the quoted literal as a single segment and apply custom parsing inside the literal if truly needed).

Depending on how the maintainers view this change, we can:
- Ship it in a minor release - Would it be worth putting it behind a feature flag?, or  
- Defer the change to the **next major release - ODL 9** with a deprecation note now.  
- My personal recommendation is to merge as a **bug fix** that corrects an inapplicable prior outcome and improves standards alignment with OData and RFC 3986. 

### Memory & performance benchmarks

| Method         | Path                                  | Mean        | Error     | StdDev     | Median      | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|--------------- |-------------------------------------- |------------:|----------:|-----------:|------------:|------:|--------:|-------:|----------:|------------:|
| Parse_Original | Customers                             | 1,508.55 ns | 37.259 ns | 106.902 ns | 1,462.45 ns |  1.00 |    0.10 | 0.1564 |    1984 B |        1.00 |
| Parse_Revised  | Customers                             |    73.09 ns |  1.766 ns |   5.039 ns |    70.40 ns |  0.05 |    0.00 | 0.0254 |     320 B |        0.16 |
|                |                                       |             |           |            |             |       |         |        |           |             |
| Parse_Original | Customers('abc')                      | 1,407.93 ns | 27.255 ns |  27.989 ns | 1,397.31 ns |  1.00 |    0.03 | 0.1640 |    2080 B |        1.00 |
| Parse_Revised  | Customers('abc')                      |    85.10 ns |  3.020 ns |   8.666 ns |    81.30 ns |  0.06 |    0.01 | 0.0286 |     360 B |        0.17 |
|                |                                       |             |           |            |             |       |         |        |           |             |
| Parse_Original | Customers('abc/pqr')                  | 1,684.34 ns | 20.034 ns |  15.641 ns | 1,687.56 ns |  1.00 |    0.01 | 0.1717 |    2168 B |        1.00 |
| Parse_Revised  | Customers('abc/pqr')                  |    99.18 ns |  3.027 ns |   8.437 ns |    95.80 ns |  0.06 |    0.01 | 0.0305 |     384 B |        0.18 |
|                |                                       |             |           |            |             |       |         |        |           |             |
| Parse_Original | Customers('abc%2Fpqr')                | 1,634.20 ns | 32.633 ns |  90.967 ns | 1,593.80 ns |  1.00 |    0.08 | 0.1736 |    2200 B |        1.00 |
| Parse_Revised  | Customers('abc%2Fpqr')                |   119.83 ns |  2.539 ns |   7.202 ns |   117.24 ns |  0.07 |    0.01 | 0.0370 |     464 B |        0.21 |
|                |                                       |             |           |            |             |       |         |        |           |             |
| Parse_Original | Customers('O''Neil')/Orders(42)/Items | 1,595.63 ns | 31.785 ns |  82.047 ns | 1,556.91 ns |  1.00 |    0.07 | 0.1907 |    2400 B |        1.00 |
| Parse_Revised  | Customers('O''Neil')/Orders(42)/Items |   153.86 ns |  3.106 ns |   8.128 ns |   151.02 ns |  0.10 |    0.01 | 0.0427 |     536 B |        0.22 |
|                |                                       |             |           |            |             |       |         |        |           |             |
| Parse_Original | Customers(1)                          | 1,441.38 ns | 35.204 ns |  99.293 ns | 1,419.87 ns |  1.00 |    0.09 | 0.1602 |    2032 B |        1.00 |
| Parse_Revised  | Customers(1)                          |    83.49 ns |  3.155 ns |   9.052 ns |    81.80 ns |  0.06 |    0.01 | 0.0267 |     336 B |        0.17 |
|                |                                       |             |           |            |             |       |         |        |           |             |
| Parse_Original | People(%27O%27%27Neil%27)/Orders(1)   | 1,824.30 ns | 36.504 ns |  94.228 ns | 1,783.86 ns |  1.00 |    0.07 | 0.1888 |    2392 B |        1.00 |
| Parse_Revised  | People(%27O%27%27Neil%27)/Orders(1)   |   166.14 ns |  3.243 ns |   7.451 ns |   162.98 ns |  0.09 |    0.01 | 0.0432 |     544 B |        0.23 |

### Tests
- Adequate tests were added to ensure maximum coverage

## Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
