### PR TITLE
Fix network isolation issue for nightly pipeline (#3341)

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -36,7 +36,9 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     settings:
-      networkIsolationPolicy: Preferred,Nuget.org # Change to Good,Nuget.org if it gets too restrictive
+      networkIsolationPolicy: Preferred,Nuget.org,AzureKeyVault,AzureActiveDirectory,AzureStorage
+      # Change to Good,Nuget.org if it gets too restrictive
+      # AzureKeyVault,AzureActiveDirectory,AzureStorage Allow policies required for the ESRP task
     pool:
       name: MSSecurity-1ES-Build-Agents-Pool
       image: MSSecurity-1ES-Windows-2022


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

This pull request fixes a network isolation issue causing the nightly pipeline build to fail. It adds the network policy required to support signing of the binaries using ESRP

### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*
