### PR TITLE
Treat unencoded `/` inside quoted literals as data (not separators) (#3340)

### DIFF
--- a/src/Microsoft.OData.Core/SRResources.Designer.cs
+++ b/src/Microsoft.OData.Core/SRResources.Designer.cs
@@ -6958,6 +6958,15 @@ namespace Microsoft.OData.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This operation is not supported for a relative URI. (parameter: &apos;{0}&apos;)..
+        /// </summary>
+        internal static string UriUtils_RequiresAbsoluteUri {
+            get {
+                return ResourceManager.GetString("UriUtils_RequiresAbsoluteUri", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The UrlValidator used to validate an ODataUri must use the same Model as the ODataUriParser..
         /// </summary>
         internal static string UriValidator_ValidatorMustUseSameModelAsParser {

--- a/src/Microsoft.OData.Core/SRResources.resx
+++ b/src/Microsoft.OData.Core/SRResources.resx
@@ -2609,4 +2609,7 @@
   <data name="TypeUtils_TypeNameIsNotQualified" xml:space="preserve">
     <value>The value '{0}' is not a qualified type name. A qualified type name is expected.</value>
   </data>
+  <data name="UriUtils_RequiresAbsoluteUri" xml:space="preserve">
+    <value>This operation is not supported for a relative URI. (parameter: '{0}').</value>
+  </data>
 </root>

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriPathParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriPathParser.cs
@@ -4,10 +4,12 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using Microsoft.OData.Core;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Numerics;
+using System.Text;
+using Microsoft.OData.Core;
 
 namespace Microsoft.OData.UriParser
 {
@@ -38,11 +40,28 @@ namespace Microsoft.OData.UriParser
         /// <returns>List of unescaped segments.</returns>
         public virtual ICollection<string> ParsePathIntoSegments(Uri fullUri, Uri serviceBaseUri)
         {
+            // Necessary: UriUtils.UriInvariantInsensitiveIsBaseOf relies on absolute/non-null; Debug.Assert is no-op in release.
+            ExceptionUtils.CheckArgumentNotNull(fullUri, nameof(fullUri));
+
             if (serviceBaseUri == null)
             {
                 Debug.Assert(!fullUri.IsAbsoluteUri, "fullUri must be relative Uri");
-                serviceBaseUri = UriUtils.CreateMockAbsoluteUri();
-                fullUri = UriUtils.CreateMockAbsoluteUri(fullUri);
+                serviceBaseUri = UriUtils.CreateMockAbsoluteUri(); // -> "http://host/"
+                fullUri = UriUtils.CreateMockAbsoluteUri(fullUri); // -> absolute
+            }
+            else
+            {
+                // Ensure absolute URIs before base-of validation; otherwise
+                // UriUtils.UriInvariantInsensitiveIsBaseOf can throw when given relative URIs.
+                if (!serviceBaseUri.IsAbsoluteUri)
+                {
+                    serviceBaseUri = UriUtils.CreateMockAbsoluteUri(serviceBaseUri);
+                }
+
+                if (!fullUri.IsAbsoluteUri)
+                {
+                    fullUri = UriUtils.CreateMockAbsoluteUri(fullUri);
+                }
             }
 
             if (!UriUtils.UriInvariantInsensitiveIsBaseOf(serviceBaseUri, fullUri))
@@ -50,54 +69,331 @@ namespace Microsoft.OData.UriParser
                 throw new ODataException(Error.Format(SRResources.UriQueryPathParser_RequestUriDoesNotHaveTheCorrectBaseUri, fullUri, serviceBaseUri));
             }
 
-            // COMPAT 29: Slash in key lookup breaks URI parser
-            // TODO: The code below has a bug that / in the named values will be considered a segment separator
-            //   so for example /Customers('abc/pqr') is treated as two segments, which is wrong.
             try
             {
-                Uri uri = fullUri;
-                int numberOfSegmentsToSkip = 0;
+                // Work with the encoded path so we can detect "%27" reliably
+                // AbsolutePath is the path component (percent-encoded where applicable)
+                string fullPath = fullUri.AbsolutePath;
+                string basePath = serviceBaseUri.AbsolutePath;
 
-                // Skip over the base URI segments
-                // need to calculate the number of segments to skip in the full
-                // uri (so that we can skip over http://blah.com/basePath for example,
-                // get only the odata specific parts of the path).
-                //
-                // because of differences in system.uri between portable lib and
-                // the desktop library, we need to handle this differently.
-                // in this case we get the number of segments to skip as simply
-                // then number of tokens in the serviceBaseUri split on slash, with
-                // length - 1 since its a zero based array.
-                numberOfSegmentsToSkip = serviceBaseUri.AbsolutePath.Split('/').Length - 1;
-                string[] uriSegments = uri.AbsolutePath.Split('/');
-
-                List<string> segments = new List<string>();
-                for (int i = numberOfSegmentsToSkip; i < uriSegments.Length; i++)
+                // Compute the starting index in fullPath right after the basePath
+                // The base-of check above guarantees this relation
+                int startIndex = 0;
+                // base-of check normalizes to uppercase and effectively does an OrdinalIgnoreCase comparison
+                if (fullPath.StartsWith(basePath, StringComparison.OrdinalIgnoreCase))
                 {
-                    string segment = uriSegments[i];
+                    startIndex = basePath.Length;
+                }
+                else
+                {
+                    // Should not happen if base-of passed and both are absolute
+                    throw new ODataException(SRResources.UriQueryPathParser_RequestUriDoesNotHaveTheCorrectBaseUri);
+                }
 
-                    // Skip the empty segment or the "/" segment
-                    if (segment.Length == 0 || segment == "/")
+                List<string> segments = new List<string>(4);
+                // Seed capacity: typical paths are short; cap to avoid large upfront allocation.
+                // Increase if profiling shows frequent growth.
+                int estimatedCapacity = fullPath.Length - startIndex;
+                StringBuilder sb = new StringBuilder(estimatedCapacity > 256 ? 256 : estimatedCapacity);
+                bool hasEncodedChars = false;
+
+                // Local helpers
+                // Matches "%27" (single quote encoded) at position i
+                static bool IsPercent27(string s, int i) => i + 2 < s.Length && s[i] == '%' && s[i + 1] == '2' && s[i + 2] == '7';
+                // Matches "%28" (left paren encoded) at position i
+                static bool IsPercent28(string s, int i) => i + 2 < s.Length && s[i] == '%' && s[i + 1] == '2' && s[i + 2] == '8';
+                // Matches "%29" (right paren encoded) at position i
+                static bool IsPercent29(string s, int i) => i + 2 < s.Length && s[i] == '%' && s[i + 1] == '2' && s[i + 2] == '9';
+                // Matches "%XX" escape sequence at position i
+                // Returns true and sets nextIndex to index after the escape if found
+                static bool TryConsumeEncodedChar(string s, int i, out int nextIndex)
+                {
+                    if (i < s.Length && s[i] == '%')
                     {
+                        if (i + 2 < s.Length)
+                        {
+                            nextIndex = i + 3; // %XX
+                        }
+                        else
+                        {
+                            // Malformed tail like "%" or "%X": append as-is, let UnescapeDataString handle that later
+                            nextIndex = i + 1;
+                        }
+
+                        return true;
+                    }
+
+                    nextIndex = i;
+
+                    return false;
+                }
+
+                // Consume a *balanced* parenthetical block that begins at a raw '(' or encoded '%28'.
+                // - Honors single-quoted strings inside the block so that '/' within quotes is treated as data
+                //   and does not split path segments.
+                // - Supports raw/encoded parentheses and quotes: '(' / ')' / %28 / %29, and quotes '\'' / %27.
+                // - Recognizes escaped quotes: '' (raw), %27%27 (encoded), and mixed forms ('%27 and %27').
+                // - Allows commas, equals, whitespace, and nested parentheses.
+                // - Returns true and sets `exclusiveEnd` to the index *after* the matching ')' or '%29'.
+                // - Sets `hasEncodedChars` to true if any percent-escape (%XX) occurs anywhere in the block.
+                // - Returns false for unbalanced parentheses or unterminated quotes; caller should then
+                //   treat characters literally
+                static bool TryConsumeParenBlock(string s, int i, out int exclusiveEnd, out bool hasEncodedChars)
+                {
+                    exclusiveEnd = i;
+                    hasEncodedChars = false;
+
+                    int j = i;
+
+                    // Opening paren: raw "(" or encoded "%28"
+                    if (j < s.Length && s[j] == '(')
+                    {
+                        j++;
+                    }
+                    else if (IsPercent28(s, j))
+                    {
+                        hasEncodedChars = true;
+                        j += 3;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+
+                    int parenDepth = 1;
+                    bool inQuote = false;
+
+                    while (j < s.Length && parenDepth > 0)
+                    {
+                        char ch = s[j];
+
+                        if (inQuote)
+                        {
+                            // Raw quote (escape or close)
+                            if (ch == '\'')
+                            {
+                                if (j + 1 < s.Length && s[j + 1] == '\'')
+                                {
+                                    j += 2; // Raw escape: ''
+                                    continue;
+                                }
+                                else if (j + 1 < s.Length && IsPercent27(s, j + 1))
+                                {
+                                    j += 4; // Mixed escaped pair: '%27
+                                    hasEncodedChars = true;
+                                    continue;
+                                }
+
+                                // Closing raw quote
+                                inQuote = false;
+                                j++;
+                                continue;
+                            }
+
+                            // Encoded quote (escape or close)
+                            if (IsPercent27(s, j))
+                            {
+                                hasEncodedChars = true;
+
+                                if (j + 3 < s.Length && IsPercent27(s, j + 3))
+                                {
+                                    j += 6; // Encoded escape: %27%27
+                                    continue;
+                                }
+                                else if (j + 3 < s.Length && s[j + 3] == '\'')
+                                {
+                                    j += 4; // Mixed escaped pair: %27'
+                                    continue;
+                                }
+
+                                // Closing encoded quote
+                                inQuote = false;
+                                j += 3;
+                                continue;
+                            }
+
+                            // Any other escape sequence
+                            if (TryConsumeEncodedChar(s, j, out int nextIndex))
+                            {
+                                hasEncodedChars = true;
+                                j = nextIndex;
+                                continue;
+                            }
+
+                            j++;
+                            continue;
+                        }
+                        else
+                        {
+                            // Slash outside quote invalidates the block (cannot protect it)
+                            if (ch == '/')
+                            {
+                                return false; // Slash becomes a segment separator
+                            }
+
+                            // Enter quote
+                            if (ch == '\'')
+                            {
+                                inQuote = true;
+                                j++;
+                                continue;
+                            }
+
+                            if (IsPercent27(s, j))
+                            {
+                                hasEncodedChars = true;
+                                inQuote = true;
+                                j += 3;
+                                continue;
+                            }
+
+                            // Nested paren (rare but legal)
+                            if (ch == '(')
+                            {
+                                parenDepth++;
+                                j++;
+                                continue;
+                            }
+
+                            if (ch == ')')
+                            {
+                                parenDepth--;
+                                j++;
+                                continue;
+                            }
+
+                            if (IsPercent28(s, j))
+                            {
+                                hasEncodedChars = true;
+                                parenDepth++;
+                                j += 3;
+                                continue;
+                            }
+
+                            if (IsPercent29(s, j))
+                            {
+                                hasEncodedChars = true;
+                                parenDepth--;
+                                j += 3;
+                                continue;
+                            }
+
+                            // Any other escape sequence
+                            if (TryConsumeEncodedChar(s, j, out int nextIndex))
+                            {
+                                hasEncodedChars = true;
+                                j = nextIndex;
+                                continue;
+                            }
+
+                            // Any other char (including '/', ',', '=', spaces, ect)
+                            j++;
+                        }
+                    }
+
+                    if (parenDepth == 0 && !inQuote)
+                    {
+                        exclusiveEnd = j;
+                        return true; // Found the matching closing paren
+                    }
+
+                    // Unbalanced or unterminated quote -> fail (caller will treat chars normally)
+                    return false;
+                }
+
+                void AddSegmentIfAny()
+                {
+                    if (sb.Length == 0)
+                    {
+                        return;
+                    }
+
+                    // Depending on internal implementation, Uri.UnescapeDataString when there's no
+                    // escaping might result into two strings so we optimize for that case, i.e.,
+                    // one allocation for sb.ToString() and for Uri.UnescapeDataString
+                    string raw = sb.ToString();
+                    // Unescape percent-encoded characters for the final segment if necessary
+                    string segment = hasEncodedChars ? Uri.UnescapeDataString(raw) : raw;
+
+                    // Skip empties and any stray "/" segment
+                    if (segment.Length > 0 && segment != "/")
+                    {
+                        if (segments.Count >= this.maxSegments)
+                        {
+                            throw new ODataException(SRResources.UriQueryPathParser_TooManySegments);
+                        }
+
+                        segments.Add(segment);
+                    }
+
+                    sb.Clear();
+                    hasEncodedChars = false; // Reset for next segment
+                }
+
+                // Walk the path after the basePath and split on unquoted '/'
+                // We don't want something like api/a'/b'/c to give us a'/b' and c instead of a', b' and c
+                for (int i = startIndex; i < fullPath.Length;)
+                {
+                    char c = fullPath[i];
+
+                    // Split on '/' unless inside a "protected" region (detected via lookahead)
+                    if (c == '/')
+                    {
+                        // Path segment separator
+                        AddSegmentIfAny();
+                        i++; // Consume path segment separator
                         continue;
                     }
 
-                    // When we use "uri.Segments" to get the segments,
-                    // The segment element includes the "/", we should remove that.
-                    if (segment[segment.Length - 1] == '/')
+                    if (c == '(' || IsPercent28(fullPath, i))
                     {
-                        segment = segment.Substring(0, segment.Length - 1);
+                        // Attempt to consume a *balanced* parenthetical (key/function args). If successful,
+                        // append it as a whole so that any '/' within quoted literals does not split the segment.
+                        // If not successful (unbalanced/unterminated), fall back to literal scanning.
+                        if (TryConsumeParenBlock(fullPath, i, out int endParen, out bool blockHasEncodedChars))
+                        {
+                            sb.Append(fullPath, i, endParen - i);
+                            if (blockHasEncodedChars)
+                            {
+                                hasEncodedChars = true;
+                            }
+
+                            i = endParen;
+                            continue;
+                        }
+
+                        // Fall through: treat as normal characters (unbalanced -> do not protect '/' enclosed in single quote)
                     }
 
-                    if (segments.Count == this.maxSegments)
+                    // Copy escaped sequences as a unit, mark for unescape
+                    if (c == '%')
                     {
-                        throw new ODataException(SRResources.UriQueryPathParser_TooManySegments);
+                        hasEncodedChars = true; // Mark that we saw an escape sequence
+
+                        if (i + 2 < fullPath.Length)
+                        {
+                            sb.Append(fullPath, i, 3);
+                            i += 3; // %XX - consume entire escape sequence
+                        }
+                        else
+                        {
+                            // Malformed tail like "%" or "%X": append as-is, let UnescapeDataString handle that later
+                            sb.Append(c);
+                            i++;
+                        }
+
+                        continue;
                     }
 
-                    segments.Add(Uri.UnescapeDataString(segment));
+                    // Regular character - just append
+                    sb.Append(c);
+                    i++; // Consume character
                 }
 
-                return segments.ToArray();
+                // Flush last segment
+                AddSegmentIfAny();
+
+                return segments;
             }
             catch (FormatException uriFormatException)
             {

--- a/src/Microsoft.OData.Core/UriUtils.cs
+++ b/src/Microsoft.OData.Core/UriUtils.cs
@@ -20,6 +20,8 @@ namespace Microsoft.OData
     /// </summary>
     internal static class UriUtils
     {
+        private static readonly Uri DefaultMockBase = new("http://host/");
+
         /// <summary>
         /// Returns an absolute URI constructed from the specified base URI and a relative URI
         /// </summary>
@@ -74,6 +76,10 @@ namespace Microsoft.OData
         {
             Debug.Assert(uri != null, "uri != null");
 
+            // TODO: AbsoluteUri is escaped, OriginalString is not escaped
+            // Doc comment says: "Return the unescaped string representation of the Uri" We'd need to use
+            // Uri.UnescapeDataString on GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped) to achieve that for absolute Uris.
+            // Fixing this would be a breaking change?
             return uri.IsAbsoluteUri ? uri.AbsoluteUri : uri.OriginalString;
         }
 
@@ -121,25 +127,63 @@ namespace Microsoft.OData
         }
 
         /// <summary>
-        /// Determines whether the <paramref name="baseUri"/> Uri instance is a
-        /// base of the specified Uri instance.
+        /// Determines whether the <paramref name="baseUri"/> Uri instance is a base of the specified Uri instance.
         /// </summary>
         /// <remarks>
-        /// The check is host agnostic. For example, "http://host1.com/Service.svc" is a valid base Uri of "https://host2.org/Service.svc/Bla"
-        /// but is not a valid base for "http://host1.com/OtherService.svc/Bla".
+        /// The check is host agnostic. For example, "http://host1.com/Service.svc" is a valid base Uri of
+        /// "https://host2.org/Service.svc/Bla" but is not a valid base for "http://host1.com/OtherService.svc/Bla".
+        /// Path comparison is case-insensitive and segment-aware to align with OData path name resolution.
         /// </remarks>
         /// <param name="baseUri">The candidate base URI.</param>
         /// <param name="uri">The specified Uri instance to test.</param>
         /// <returns>true if the baseUri Uri instance is a base of uri; otherwise false.</returns>
         internal static bool UriInvariantInsensitiveIsBaseOf(Uri baseUri, Uri uri)
         {
-            Debug.Assert(baseUri != null, "baseUri != null");
-            Debug.Assert(uri != null, "uri != null");
+            ExceptionUtils.CheckArgumentNotNull(baseUri, nameof(baseUri));
+            ExceptionUtils.CheckArgumentNotNull(uri, nameof(uri));
 
-            Uri upperCurrent = CreateBaseComparableUri(baseUri);
-            Uri upperUri = CreateBaseComparableUri(uri);
+            // Require both Uris to be absolute
+            if (!baseUri.IsAbsoluteUri)
+            {
+                throw new InvalidOperationException(Error.Format(SRResources.UriUtils_RequiresAbsoluteUri, nameof(baseUri)));
+            }
 
-            return upperCurrent.IsBaseOf(upperUri);
+            if (!uri.IsAbsoluteUri)
+            {
+                throw new InvalidOperationException(Error.Format(SRResources.UriUtils_RequiresAbsoluteUri, nameof(uri)));
+            }
+
+            Uri absBase = baseUri.IsAbsoluteUri ? baseUri : new Uri(DefaultMockBase, baseUri);
+            Uri absUri = uri.IsAbsoluteUri ? uri : new Uri(DefaultMockBase, uri);
+
+            // Host-agnostic path comparison (escaped, OrdinalIgnoreCase)
+            ReadOnlySpan<char> basePath = absBase.GetComponents(UriComponents.Path, UriFormat.UriEscaped);
+            ReadOnlySpan<char> uriPath = absUri.GetComponents(UriComponents.Path, UriFormat.UriEscaped);
+
+            basePath = TrimSingleLeadingSlash(basePath);
+            uriPath = TrimSingleLeadingSlash(uriPath);
+
+            // Treat empty or root base path as a base of any path on any host
+            if (basePath.Length == 0)
+            {
+                return true;
+            }
+
+            // Fast prefix check (case-insensitive)
+            if (!uriPath.StartsWith(basePath, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // If equal length, it's an exact match => base-of
+            if (uriPath.Length == basePath.Length)
+            {
+                return true;
+            }
+
+            // Boundary check: "/odata" is not a base of "/odata2"
+            // If base ends with '/', it represents a complete segment; otherwise the next char must be '/'.
+            return basePath[^1] == '/' || uriPath[basePath.Length] == '/';
         }
 
         /// <summary>
@@ -229,37 +273,19 @@ namespace Microsoft.OData
         /// <returns>The mock Uri, the base Uri if given <paramref name="uri"/> is null</returns>
         internal static Uri CreateMockAbsoluteUri(Uri uri = null)
         {
-            Uri BaseMockUri = new Uri("http://host/");
-
             if (uri == null)
             {
-                return BaseMockUri;
+                return DefaultMockBase;
             }
 
-            if (uri.IsAbsoluteUri)
-            {
-                return uri;
-            }
-            else
-            {
-                return new Uri(BaseMockUri, uri);
-            }
+            return uri.IsAbsoluteUri ? uri : new Uri(DefaultMockBase, uri);
         }
 
-        /// <summary>Creates a URI suitable for host-agnostic comparison purposes.</summary>
-        /// <param name="uri">URI to compare.</param>
-        /// <returns>URI suitable for comparison.</returns>
-        private static Uri CreateBaseComparableUri(Uri uri)
+        private static ReadOnlySpan<char> TrimSingleLeadingSlash(ReadOnlySpan<char> input)
         {
-            Debug.Assert(uri != null, "uri != null");
-
-            uri = new Uri(UriUtils.UriToString(uri).ToUpperInvariant(), UriKind.RelativeOrAbsolute);
-
-            UriBuilder builder = new UriBuilder(uri);
-            builder.Host = "h";
-            builder.Port = 80;
-            builder.Scheme = "http";
-            return builder.Uri;
+            // GetComponents(Path, Escaped) typically returns a leading slash for absolute URIs.
+            // We can normalize away a single leading slash to make boundary logic simpler.
+            return input.Length > 0 && input[0] == '/' ? input.Slice(1) : input;
         }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriPathParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriPathParserTests.cs
@@ -64,10 +64,10 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         }
 
         [Fact]
-        public void ParsePathRespectsSlashAsSegmentMarkerOverSingleQuotes()
+        public void ParsePathDoesNotSplitOnSlashInsideSingleQuotes()
         {
             var list = this.pathParser.ParsePathIntoSegments(new Uri(this.baseUri.AbsoluteUri + "EntitySet('string/key')"), this.baseUri);
-            string[] expectedListOrder = new[] { "EntitySet('string", "key')" };
+            string[] expectedListOrder = new[] { "EntitySet('string/key')" };
 
             list.ContainExactly(expectedListOrder);
         }
@@ -290,6 +290,461 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             test = "'invalid";
             Assert.False(UriParserHelper.TryRemoveQuotes(ref test));
             Assert.Equal("'invalid", test);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/api/People('Foo/Bar')", "People('Foo/Bar')")]
+        [InlineData("http://localhost/api/People(%27Foo/Bar%27)", "People('Foo/Bar')")]
+        [InlineData("http://localhost/api/People%28'Foo/Bar'%29", "People('Foo/Bar')")]
+        [InlineData("http://localhost/api/People%28%27Foo/Bar%27%29", "People('Foo/Bar')")]
+        [InlineData("http://localhost/api/People(%27Foo/Bar%27%29", "People('Foo/Bar')")]
+        [InlineData("http://localhost/api/People%28%27Foo/Bar%27)", "People('Foo/Bar')")]
+        [InlineData("http://localhost/api/People(%27Foo/Bar')", "People('Foo/Bar')")]
+        [InlineData("http://localhost/api/People('Foo/Bar%27)", "People('Foo/Bar')")]
+        [InlineData("http://localhost/api/People('Foo%2FBar')", "People('Foo/Bar')")]
+        [InlineData("http://localhost/api/People(%27Foo%2FBar%27)", "People('Foo/Bar')")]
+        [InlineData("http://localhost/api/People%28%27Foo%2FBar%27%29", "People('Foo/Bar')")]
+        [InlineData("http://localhost/api/People('Foo%2fBar')", "People('Foo/Bar')")]        // lowercase 'f'
+        [InlineData("http://localhost/api/People(%27Foo%2fBar%27)", "People('Foo/Bar')")]    // lowercase 'f'
+        [InlineData("http://localhost/api/People%28%27O'%27Neil/Jack%27%29", "People('O''Neil/Jack')")]
+        [InlineData("http://localhost/api/People%28%27O%27'Neil/Jack%27%29", "People('O''Neil/Jack')")]
+        [InlineData("http://localhost/api/People(%27O%27'Neil/Jack%27%29", "People('O''Neil/Jack')")]
+        [InlineData("http://localhost/api/People%28%27O%27'Neil/Jack%27)", "People('O''Neil/Jack')")]
+        [InlineData("http://localhost/api/People('O%27'Neil/Jack%27)", "People('O''Neil/Jack')")]
+        [InlineData("http://localhost/api/People(%27O%27'Neil/Jack')", "People('O''Neil/Jack')")]
+        [InlineData("http://localhost/api/People(%27O''Neil/Jack')", "People('O''Neil/Jack')")]
+        [InlineData("http://localhost/api/People%28'O%27'Neil/Jack%27%29", "People('O''Neil/Jack')")]
+        [InlineData("http://localhost/api/People%28'O%27'Neil/Jack'%29", "People('O''Neil/Jack')")]
+        [InlineData("http://localhost/api/People%28'O''Neil/Jack'%29", "People('O''Neil/Jack')")]
+        [InlineData("http://localhost/api/People%28%27Jack/O'%27Neil%27%29", "People('Jack/O''Neil')")]
+        [InlineData("http://localhost/api/People%28%27Jack/O%27'Neil%27%29", "People('Jack/O''Neil')")]
+        [InlineData("http://localhost/api/People(%27Jack/O%27'Neil%27%29", "People('Jack/O''Neil')")]
+        [InlineData("http://localhost/api/People%28%27Jack/O%27'Neil%27)", "People('Jack/O''Neil')")]
+        [InlineData("http://localhost/api/People('Jack/O%27'Neil%27)", "People('Jack/O''Neil')")]
+        [InlineData("http://localhost/api/People(%27Jack/O%27'Neil')", "People('Jack/O''Neil')")]
+        [InlineData("http://localhost/api/People(%27Jack/O''Neil')", "People('Jack/O''Neil')")]
+        [InlineData("http://localhost/api/People%28'Jack/O%27'Neil%27%29", "People('Jack/O''Neil')")]
+        [InlineData("http://localhost/api/People%28'Jack/O%27'Neil'%29", "People('Jack/O''Neil')")]
+        [InlineData("http://localhost/api/People%28'Jack/O''Neil'%29", "People('Jack/O''Neil')")]
+        [InlineData("http://localhost/api/People%28%20%27O'%27Neil/Jack%27%20%29", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People%28%20%27O%27'Neil/Jack%27%20%29", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People(%20%27O%27'Neil/Jack%27%20%29", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People%28%20%27O%27'Neil/Jack%27%20)", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People(%20'O%27'Neil/Jack%27%20)", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People(%20%27O%27'Neil/Jack'%20)", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People(%20%27O''Neil/Jack'%20)", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People%28%20'O%27'Neil/Jack%27%20%29", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People%28%20'O%27'Neil/Jack'%20%29", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People%28%20'O''Neil/Jack'%20%29", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People%28 %27O'%27Neil/Jack%27 %29", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People%28 %27O%27'Neil/Jack%27 %29", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People( %27O%27'Neil/Jack%27 %29", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People%28 %27O%27'Neil/Jack%27 )", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People( 'O%27'Neil/Jack%27 )", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People( %27O%27'Neil/Jack' )", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People( %27O''Neil/Jack' )", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People%28 'O%27'Neil/Jack%27 %29", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People%28 'O%27'Neil/Jack' %29", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People%28 'O''Neil/Jack' %29", "People( 'O''Neil/Jack' )")]
+        [InlineData("http://localhost/api/People(%27O'%27Neil%20(Jack)%27)", "People('O''Neil (Jack)')")]
+        [InlineData("http://localhost/api/People%28%27O'%27Neil%20(Jack)%27%29", "People('O''Neil (Jack)')")]
+        [InlineData("http://localhost/api/People(%27O'%27Neil%20%28Jack%29%27)", "People('O''Neil (Jack)')")]
+        [InlineData("http://localhost/api/People%28%27O'%27Neil%20%28Jack%29%27%29", "People('O''Neil (Jack)')")]
+        [InlineData("http://localhost/api/People(%27O'%27Neil%20(Jack%29%27)", "People('O''Neil (Jack)')")]
+        [InlineData("http://localhost/api/People%28%27O'%27Neil%20%28Jack)%27%29", "People('O''Neil (Jack)')")]
+        [InlineData("http://localhost/api/People('O%20Neil/Jack')", "People('O Neil/Jack')")] // space inside literal (encoded)
+        [InlineData("http://localhost/api/People(%27O%20Neil/Jack%27)", "People('O Neil/Jack')")]
+        [InlineData("http://localhost/api/People(%20%20%27Foo/Bar%27%20%20)", "People(  'Foo/Bar'  )")] // multiple spaces around literal
+        [InlineData("http://localhost/api/People('Foo%2CBar')", "People('Foo,Bar')")] // comma
+        [InlineData("http://localhost/api/People(%27caf%C3%A9/Bar%27)", "People('café/Bar')")] // UTF-8 é
+        [InlineData("http://localhost/api/People('')", "People('')")] // empty literal
+        [InlineData("http://localhost/api/People(%27%27)", "People('')")] // empty literal encoded
+        [InlineData("http://localhost/api/People('''/Bar')", "People('''/Bar')")] // literal contains an escaped quote then slash
+        [InlineData("http://localhost/api/People(%27%27%27/Bar%27)", "People('''/Bar')")] // encoded then raw
+        [InlineData("http://localhost/api/People(%27%27%27%2FBar%27)", "People('''/Bar')")] // encoded slash
+        [InlineData("http://localhost/api/People('Foo/Bar')/", "People('Foo/Bar')")] // trailing slash
+        [InlineData("http://localhost/api//People('Foo/Bar')", "People('Foo/Bar')")] // trailing slash
+        [InlineData("http://localhost/api/People(logonName='Foo/Bar')", "People(logonName='Foo/Bar')")]// key=value containing slash
+        [InlineData("http://localhost/api/People(logonName='Foo/Bar',city='Juarez/Border')", "People(logonName='Foo/Bar',city='Juarez/Border')")] // key=value containing slash, multiple keys
+        [InlineData("http://localhost/api/People('Foo+Bar')", "People('Foo+Bar')")] // + in quote stays literal
+        [InlineData("http://localhost/api/People('Foo%0ABar')", "People('Foo\nBar')")] // Encoded newline in quote becomes newline
+        [InlineData("http://localhost/api/People('Foo%0DBar')", "People('Foo\rBar')")] // Encoded carriage return in quote becomes carriage return
+        [InlineData("http://localhost/api/People('Foo%0D%0ABar')", "People('Foo\r\nBar')")] // Encoded CRLF in quote becomes CRLF
+        [InlineData("http://localhost/api/People('Foo''Bar''Baz')", "People('Foo''Bar''Baz')")] // Repeated escaped quotes
+        [InlineData("http://localhost/api/People(%27Foo%27%27Bar%27%27Baz%27)", "People('Foo''Bar''Baz')")] // Repeated encoded quotes
+        [InlineData("http://localhost/api/People('Foo😊')", "People('Foo😊')")] // Surrogate pair (emoji)
+        [InlineData("http://localhost/api/People('é')", "People('é')")] // Combination of base character + accent
+        [InlineData("http://localhost/api/People('مرحبا')", "People('مرحبا')")] // CJK literals
+        [InlineData("http://localhost/api/People('日本')", "People('日本')")]
+        [InlineData("http://localhost/api/People('Foo%252FBar')", "People('Foo%2FBar')")] // Double encoded
+        [InlineData("http://localhost/api/People%28%27%61%62%63%64%65%66%67%68%69%6A%6B%6C%6D%2F%6E%6F%70%71%72%73%74%75%66%77%78%79%7A%27%29", "People('abcdefghijklm/nopqrstufwxyz')")]
+        [InlineData("http://localhost/api/People%28%27%61%62%63%64%65%66%67%68%69%6a%6b%6c%6d%2f%6e%6f%70%71%72%73%74%75%66%77%78%79%7a%27%29", "People('abcdefghijklm/nopqrstufwxyz')")]
+        [InlineData("http://localhost/api/People%28%27%61%62%63%64%65%66%67%68%69%6A%6B%6C%6D%2f%6e%6f%70%71%72%73%74%75%66%77%78%79%7a%27%29", "People('abcdefghijklm/nopqrstufwxyz')")]
+        [InlineData("http://localhost/api/People('abcdefghijklm/%6e%6f%70%71%72%73%74%75%66%77%78%79%7a%27%29", "People('abcdefghijklm/nopqrstufwxyz')")]
+        [InlineData("http://localhost/api/People%28%27%41%42%43%44%45%46%47%48%49%4A%4B%4C%4D%2F%4E%4F%50%51%52%53%54%55%56%57%58%59%5A%27%29", "People('ABCDEFGHIJKLM/NOPQRSTUVWXYZ')")]
+        [InlineData("http://localhost/api/People%28%27%41%42%43%44%45%46%47%48%49%4a%4b%4c%4d%2f%4e%4f%50%51%52%53%54%55%56%57%58%59%5a%27%29", "People('ABCDEFGHIJKLM/NOPQRSTUVWXYZ')")]
+        [InlineData("http://localhost/api/People%28%27%41%42%43%44%45%46%47%48%49%4a%4b%4c%4d%2F%4E%4F%50%51%52%53%54%55%56%57%58%59%5A%27%29", "People('ABCDEFGHIJKLM/NOPQRSTUVWXYZ')")]
+        [InlineData("http://localhost/api/People%28%27%41%42%43%44%45%46%47%48%49%4a%4b%4c%4d%2FNOPQRSTUVWXYZ')", "People('ABCDEFGHIJKLM/NOPQRSTUVWXYZ')")]
+        public void ParsePathParenthesizedSegmentNormalization(string uriString, string expectedSegment)
+        {
+            // Arrange
+            var baseUri = new Uri("http://localhost/api/");
+            var uri = new Uri(uriString);
+
+            // Act
+            var segments = this.pathParser.ParsePathIntoSegments(uri, baseUri);
+
+            // Assert
+            var segment = Assert.Single(segments);
+            Assert.Equal(expectedSegment, segment);
+        }
+
+        [Fact]
+        public void ParsePathIntoSegments()
+        {
+            var segments = this.pathParser.ParsePathIntoSegments(new Uri("./People('Foo/Bar')", UriKind.RelativeOrAbsolute), new Uri("./", UriKind.RelativeOrAbsolute));
+        }
+
+        [Theory]
+        // Typical cases
+        [InlineData("http://localhost/api/", "http://localhost/api/People('O''Neil')", "People('O''Neil')")]
+        [InlineData("http://localhost/api/", "http://localhost/api/People(%27O%27%27Neil%27)", "People('O''Neil')")]
+        [InlineData("http://localhost/api/", "http://localhost/api/People%28%27O%27%27Neil%27%29", "People('O''Neil')")]
+        [InlineData("http://localhost/api/", "http://localhost/api/Categories('Smartphone%2FTablet')", "Categories('Smartphone/Tablet')")]
+        // Per the OData V4 spec, forward slashes that are not path separators must be percent-encoded.
+        // In practice, some clients (e.g., Excel or other external integrations) emit unencoded slashes inside quoted literals so we try to accommodate unencoded slash in unquoted literals.
+        [InlineData("http://localhost/api/", "http://localhost/api/Categories('Smartphone/Tablet')", "Categories('Smartphone/Tablet')")]
+        [InlineData("http://localhost/api/", "api/People('O''Neil')", "People('O''Neil')")]
+        [InlineData("http://localhost/api/", "api/People(%27O%27%27Neil%27)", "People('O''Neil')")]
+        [InlineData("http://localhost/api/", "api/People%28%27O%27%27Neil%27%29", "People('O''Neil')")]
+        [InlineData("http://localhost/api/", "api/Categories('Smartphone%2FTablet')", "Categories('Smartphone/Tablet')")]
+        [InlineData("http://localhost/api/", "api/Categories('Smartphone/Tablet')", "Categories('Smartphone/Tablet')")]
+        [InlineData("api/", "http://localhost/api/People('O''Neil')", "People('O''Neil')")]
+        [InlineData("api/", "http://localhost/api/People(%27O%27%27Neil%27)", "People('O''Neil')")]
+        [InlineData("api/", "http://localhost/api/People%28%27O%27%27Neil%27%29", "People('O''Neil')")]
+        [InlineData("api/", "http://localhost/api/Categories('Smartphone%2FTablet')", "Categories('Smartphone/Tablet')")]
+        [InlineData("api/", "http://localhost/api/Categories('Smartphone/Tablet')", "Categories('Smartphone/Tablet')")]
+        [InlineData("api/", "api/People('O''Neil')", "People('O''Neil')")]
+        [InlineData("api/", "api/People(%27O%27%27Neil%27)", "People('O''Neil')")]
+        [InlineData("api/", "api/People%28%27O%27%27Neil%27%29", "People('O''Neil')")]
+        [InlineData("api/", "api/Categories('Smartphone%2FTablet')", "Categories('Smartphone/Tablet')")]
+        [InlineData("api/", "api/Categories('Smartphone/Tablet')", "Categories('Smartphone/Tablet')")]
+        // Case-insensitive hex for %2f (ensure lower-case hex works)
+        [InlineData("http://localhost/api/", "http://localhost/api/Categories('Smartphone%2fTablet')", "Categories('Smartphone/Tablet')")]
+        // Mixed encoded/unencoded quotes inside the same literal
+        [InlineData("http://localhost/api/", "http://localhost/api/People('O%27%27Neil')", "People('O''Neil')")]
+        [InlineData("http://localhost/api/", "http://localhost/api/People(%27O''Neil%27)", "People('O''Neil')")]
+        // Encoded spaces and plus inside quoted literal
+        [InlineData("http://localhost/api/", "http://localhost/api/Tags('C%23%20and%20C%2b%2b')", "Tags('C# and C++')")]
+        // Non-ASCII percent-encoded (UTF‑8)
+        [InlineData("http://localhost/api/", "http://localhost/api/Names('caf%C3%A9')", "Names('café')")]
+        // Encoded parentheses in the *name* part (not only the key)
+        [InlineData("http://localhost/api/", "http://localhost/api/Cate%67ories%28%27X%27%29", "Categories('X')")] // %67 = 'g'
+        // Encoded percent sign itself
+        [InlineData("http://localhost/api/", "http://localhost/api/Docs('%25Complete')", "Docs('%Complete')")]
+        // Base has different case (case-insensitive base-of)
+        [InlineData("http://localhost/API/", "http://localhost/api/People('O''Neil')", "People('O''Neil')")]
+        // Base without trailing slash vs with it in full
+        [InlineData("http://localhost/api", "http://localhost/api/Products(1)", "Products(1)")]
+        // Encoded slash at start/end inside quotes
+        [InlineData("http://localhost/api/", "http://localhost/api/Names('%2Falpha')", "Names('/alpha')")]
+        [InlineData("http://localhost/api/", "http://localhost/api/Names('omega%2F')", "Names('omega/')")]
+        [InlineData("http://localhost/api/", "http://localhost/api/$metadata", "$metadata")]
+        [InlineData("http://localhost/api/", "http://localhost/api/%24metadata", "$metadata")]
+        // Customer reported cases
+        [InlineData("api/", "api/entity('/subscriptions/00000000-0000-0000-0000-000000000000')", "entity('/subscriptions/00000000-0000-0000-0000-000000000000')")]
+        [InlineData("https://myservice/odata/", "https://myservice/odata/MyEntity('key/with/slashes')", "MyEntity('key/with/slashes')")]
+        [InlineData("https://sample.com/", "https://sample.com/resources('http%3A%2F%2Fsample.sample.net%2Fsample%2Fservices%2FFoo')", "resources('http://sample.sample.net/sample/services/Foo')")]
+        [InlineData("http://localhost:5913/efcore", "http://localhost:5913/efcore/Movies('a%30b')", "Movies('a0b')")]
+        [InlineData("http://localhost:5000/odata", "http://localhost:5000/odata/Customers(%27a%30b%27)", "Customers('a0b')")]
+        [InlineData("odata/", "/odata/issue1964('\"%2F\"')", "issue1964('\"/\"')")]
+        [InlineData("odata/", "/odata/entity('abc/123')", "entity('abc/123')")]
+        [InlineData("/", "/new_alesers(new_name='alex%2F3')", "new_alesers(new_name='alex/3')")]
+        [InlineData("/", "/alssc_anglesectors(alssc_name='Water Auth/Company')", "alssc_anglesectors(alssc_name='Water Auth/Company')")]
+        [InlineData("/", "/alssc_anglesectors(alssc_name='Water Auth%2FCompany')", "alssc_anglesectors(alssc_name='Water Auth/Company')")]
+        public void ParsePathWithEncodedSequencesAndSlash(string baseUriString, string uriString, string expectedSegment)
+        {
+            // Arrange
+            var baseUri = baseUriString is null ? null : new Uri(baseUriString, UriKind.RelativeOrAbsolute);
+            var uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
+
+            // Act
+            var parseSegments = this.pathParser.ParsePathIntoSegments(uri, baseUri);
+
+            // Assert
+            var segment = Assert.Single(parseSegments);
+            Assert.Equal(expectedSegment, segment);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/api/", "http://localhost/api/Products(1)/Supplier('O''Neil')", new[] { "Products(1)", "Supplier('O''Neil')" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/Products(1)/Supplier(%27O%27%27Neil%27)", new[] { "Products(1)", "Supplier('O''Neil')" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/People('Foo/Bar')/Friends(3)", new[] { "People('Foo/Bar')", "Friends(3)" })] // unencoded slash inside quotes
+        [InlineData("http://localhost/api/", "http://localhost/api/People('Foo%2FBar')/Friends(3)", new[] { "People('Foo/Bar')", "Friends(3)" })] // encoded slash inside quotes
+        [InlineData("http://localhost/api/", "http://localhost/api/Team%28%27A%28B%29%27%29/Members", new[] { "Team('A(B)')", "Members" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/People(%27Foo/Bar%27)/Friends", new[] { "People('Foo/Bar')", "Friends" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/People%28%27Foo/Bar%27%29/Friends", new[] { "People('Foo/Bar')", "Friends" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/People('O%27'Neil/Jack')/Next", new[] { "People('O''Neil/Jack')", "Next" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/People('Foo/Bar)/Friends", new[] { "People('Foo", "Bar)", "Friends" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/People('Foo/Bar)", new[] { "People('Foo", "Bar)" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/People(%22Foo/Bar%22)", new[] { "People(\"Foo", "Bar\")" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/People(Foo=1/Bar=2)", new[] { "People(Foo=1", "Bar=2)" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/Foo'/Bar", new[] { "Foo'", "Bar" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/Foo%27/Bar", new[] { "Foo'", "Bar" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/Customers('abc%2F/''efg')/ abc /'%2F", new[] { "Customers('abc//''efg')", " abc ", "'/" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/Customers(%27abc%2F/'%27efg')/ abc' /'%2F", new[] { "Customers('abc//''efg')", " abc' ", "'/" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/Customers(%27abc%2F/'%27efg')/ 'abc /'%2F", new[] { "Customers('abc//''efg')", " 'abc ", "'/" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/Customers(%27abc%2F/'%27efg')/ 'abc/ijk /'%2F", new[] { "Customers('abc//''efg')", " 'abc", "ijk ", "'/" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/Customers(%27abc%2F/'%27efg')/ 'abc/ijk /'pqr/xyz'", new[] { "Customers('abc//''efg')", " 'abc", "ijk ", "'pqr", "xyz'" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/Products(1)/$metadata", new[] { "Products(1)", "$metadata" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/Products(1)/%24metadata", new[] { "Products(1)", "$metadata" })]
+        // Customer reported cases
+        [InlineData("security/", "security/zones('b288f9e672c04efeb31ec39276ec4928')/environments('/subscriptions/bf92c6ed78d24690919bfb93e84682bf')", new[] { "zones('b288f9e672c04efeb31ec39276ec4928')", "environments('/subscriptions/bf92c6ed78d24690919bfb93e84682bf')" })]
+        [InlineData("odata/", "/odata/entity/search('abc/123')", new[] { "entity", "search('abc/123')" })]
+        [InlineData("/", "/ApplicationSegments('1234')/corsConfigurations('/Test/app')", new[] { "ApplicationSegments('1234')", "corsConfigurations('/Test/app')" })]
+        [InlineData("/", "/ApplicationSegments('1234')/corsConfigurations('%2FTest/app')", new[] { "ApplicationSegments('1234')", "corsConfigurations('/Test/app')" })]
+        public void ParsePathMultipleSegments(string baseUriString, string uriString, string[] expectedSegments)
+        {
+            // Arrange
+            var baseUri = new Uri(baseUriString, UriKind.RelativeOrAbsolute);
+            var uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
+
+            // Act
+            var segments = this.pathParser.ParsePathIntoSegments(uri, baseUri);
+
+            // Assert
+            Assert.Equal(expectedSegments, segments);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/api/", "http://localhost/api/")]
+        [InlineData("http://localhost/api", "http://localhost/api")]
+        public void ParsePathNoSegmentsReturnsEmpty(string baseUriString, string uriString)
+        {
+            // Arrange
+            var baseUri = new Uri(baseUriString, UriKind.RelativeOrAbsolute);
+            var uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
+
+            // Act
+            var segments = this.pathParser.ParsePathIntoSegments(uri, baseUri);
+
+            // Assert
+            Assert.Empty(segments);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/api/", "http://localhost/api//Products//(1)//", new[] { "Products", "(1)" })]
+        [InlineData("http://localhost/api/", "http://localhost/api///", new string[0])]
+        public void ParsePathDuplicateOrTrailingSlashesOmitsEmptySegments(string baseUriString, string uriString, string[] expected)
+        {
+            // Arrange
+            var baseUri = new Uri(baseUriString, UriKind.RelativeOrAbsolute);
+            var uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
+
+            // Act
+            var segments = this.pathParser.ParsePathIntoSegments(uri, baseUri);
+
+            // Assert
+            Assert.Equal(expected, segments);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/api/", "http://localhost/api/Products(1)?$select=Name", new[] { "Products(1)" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/Products(1)#frag", new[] { "Products(1)" })]
+        [InlineData("http://localhost/api/", "http://localhost/api/Products(1)?x=y#z", new[] { "Products(1)" })]
+        public void ParsePathIgnoresQueryAndFragment(string baseUriString, string uriString, string[] expected)
+        {
+            // Arrange
+            var baseUri = new Uri(baseUriString, UriKind.RelativeOrAbsolute);
+            var uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
+
+            // Act
+            var segments = this.pathParser.ParsePathIntoSegments(uri, baseUri);
+
+            // Assert
+            Assert.Equal(expected, segments);
+        }
+
+        [Theory]
+        [InlineData("api/", "api/People()", "People()")] // both relative, empty parens
+        [InlineData("api/", "api/People('X')", "People('X')")] // both relative
+        [InlineData("api", "api/People('X')", "People('X')")] // both relative, base no trailing slash
+        [InlineData("api/", "http://host/api/People('X')", "People('X')")] // base rel, full abs
+        [InlineData("http://host/api/", "api/People('X')", "People('X')")] // base abs, full rel
+        [InlineData("/", "People('X')", "People('X')")] // base root + relative full -> mock base
+        [InlineData("/", "./People('X')", "People('X')")]
+        [InlineData("/", "../People('X')", "People('X')")]
+        [InlineData("./", "People('X')", "People('X')")]
+        [InlineData("./", "./People('X')", "People('X')")]
+        [InlineData("./", "../People('X')", "People('X')")]
+        [InlineData("../", "People('X')", "People('X')")]
+        [InlineData("../", "./People('X')", "People('X')")]
+        [InlineData("../", "../People('X')", "People('X')")]
+        [InlineData(null, "People('X')", "People('X')")] // null base + relative full -> mock base
+        public void ParsePathMockingCombinations(string baseUriString, string uriString, string expectedSegment)
+        {
+            // Arrange
+            var baseUri = baseUriString is null ? null : new Uri(baseUriString, UriKind.RelativeOrAbsolute);
+            var uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
+
+            // Act
+            var segments = this.pathParser.ParsePathIntoSegments(uri, baseUri);
+            var segment = Assert.Single(segments);
+
+            // Assert
+            Assert.Equal(expectedSegment, segment);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/api/", "http://localhost/api/Files('name;v%3D1.1')", "Files('name;v=1.1')")]
+        [InlineData("http://localhost/api/", "http://localhost/api/Files('a;b;c')", "Files('a;b;c')")]
+        public void ParsePathSemicolonParamsInsideLiteral(string baseUriString, string uriString, string expected)
+        {
+            // Arrange
+            var baseUri = new Uri(baseUriString, UriKind.RelativeOrAbsolute);
+            var uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
+
+            // Act
+            var segments = this.pathParser.ParsePathIntoSegments(uri, baseUri);
+            var segment = Assert.Single(segments);
+
+            // Assert
+            Assert.Equal(expected, segment);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/api/", "http://localhost/api/%50roducts(1)", "Products(1)")] // %50 = 'P' at segment start
+        [InlineData("http://localhost/api/", "http://localhost/api/Products(1)%2F", "Products(1)/")] // encoded slash at end of segment (retained within same segment)
+        [InlineData("http://localhost/api/", "http://localhost/api/%27A%27", "'A'")] // entire segment is an encoded quoted literal
+        public void ParsePathEdgeEncodings(string baseUriString, string uriString, string expectedSegment)
+        {
+            // Arrange
+            var baseUri = new Uri(baseUriString, UriKind.RelativeOrAbsolute);
+            var uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
+
+            // Act
+            var segments = this.pathParser.ParsePathIntoSegments(uri, baseUri);
+            var segment = Assert.Single(segments);
+
+            // Assert
+            Assert.Equal(expectedSegment, segment);
+        }
+
+        [Fact]
+        public void ParsePathBaseCaseInsensitivity()
+        {
+            // Arrange
+            var baseUri = new Uri("http://localhost/API/", UriKind.Absolute);
+            var uri = new Uri("http://localhost/api/Products", UriKind.Absolute);
+
+            // Act
+            var segments = this.pathParser.ParsePathIntoSegments(uri, baseUri);
+            var segment = Assert.Single(segments);
+
+            // Assert
+            Assert.Equal("Products", segment);
+        }
+
+        [Theory]
+        [InlineData("http://localhost:80/api/", "https://localhost:443/api/People('X')", "People('X')")] // scheme and default port difference ignored
+        [InlineData("http://localhost:80/api/", "http://localhost/api/People('X')", "People('X')")] // default port omitted
+        [InlineData("https://LOCALHOST/API/", "http://localhost/api/People('X')", "People('X')")] // scheme and case difference ignored
+        public void ParsePathSchemePortHostVariance(string baseUriString, string uriString, string expected)
+        {
+            // Arrange
+            var baseUri = new Uri(baseUriString, UriKind.Absolute);
+            var uri = new Uri(uriString, UriKind.Absolute);
+
+            // Act
+            var segment = Assert.Single(this.pathParser.ParsePathIntoSegments(uri, baseUri));
+
+            // Assert
+            Assert.Equal(expected, segment);
+        }
+
+        [Fact]
+        public void ParsePathLongSegmentWithManyEscapes()
+        {
+            // Arrange
+            var baseUri = new Uri("http://localhost/api/", UriKind.Absolute);
+            var repeated = string.Concat(Enumerable.Repeat("%2F%27%32%30", 50)); // "/'20" repeated (odd but valid)
+            var uri = new Uri($"http://localhost/api/Doc('{repeated}')", UriKind.Absolute);
+
+            // Act
+            var segment = Assert.Single(this.pathParser.ParsePathIntoSegments(uri, baseUri));
+
+            // Assert
+            Assert.StartsWith("Doc('", segment);
+            Assert.EndsWith("')", segment);
+            Assert.Contains("/'20", segment); // verifies decode
+        }
+
+        [Theory]
+        [InlineData("http://localhost/api/?Foo=Bar", "http://localhost/api/People('Foo/Bar')")]
+        [InlineData("http://localhost/api/#Foo", "http://localhost/api/People('Foo/Bar')")]
+        public void ParsePathBaseUriWithQueryOrFragment(string baseUriString, string uriString)
+        {
+            // Arrange
+            var baseUri = new Uri(baseUriString);
+            var uri = new Uri(uriString);
+
+            // Act
+            var segments = this.pathParser.ParsePathIntoSegments(uri, baseUri);
+
+            // Assert
+            var segment = Assert.Single(segments);
+            Assert.Equal("People('Foo/Bar')", segment);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/api/People('Foo%2')", "People('Foo%2')")]
+        [InlineData("http://localhost/api/People('Foo%GG')", "People('Foo%GG')")]
+        [InlineData("http://localhost/api/People('Foo%C3')", "People('Foo%C3')")]
+        [InlineData("http://localhost/api/People('Foo%C3%28')", "People('Foo%C3(')")]
+        public void ParsePathPercentEncodingNotValidOrUtf8SequenceMalformed(string uriString, string expected)
+        {
+            // Arrange
+            var baseUri = new Uri("http://localhost/api/");
+            var uri = new Uri(uriString);
+            
+            // Act
+            var segments = this.pathParser.ParsePathIntoSegments(uri, baseUri); // Uri.UnescapeDataString is lenient - does not throw
+
+            // Assert
+            var segment = Assert.Single(segments);
+            Assert.Equal(expected, segment);
+        }
+
+        [Fact]
+        public void ParsePathSegmentsAtPathLimit()
+        {
+            // Arrange
+            var localPathParser = new UriPathParser(new ODataUriParserSettings { PathLimit = 2 });
+            var baseUri = new Uri("http://localhost/api/");
+            var uri = new Uri("http://localhost/api/People('Foo/Bar')/Orders");
+
+            // Act
+            var segments = localPathParser.ParsePathIntoSegments(uri, baseUri);
+
+            // Assert
+            this.VerifyPath(segments,
+            [
+                s => Assert.Equal("People('Foo/Bar')", s),
+                s => Assert.Equal("Orders", s),
+            ]);
+        }
+
+        [Fact]
+        public void ParsePathThrowsExceptionForMaxPathLimitExceeded()
+        {
+            // Arrange
+            var localPathParser = new UriPathParser(new ODataUriParserSettings { PathLimit = 2 });
+            var baseUri = new Uri("http://localhost/api/");
+            var uri = new Uri("http://localhost/api/Customers(5)/Orders(3)/Items");
+
+            // Act & Assert
+            var exception = Assert.Throws<ODataException>(() => localPathParser.ParsePathIntoSegments(uri, baseUri));
+            Assert.Equal("Too many segments in URI.", exception.Message);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Cherry-pick https://github.com/OData/odata.net/pull/3340 into dev-9.x branch

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*