### PR TITLE
UriUtils.UriInvariantInsensitiveIsBaseOf should be preserve double slashes in base URI - RFC 3986

### DIFF
--- a/src/Microsoft.OData.Core/UriUtils.cs
+++ b/src/Microsoft.OData.Core/UriUtils.cs
@@ -160,9 +160,6 @@ namespace Microsoft.OData
             ReadOnlySpan<char> basePath = absBase.GetComponents(UriComponents.Path, UriFormat.UriEscaped);
             ReadOnlySpan<char> uriPath = absUri.GetComponents(UriComponents.Path, UriFormat.UriEscaped);
 
-            basePath = TrimSingleLeadingSlash(basePath);
-            uriPath = TrimSingleLeadingSlash(uriPath);
-
             // Treat empty or root base path as a base of any path on any host
             if (basePath.Length == 0)
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes `UriInvariantInsensitiveIsBaseOf_DoubleSlashesTreatedLiterally` test.* The recent refactor of `UriPathParser.ParsePathIntoSegments` together with it's helper methods in `UriUtils` broke the test.

### Description

The test `UriInvariantInsensitiveIsBaseOf_DoubleSlashesTreatedLiterally` verifies that the base‑of logic treats consecutive slashes in the path as significant (i.e. it does NOT collapse “//” to “/”). Concretely:
- Base URI:  http://x//odata (path segments: ["", "odata"])
- Candidate1: http://x//odata/Products (segments: ["", "odata", "Products"]) -> should match (True)
- Candidate2: http://x/odata/Products  (segments: ["odata", "Products"]) -> should NOT match (False)

So it asserts:
1. Empty path segments created by a double slash are preserved.
2. Segment comparison is structural (prefix match on the exact segment sequence), not a simple string compare after “slash compression”.
3. The algorithm must not normalize multiple consecutive slashes into one when determining base relationships.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
