### PR TITLE
Refactor JsonReader async paths to reduce GC pressure

### DIFF
--- a/src/Microsoft.OData.Core/CacheTasks.cs
+++ b/src/Microsoft.OData.Core/CacheTasks.cs
@@ -1,0 +1,35 @@
+//---------------------------------------------------------------------
+// <copyright file="CachedTasks.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData
+{
+    #region Namespaces
+    using System.Diagnostics.CodeAnalysis;
+    using System.Threading.Tasks;
+    using Microsoft.OData.Json;
+    #endregion Namespaces
+
+    internal static class CachedTasks
+    {
+        internal static readonly Task<bool> True = Task.FromResult(true);
+        
+        internal static readonly Task<bool> False = Task.FromResult(false);
+
+        internal static readonly Task<object> ObjectNull = Task.FromResult<object>(null);
+
+        internal static readonly Task<object> ObjectTrue = Task.FromResult<object>(true);
+
+        internal static readonly Task<object> ObjectFalse = Task.FromResult<object>(false);
+
+        internal static readonly Task<JsonNodeType> StartObject = Task.FromResult(JsonNodeType.StartObject);
+
+        internal static readonly Task<JsonNodeType> StartArray = Task.FromResult(JsonNodeType.StartArray);
+
+        internal static readonly Task<JsonNodeType> PrimitiveValue = Task.FromResult(JsonNodeType.PrimitiveValue);
+
+        internal static readonly Task<JsonNodeType> Property = Task.FromResult(JsonNodeType.Property);
+    }
+}

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ChunkedStringReader.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ChunkedStringReader.cs
@@ -1,0 +1,161 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ChunkedStringReader.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.OData.Tests.Json
+{
+    /// <summary>
+    /// Text reader that that simulates a chunked / streaming input source so JsonReader
+    /// paths that depend on partial buffers and truly asynchronous completion are exercised.
+    /// - Returns at most <c>chunkSize</c> characters per read to force multiple buffer refills.
+    /// - All asynchronous APIs (`ReadAsync`, `ReadAsync(Memory<char>)`, `ReadToEndAsync`) first await <see cref="Task.Yield"/> so
+    ///   the returned <see cref="ValueTask"/> / <see cref="Task"/> is not completed synchronously (forces “slow” paths).
+    /// - Tracks whether any async operation actually completed asynchronously via <see cref="ObservedAsyncCompletion"/> for assertions.
+    /// Use <see cref="ChunkedStringReader"/> to validate boundary conditions,
+    /// incremental parsing, and correct handling of partially available data.
+    /// </summary>
+    internal sealed class ChunkedStringReader : TextReader
+    {
+        private readonly ReadOnlyMemory<char> data;
+        private readonly int chunkSize;
+        private int pos;
+        private bool disposed;
+
+        /// <summary>
+        /// True if an async read completed asynchronously at least once.
+        /// Useful for asserting the "slow path" was taken in tests.
+        /// </summary>
+        public bool ObservedAsyncCompletion { get; private set; }
+
+        /// <param name="data">The source text to read.</param>
+        /// <param name="chunkSize">
+        /// Maximum number of characters to return per read.
+        /// Use a small value (e.g., 64–256) to force refills during parsing.
+        /// </param>
+        public ChunkedStringReader(string data, int chunkSize = 128)
+            : this((data ?? throw new ArgumentNullException(nameof(data))).AsMemory(), chunkSize)
+        {
+        }
+
+        public ChunkedStringReader(ReadOnlyMemory<char> data, int chunkSize = 128)
+        {
+            if (chunkSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(chunkSize));
+            }
+
+            this.data = data;
+            this.chunkSize = chunkSize;
+            this.pos = 0;
+        }
+
+        public override void Close() => Dispose(true);
+
+        protected override void Dispose(bool disposing)
+        {
+            this.disposed = true;
+            base.Dispose(disposing);
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (this.disposed)
+            {
+                throw new ObjectDisposedException(nameof(ChunkedStringReader));
+            }
+        }
+
+        public override int Peek()
+        {
+            ThrowIfDisposed();
+
+            return this.pos < this.data.Length ? this.data.Span[this.pos] : -1;
+        }
+
+        public override int Read()
+        {
+            ThrowIfDisposed();
+            if (this.pos >= this.data.Length) return -1;
+
+            return this.data.Span[this.pos++];
+        }
+
+        public override int Read(char[] buffer, int index, int count)
+        {
+            ThrowIfDisposed();
+
+            ArgumentNullException.ThrowIfNull(buffer);
+            if ((uint)index > (uint)buffer.Length) throw new ArgumentOutOfRangeException(nameof(index));
+            if ((uint)count > (uint)(buffer.Length - index)) throw new ArgumentOutOfRangeException(nameof(count));
+
+            if (this.pos >= this.data.Length) return 0;
+
+            int toCopy = Math.Min(Math.Min(count, this.chunkSize), this.data.Length - this.pos);
+            this.data.Span.Slice(this.pos, toCopy).CopyTo(buffer.AsSpan(index, toCopy));
+            this.pos += toCopy;
+
+            return toCopy;
+        }
+
+        public override int Read(Span<char> buffer)
+        {
+            ThrowIfDisposed();
+            if (this.pos >= this.data.Length) return 0;
+
+            int toCopy = Math.Min(Math.Min(buffer.Length, this.chunkSize), this.data.Length - this.pos);
+            this.data.Span.Slice(this.pos, toCopy).CopyTo(buffer[..toCopy]);
+            this.pos += toCopy;
+
+            return toCopy;
+        }
+
+        public override Task<int> ReadAsync(char[] buffer, int index, int count)
+        {
+            // Delegate to the Memory<char>-based implementation, which guarantees async completion.
+            return ReadAsync(new Memory<char>(buffer, index, count), CancellationToken.None).AsTask();
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<char> buffer, CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+
+            // Ensure this ValueTask is *not* IsCompletedSuccessfully at the call-site.
+            // Task.Yield() is lightweight and reliable for tests.
+            await Task.Yield();
+
+            cancellationToken.ThrowIfCancellationRequested();
+            ObservedAsyncCompletion = true;
+
+            if (this.pos >= this.data.Length) return 0;
+
+            int toCopy = Math.Min(Math.Min(buffer.Length, this.chunkSize), this.data.Length - this.pos);
+            this.data.Span.Slice(this.pos, toCopy).CopyTo(buffer.Span[..toCopy]);
+            this.pos += toCopy;
+
+            return toCopy;
+        }
+
+        public override async Task<string> ReadToEndAsync()
+        {
+            ThrowIfDisposed();
+
+            // Force asynchrony once.
+            await Task.Yield();
+            ObservedAsyncCompletion = true;
+
+            if (this.pos >= this.data.Length) return string.Empty;
+
+            string str = new string(this.data.Span.Slice(this.pos));
+            this.pos = this.data.Length;
+
+            return str;
+        }
+    }
+}

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonReaderRegressionTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonReaderRegressionTests.cs
@@ -1,0 +1,671 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="JsonReaderRegressionTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.OData.Core;
+using Microsoft.OData.Json;
+using Xunit;
+
+namespace Microsoft.OData.Tests.Json
+{
+    public class JsonReaderRegressionTests
+    {
+        #region Constants
+
+        private const string LargeNumberAsString = "3.1415926535897932384626433832795028841971693993751058209749445" +
+                "92307816406286208998628034825342117067982148086513282306647093844609550582231725359408128" +
+                "48111745028410270193852110555964462294895493038196442881097566593344612847564823378678316" +
+                "52712019091456485669234603486104543266482133936072602491412737245870066063155881748815209" +
+                "20962829254091715364367892590360011330530548820466521384146951941511609433057270365759591" +
+                "95309218611738193261179310511854807446237996274956735188575272489122793818301194912983367" +
+                "33624406566430860213949463952247371907021798609437027705392171762931767523846748184676694" +
+                "05132000568127145263560827785771342757789609173637178721468440901224953430146549585371050" +
+                "79227968925892354201995611212902196086403441815981362977477130996051870721134999999837297" +
+                "80499510597317328160963185950244594553469083026425223082533446850352619311881710100031378" +
+                "38752886587533208381420617177669147303598253490428755468731159562863882353787593751957781" +
+                "8577805321712268066130019278766111959092164201989380952572010654858632788";
+
+        #endregion Constants
+
+        public enum ReaderSourceKind
+        {
+            Buffered,   // StringReader (baseline)
+            Chunked     // ChunkedStringReader (forced refills / async completion)
+        }
+
+        private static IEnumerable<object[]> ExpandWithReaderKinds(TheoryData<string> theoryData)
+        {
+            foreach (var dataRow in theoryData)
+            {
+                var payload = dataRow[0];
+                yield return new object[] { payload, ReaderSourceKind.Buffered }; // baseline buffered StringReader
+                yield return new object[] { payload, ReaderSourceKind.Chunked }; // chunked/refill ChunkedStringReader
+            }
+        }
+
+        private static TextReader CreateTextReader(string payload, ReaderSourceKind readerKind, int chunkSize = 128) =>
+            readerKind == ReaderSourceKind.Buffered ? new StringReader(payload) : new ChunkedStringReader(payload, chunkSize);
+
+        public static TheoryData<string> NullLiteralBufferBoundaryData => new()
+        {
+            // A: null fully inside initial 2040-char buffer
+            { "{\"IgnoreProp\":\"" + new string('s', 2007) + "\",\"NullProp\":null}" },
+            // B: buffer ends just after 'n'
+            { "{\"IgnoreProp\":\"" + new string('s', 2011) + "\",\"NullProp\":null}" },
+            // C: buffer ends just after ':' (null entirely requires second read)
+            { "{\"IgnoreProp\":\"" + new string('s', 2012) + "\",\"NullProp\":null}" },
+        };
+
+        public static TheoryData<string> BooleanLiteralBufferBoundaryData => new()
+        {
+            // A: boolean fully inside initial 2040-char buffer
+            { "{\"IgnoreProp\":\"" + new string('s', 2007) + "\",\"BooleanProp\":true}" },
+            // B: buffer ends just after 't'
+            { "{\"IgnoreProp\":\"" + new string('s', 2008) + "\",\"BooleanProp\":true}" },
+            // C: buffer ends just after ':' (boolean entirely requires second read)
+            { "{\"IgnoreProp\":\"" + new string('s', 2009) + "\",\"BooleanProp\":true}" },
+        };
+
+        public static TheoryData<string> NumberLiteralBufferBoundaryData => new()
+        {
+            // A: number fully inside initial 2040-char buffer
+            { "{\"IgnoreProp\":\"" + new string('s', 1992) + "\",\"NumberProp\":3.142857142857143}" },
+            // B: buffer ends just after '3'
+            { "{\"IgnoreProp\":\"" + new string('s', 2009) + "\",\"NumberProp\":3.142857142857143}" },
+            // C: buffer ends just after ':' (number entirely requires second read)
+            { "{\"IgnoreProp\":\"" + new string('s', 2010) + "\",\"NumberProp\":3.142857142857143}" },
+        };
+
+        public static TheoryData<string> StringLiteralBufferBoundaryData => new()
+        {
+            // A: string fully inside initial 2040-char buffer
+            { "{\"IgnoreProp\":\"" + new string('s', 1964) + "\",\"StringProp\":\"The quick brown fox jumps over the lazy dog\"}" },
+            // B: buffer ends just after '\"T'
+            { "{\"IgnoreProp\":\"" + new string('s', 2008) + "\",\"StringProp\":\"The quick brown fox jumps over the lazy dog\"}" },
+            // C: buffer ends just after ':' (string entirely requires second read)
+            { "{\"IgnoreProp\":\"" + new string('s', 2010) + "\",\"StringProp\":\"The quick brown fox jumps over the lazy dog\"}" },
+        };
+
+        public static TheoryData<string> StringLiteralWithEscapeBufferBoundaryData => new()
+        {
+            // A: string with escape fully inside initial 2040-char buffer
+            { "{\"IgnoreProp\":\"" + new string('s', 1960) + "\",\"StringProp\":\"The quick brown fox jumps over the lazy dog\\r\\n\"}" },
+            // B: buffer ends just after 'dog\\'
+            { "{\"IgnoreProp\":\"" + new string('s', 1965) + "\",\"StringProp\":\"The quick brown fox jumps over the lazy dog\\r\\n\"}" },
+            // C: buffer ends just after 'dog\\r'
+            { "{\"IgnoreProp\":\"" + new string('s', 1964) + "\",\"StringProp\":\"The quick brown fox jumps over the lazy dog\\r\\n\"}" },
+        };
+
+        public static TheoryData<string> WhitespaceBufferBoundaryData => new()
+        {
+            // A: whitespace fully inside initial 2040-char buffer
+            { "{\"IgnoreProp\":\"" + new string('s', 1939) + "\",\"WhitespacePrecedingValueProp\":       \"The quick brown fox jumps over the lazy dog\"}" },
+            // B: buffer ends just after ':'
+            { "{\"IgnoreProp\":\"" + new string('s', 1992) + "\",\"WhitespacePrecedingValueProp\":       \"The quick brown fox jumps over the lazy dog\"}" },
+            // C: buffer ends just after ': '
+            { "{\"IgnoreProp\":\"" + new string('s', 1991) + "\",\"WhitespacePrecedingValueProp\":       \"The quick brown fox jumps over the lazy dog\"}" },
+            // C: buffer ends just after ':       '
+            { "{\"IgnoreProp\":\"" + new string('s', 1985) + "\",\"WhitespacePrecedingValueProp\":       \"The quick brown fox jumps over the lazy dog\"}" },
+            // C: buffer ends just after ':       \"'
+            { "{\"IgnoreProp\":\"" + new string('s', 1984) + "\",\"WhitespacePrecedingValueProp\":       \"The quick brown fox jumps over the lazy dog\"}" },
+        };
+
+        public static TheoryData<string> PropertyBoundaryData => new()
+        {
+            // A: quoted property name fully inside initial 2040-char buffer
+            { "{\"Pro" + new string('o', 2029) + "p\":13}" },
+            // B: buffer ends just before 'p'
+            { "{\"Pro" + new string('o', 2035) + "p\":13}" },
+            // A: unquoted property name fully inside initial 2040-char buffer
+            { "{Pro" + new string('o', 2031) + "p:13}" },
+            // B: buffer ends just before 'p'
+            { "{Pro" + new string('o', 2036) + "p:13}" },
+        };
+
+        // Wrapped datasets including both source patterns reader kinds
+        public static IEnumerable<object[]> NullLiteralBufferBoundaryData_WithReaderKinds =>
+            ExpandWithReaderKinds(NullLiteralBufferBoundaryData);
+
+        public static IEnumerable<object[]> BooleanLiteralBufferBoundaryData_WithReaderKinds =>
+            ExpandWithReaderKinds(BooleanLiteralBufferBoundaryData);
+
+        public static IEnumerable<object[]> NumberLiteralBufferBoundaryData_WithReaderKinds =>
+            ExpandWithReaderKinds(NumberLiteralBufferBoundaryData);
+
+        public static IEnumerable<object[]> StringLiteralBufferBoundaryData_WithReaderKinds =>
+            ExpandWithReaderKinds(StringLiteralBufferBoundaryData);
+
+        public static IEnumerable<object[]> StringLiteralWithEscapeBufferBoundaryData_WithReaderKinds =>
+            ExpandWithReaderKinds(StringLiteralWithEscapeBufferBoundaryData);
+
+        public static IEnumerable<object[]> WhitespaceBufferBoundaryData_WithReaderKinds =>
+            ExpandWithReaderKinds(WhitespaceBufferBoundaryData);
+
+        public static IEnumerable<object[]> PropertyBoundaryData_WithReaderKinds =>
+            ExpandWithReaderKinds(PropertyBoundaryData);
+
+        [Theory]
+        [MemberData(nameof(NullLiteralBufferBoundaryData_WithReaderKinds))]
+        public async Task Read_NullLiteral_BufferBoundaryAsync(string payload, ReaderSourceKind sourceKind)
+        {
+            var textReader = CreateTextReader(payload, sourceKind);
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                await reader.ReadAsync(); // IgnoreProp
+                Assert.Equal("IgnoreProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // IgnoreProp value
+                Assert.Equal(new string('s', payload.Length - 33), await reader.GetValueAsync());
+                await reader.ReadAsync(); // NullProp
+                Assert.Equal("NullProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // NullProp value
+                Assert.Null(await reader.GetValueAsync());
+
+                if (sourceKind == ReaderSourceKind.Chunked)
+                {
+                    Assert.True(((ChunkedStringReader)textReader).ObservedAsyncCompletion);
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanLiteralBufferBoundaryData_WithReaderKinds))]
+        public async Task Read_BooleanLiteral_BufferBoundaryAsync(string payload, ReaderSourceKind sourceKind)
+        {
+            var textReader = CreateTextReader(payload, sourceKind);
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                await reader.ReadAsync(); // IgnoreProp
+                Assert.Equal("IgnoreProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // IgnoreProp value
+                Assert.Equal(new string('s', payload.Length - 36), await reader.GetValueAsync());
+                await reader.ReadAsync(); // BooleanProp
+                Assert.Equal("BooleanProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // BooleanProp value
+                Assert.Equal(true, await reader.GetValueAsync());
+
+                if (sourceKind == ReaderSourceKind.Chunked)
+                {
+                    Assert.True(((ChunkedStringReader)textReader).ObservedAsyncCompletion);
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(NumberLiteralBufferBoundaryData_WithReaderKinds))]
+        public async Task Read_NumberLiteral_BufferBoundaryAsync(string payload, ReaderSourceKind sourceKind)
+        {
+            var textReader = CreateTextReader(payload, sourceKind);
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                await reader.ReadAsync(); // IgnoreProp
+                Assert.Equal("IgnoreProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // IgnoreProp value
+                Assert.Equal(new string('s', payload.Length - 48), await reader.GetValueAsync());
+                await reader.ReadAsync(); // NumberProp
+                Assert.Equal("NumberProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // NumberProp value
+                Assert.Equal(3.142857142857143m, await reader.GetValueAsync());
+
+                if (sourceKind == ReaderSourceKind.Chunked)
+                {
+                    Assert.True(((ChunkedStringReader)textReader).ObservedAsyncCompletion);
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(StringLiteralBufferBoundaryData_WithReaderKinds))]
+        public async Task Read_StringLiteral_BufferBoundaryAsync(string payload, ReaderSourceKind sourceKind)
+        {
+            var textReader = CreateTextReader(payload, sourceKind);
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                await reader.ReadAsync(); // IgnoreProp
+                Assert.Equal("IgnoreProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // IgnoreProp value
+                Assert.Equal(new string('s', payload.Length - 76), await reader.GetValueAsync());
+                await reader.ReadAsync(); // StringProp
+                Assert.Equal("StringProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // StringProp value
+                Assert.Equal("The quick brown fox jumps over the lazy dog", await reader.GetValueAsync());
+
+                if (sourceKind == ReaderSourceKind.Chunked)
+                {
+                    Assert.True(((ChunkedStringReader)textReader).ObservedAsyncCompletion);
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(StringLiteralWithEscapeBufferBoundaryData_WithReaderKinds))]
+        public async Task Read_StringLiteralWithEscape_BufferBoundaryAsync(string payload, ReaderSourceKind sourceKind)
+        {
+            var textReader = CreateTextReader(payload, sourceKind);
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                await reader.ReadAsync(); // IgnoreProp
+                Assert.Equal("IgnoreProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // IgnoreProp value
+                Assert.Equal(new string('s', payload.Length - 80), await reader.GetValueAsync());
+                await reader.ReadAsync(); // StringProp
+                Assert.Equal("StringProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // StringProp value
+                Assert.Equal("The quick brown fox jumps over the lazy dog\r\n", await reader.GetValueAsync());
+
+                if (sourceKind == ReaderSourceKind.Chunked)
+                {
+                    Assert.True(((ChunkedStringReader)textReader).ObservedAsyncCompletion);
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(WhitespaceBufferBoundaryData_WithReaderKinds))]
+        public async Task Read_Whitespace_BufferBoundaryAsync(string payload, ReaderSourceKind sourceKind)
+        {
+            var textReader = CreateTextReader(payload, sourceKind);
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                await reader.ReadAsync(); // IgnoreProp
+                Assert.Equal("IgnoreProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // IgnoreProp value
+                Assert.Equal(new string('s', payload.Length - 101), await reader.GetValueAsync());
+                await reader.ReadAsync(); // WhitespacePrecedingValueProp
+                Assert.Equal("WhitespacePrecedingValueProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // WhitespacePrecedingValueProp value
+                Assert.Equal("The quick brown fox jumps over the lazy dog", await reader.GetValueAsync());
+
+                if (sourceKind == ReaderSourceKind.Chunked)
+                {
+                    Assert.True(((ChunkedStringReader)textReader).ObservedAsyncCompletion);
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(PropertyBoundaryData_WithReaderKinds))]
+        public async Task Read_PropertyBoundary_BufferBoundaryAsync(string payload, ReaderSourceKind sourceKind)
+        {
+            var textReader = CreateTextReader(payload, sourceKind);
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                await reader.ReadAsync(); // Prop
+                Assert.Equal(
+                    "Pro" + new string('o', payload.Length - (payload.StartsWith("{\"Pro") ? 11 : 9)) + "p",
+                    await reader.GetValueAsync());
+                await reader.ReadAsync(); // Prop value
+                Assert.Equal(13, await reader.GetValueAsync());
+
+                if (sourceKind == ReaderSourceKind.Chunked)
+                {
+                    Assert.True(((ChunkedStringReader)textReader).ObservedAsyncCompletion);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Read_NullProperties_ChunkedSourceAsync()
+        {
+            var payload = "{" + BuildNullPropertiesPayload(3072, out int propertyCount) + "}";
+            var textReader = new ChunkedStringReader(payload, chunkSize: 128);
+
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                int i = 0;
+                while (i < propertyCount)
+                {
+                    await reader.ReadAsync(); // Property name
+                    Assert.Equal($"Property{i + 1}", await reader.GetValueAsync());
+                    await reader.ReadAsync(); // Property value
+                    Assert.Null(await reader.GetValueAsync());
+                    i++;
+                }
+            }
+
+            Assert.True(textReader.ObservedAsyncCompletion);
+        }
+
+        [Fact]
+        public async Task Read_NumberProperties_ChunkedSourceAsync()
+        {
+            var payload = "{" + BuildNumberPropertiesPayload(3072, out int propertyCount) + "}";
+            var textReader = new ChunkedStringReader(payload, chunkSize: 128);
+
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                int i = 0;
+                while (i < propertyCount)
+                {
+                    await reader.ReadAsync(); // Property name
+                    Assert.Equal($"Property{i + 1}", await reader.GetValueAsync());
+                    await reader.ReadAsync(); // Property value
+                    Assert.Equal(i + 1, await reader.GetValueAsync());
+                    i++;
+                }
+            }
+
+            Assert.True(textReader.ObservedAsyncCompletion);
+        }
+
+        [Fact]
+        public async Task Read_BooleanProperties_ChunkedSourceAsync()
+        {
+            var payload = "{" + BuildBooleanPropertiesPayload(3072, out int propertyCount) + "}";
+            var textReader = new ChunkedStringReader(payload, chunkSize: 128);
+
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                int i = 0;
+                while (i < propertyCount)
+                {
+                    await reader.ReadAsync(); // Property name
+                    Assert.Equal($"Property{i + 1}", await reader.GetValueAsync());
+                    await reader.ReadAsync(); // Property value
+                    Assert.Equal((i + 1) % 2 == 0, await reader.GetValueAsync());
+                    i++;
+                }
+            }
+
+            Assert.True(textReader.ObservedAsyncCompletion);
+        }
+
+        [Fact]
+        public async Task Read_StringProperties_ChunkedSourceAsync()
+        {
+            var payload = "{" + BuildStringPropertiesPayload(3072, out int propertyCount) + "}";
+            var textReader = new ChunkedStringReader(payload, chunkSize: 128);
+
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                int i = 0;
+                while (i < propertyCount)
+                {
+                    await reader.ReadAsync(); // Property name
+                    Assert.Equal($"Property{i + 1}", await reader.GetValueAsync());
+                    await reader.ReadAsync(); // Property value
+                    Assert.Equal($"String{i + 1}", await reader.GetValueAsync());
+                    i++;
+                }
+            }
+
+            Assert.True(textReader.ObservedAsyncCompletion);
+        }
+
+        [Fact]
+        public async Task Read_LargeNumberLiteral_ChunkedSourceAsync()
+        {
+            // Long number ensures multiple refills occur triggering slow path
+            var payload = "{\"NumberProp\":" + LargeNumberAsString + "}";
+            var textReader = new ChunkedStringReader(payload, chunkSize: 128);
+
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                await reader.ReadAsync(); // NumberProp
+                Assert.Equal("NumberProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // NumberProp value
+                Assert.True(3.14m <= Assert.IsType<decimal>(await reader.GetValueAsync()));
+            }
+
+            Assert.True(textReader.ObservedAsyncCompletion);
+        }
+
+        [Fact]
+        public async Task Read_LargeNumberLiteral_EOF_ChunkedSourceAsync()
+        {
+            var payload = "{\"NumberProp\":" + LargeNumberAsString;
+            var textReader = new ChunkedStringReader(payload, chunkSize: 128);
+
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                await reader.ReadAsync(); // NumberProp
+                Assert.Equal("NumberProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // NumberProp value
+                Assert.True(3.14m <= Assert.IsType<decimal>(await reader.GetValueAsync()));
+            }
+
+            Assert.True(textReader.ObservedAsyncCompletion);
+        }
+
+        [Fact]
+        public async Task Read_Array_FirstElementAfterLargeWhitespace_ChunkedSourceAsync()
+        {
+            var payload = "{\"ArrayProp\":[" + new string(' ', 2026) + "13,7]}";
+            var textReader = new ChunkedStringReader(payload, chunkSize: 128);
+
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                await reader.ReadAsync(); // ArrayProp
+                Assert.Equal("ArrayProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // [
+                Assert.Equal(JsonNodeType.StartArray, reader.NodeType);
+                await reader.ReadAsync(); // Item 1
+                Assert.Equal(13, await reader.GetValueAsync());
+                await reader.ReadAsync(); // Item 2
+                Assert.Equal(7, await reader.GetValueAsync());
+                await reader.ReadAsync(); // ]
+                Assert.Equal(JsonNodeType.EndArray, reader.NodeType);
+                await reader.ReadAsync(); // }
+            }
+
+            Assert.True(textReader.ObservedAsyncCompletion);
+        }
+
+        [Fact]
+        public async Task Read_PropertyNameQuoted_MissingColon_ChunkedSource_ThrowsAsync()
+        {
+            var propertyName = "D" + new string('a', 128) + "ta";
+            var payload = "{\"" + propertyName + "\"}";
+            var textReader = new ChunkedStringReader(payload, chunkSize: 128);
+
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                var exception = await Assert.ThrowsAsync<ODataException>(reader.ReadAsync); // Property name
+
+                Assert.Equal(
+                    Error.Format(SRResources.JsonReader_MissingColon, propertyName),
+                    exception.Message);
+            }
+        }
+
+        [Fact]
+        public async Task Read_PropertyNameUnquoted_MissingColon_ChunkedSource_ThrowsAsync()
+        {
+            var propertyName = "D" + new string('a', 128) + "ta";
+            var payload = "{" + propertyName + "}";
+            var textReader = new ChunkedStringReader(payload, chunkSize: 128);
+
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                var exception = await Assert.ThrowsAsync<ODataException>(reader.ReadAsync); // Property name
+
+                Assert.Equal(
+                    Error.Format(SRResources.JsonReader_MissingColon, propertyName),
+                    exception.Message);
+            }
+        }
+
+        [Fact]
+        public async Task Read_BooleanLiteral_InvalidToken_ChunkedSource_ThrowsAsync()
+        {
+            var payload = "{\"D" + new string('a', 120) + "ta\":treu}";
+            var textReader = new ChunkedStringReader(payload, chunkSize: 128);
+
+            using (var reader = new JsonReader(textReader, isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                await reader.ReadAsync(); // Property name
+                await reader.GetValueAsync();
+                var exception = await Assert.ThrowsAsync<ODataException>(reader.ReadAsync); // Property value
+
+                Assert.Equal(
+                    Error.Format(SRResources.JsonReader_UnexpectedToken, "treu"),
+                    exception.Message);
+            }
+        }
+
+        [Fact]
+        public async Task Read_NullLiteral_InvalidToken_ChunkedSource_ThrowsAsync()
+        {
+            var payload = "{\"IgnoreProp\":\"" + new string('s', 2019) + "\",\"NullProp\":nil}";
+            using (var reader = new JsonReader(new ChunkedStringReader(payload, chunkSize: 128), isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                await reader.ReadAsync(); // IgnoreProp
+                Assert.Equal("IgnoreProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // IgnoreProp value
+                await reader.GetValueAsync();
+                await reader.ReadAsync(); // NullProp
+                Assert.Equal("NullProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // NullProp value
+                var exception = await Assert.ThrowsAsync<ODataException>(reader.GetValueAsync);
+
+                Assert.Equal(Error.Format(SRResources.JsonReader_UnexpectedToken, "nil"), exception.Message);
+            }
+        }
+
+        [Fact]
+        public async Task Read_StringLiteral_InvalidEscapeSequence_ChunkedSource_ThrowsAsync()
+        {
+            var payload = "{\"IgnoreProp\":\"" + new string('s', 1965) + "\",\"StringProp\":\"The quick brown fox jumps over the lazy dog\\";
+            using (var reader = new JsonReader(new ChunkedStringReader(payload, chunkSize: 18), isIeee754Compatible: false))
+            {
+                await reader.ReadAsync(); // {
+                await reader.ReadAsync(); // IgnoreProp
+                Assert.Equal("IgnoreProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // IgnoreProp value
+                await reader.GetValueAsync();
+                await reader.ReadAsync(); // StringProp
+                Assert.Equal("StringProp", await reader.GetValueAsync());
+                await reader.ReadAsync(); // StringProp value
+                var exception = await Assert.ThrowsAsync<ODataException>(reader.GetValueAsync);
+
+                Assert.Equal(
+                    Error.Format(SRResources.JsonReader_UnrecognizedEscapeSequence, "\\"),
+                    exception.Message);
+            }
+        }
+
+        static string BuildNullPropertiesPayload(int lengthHint, out int propertyCount)
+        {
+            var builder = new StringBuilder(lengthHint + 64);
+            int i = 1;
+            bool first = true;
+            while (builder.Length < lengthHint)
+            {
+                if (!first)
+                {
+                    builder.Append(',');
+                }
+
+                first = false;
+                builder.Append("\"Property");
+                builder.Append(i);
+                builder.Append("\":null");
+                i++;
+            }
+
+            propertyCount = i - 1;
+
+            return builder.ToString();
+        }
+
+        static string BuildNumberPropertiesPayload(int lengthHint, out int propertyCount)
+        {
+            var builder = new StringBuilder(lengthHint + 64);
+            int i = 1;
+            bool first = true;
+            while (builder.Length < lengthHint)
+            {
+                if (!first)
+                {
+                    builder.Append(',');
+                }
+
+                first = false;
+                builder.Append("\"Property");
+                builder.Append(i);
+                builder.Append("\":");
+                builder.Append(i);
+                i++;
+            }
+
+            propertyCount = i - 1;
+
+            return builder.ToString();
+        }
+
+        static string BuildBooleanPropertiesPayload(int lengthHint, out int propertyCount)
+        {
+            var builder = new StringBuilder(lengthHint + 64);
+            int i = 1;
+            bool first = true;
+            while (builder.Length < lengthHint)
+            {
+                if (!first)
+                {
+                    builder.Append(',');
+                }
+
+                first = false;
+                builder.Append("\"Property");
+                builder.Append(i);
+                builder.Append("\":");
+                builder.Append(i % 2 == 0 ? "true" : "false");
+                i++;
+            }
+
+            propertyCount = i - 1;
+
+            return builder.ToString();
+        }
+
+        static string BuildStringPropertiesPayload(int lengthHint, out int propertyCount)
+        {
+            var builder = new StringBuilder(lengthHint + 64);
+            int i = 1;
+            bool first = true;
+            while (builder.Length < lengthHint)
+            {
+                if (!first)
+                {
+                    builder.Append(',');
+                }
+
+                first = false;
+                builder.Append("\"Property");
+                builder.Append(i);
+                builder.Append("\":");
+                builder.Append($"\"String{i}\"");
+                i++;
+            }
+
+            propertyCount = i - 1;
+
+            return builder.ToString();
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3358.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Benchmarks

```markdown
| Method    | Implementation | Mean     | Error    | StdDev   | Ratio | RatioSD | Completed Work Items | Lock Contentions | Gen0    | Gen1   | Allocated | Alloc Ratio |
|---------- |--------------- |---------:|---------:|---------:|------:|--------:|---------------------:|-----------------:|--------:|-------:|----------:|------------:|
| ReadAsync | V0             | 550.4 us | 27.38 us | 40.99 us |  1.01 |    0.10 |              10.0000 |           0.0371 | 39.0625 | 9.7656 |  486.1 KB |        1.00 |
|           |                |          |          |          |       |         |                      |                  |         |        |           |             |
| ReadAsync | V1             | 483.1 us | 22.19 us | 32.52 us |  1.00 |    0.09 |              10.0029 |           0.2490 | 35.1563 | 7.8125 | 435.52 KB |        1.00 |
```

**Performance**:
- Mean: V0 = 550.4 µs, V1 = 483.1 µs → V1 is ~12.2% faster ((550.4−483.1)/550.4).
- Relative StdDev: V0 ≈ 7.45% (40.99 / 550.4), V1 ≈ 6.73%.
- Error column (standard error proxy) shows intervals do not obviously overlap enough to invalidate a ~12% gain.

**Allocations**:
- V0: 486.1 KB, V1: 435.52 KB → ~10.4% reduction (~50.6 KB/op).
- Gen0 / Gen1 trigger counts lower for V1 (fewer promoted objects), consistent with reduced allocation pressure.

**Summary**:
The refactored reader (V1) delivers a solid double win: ~12% faster and ~10% fewer allocations for the sample payload. Variance is acceptable.

**Payload**:
```json
{
  "@odata.context": "http://tempuri.org/$metadata#SuperEntities/$entity",
  "Id": 1,
  "BooleanProperty": true,
  "Int32Property": 13,
  "SingleProperty": 3.142,
  "Int16Property": 7,
  "Int64Property": 6078747774547,
  "DoubleProperty": 3.14159265359,
  "DecimalProperty": 7654321,
  "GuidProperty": "00000017-003b-003b-0001-020304050607",
  "DateTimeOffsetProperty": "1970-12-31T23:59:59Z",
  "TimeSpanProperty": "PT23H59M59S",
  "ByteProperty": 1,
  "SignedByteProperty": 9,
  "StringProperty": "foo",
  "DateProperty": "1970-01-01",
  "TimeOfDayProperty": "23:59:59.0000000",
  "ColorProperty": "Black",
  "GeographyPointProperty": { "type": "Point", "coordinates": [22.2, 22.2], "crs": { "type": "name", "properties": { "name": "EPSG:4326" } } },
  "GeometryPointProperty": { "type": "Point", "coordinates": [7.0, 13.0], "crs": { "type": "name", "properties": { "name": "EPSG:0" } } },
  "BooleanCollectionProperty": [true, false],
  "Int32CollectionProperty": [13, 31],
  "SingleCollectionProperty": [3.142, 241.3],
  "Int16CollectionProperty": [7, 11],
  "Int64CollectionProperty": [6078747774547, 7454777478706],
  "DoubleCollectionProperty": [3.14159265359, 95356295141.3],
  "DecimalCollectionProperty": [7654321, 1234567],
  "GuidCollectionProperty": ["00000017-003b-003b-0001-020304050607", "0000000b-001d-001d-0706-050403020100"],
  "DateTimeOffsetCollectionProperty": ["1970-12-31T23:59:59Z", "1858-11-17T11:29:29Z"],
  "TimeSpanCollectionProperty": ["PT23H59M59S", "PT11H29M29S"],
  "ByteCollectionProperty": [1, 9],
  "SignedByteCollectionProperty": [9, 1],
  "StringCollectionProperty": ["foo", "bar"],
  "DateCollectionProperty": ["1970-12-31", "1858-11-17"],
  "TimeOfDayCollectionProperty": ["23:59:59.0000000", "11:29:29.0000000"],
  "ColorCollectionProperty": ["Black", "White"],
  "GeographyPointCollectionProperty": [
    { "type": "Point", "coordinates": [22.2, 22.2], "crs": { "type": "name", "properties": { "name": "EPSG:4326" } } },
    { "type": "Point", "coordinates": [11.6, 11.9], "crs": { "type": "name", "properties": { "name": "EPSG:4326" } } }
  ],
  "GeometryPointCollectionProperty": [
    { "type": "Point", "coordinates": [7.0, 13.0], "crs": { "type": "name", "properties": { "name": "EPSG:0" } } },
    { "type": "Point", "coordinates": [13.0, 7.0], "crs": { "type": "name", "properties": { "name": "EPSG:0" } } }
  ],
  "DynamicPrimitiveProperty@odata.type": "#Edm.Double",
  "DynamicPrimitiveProperty": 3.14159265359,
  "DynamicSpatialProperty@odata.type": "#Edm.GeographyPoint",
  "DynamicSpatialProperty": { "type": "Point", "coordinates": [11.1, 11.1], "crs": { "type": "name", "properties": { "name": "EPSG:4326" } } },
  "DynamicNullProperty@odata.type": "#Edm.String",
  "DynamicNullProperty": null,
  "DynamicStringValueProperty@odata.type": "#Edm.String",
  "DynamicStringValueProperty": "The quick brown fox jumps over the lazy dog",
  "CoordinateProperty": { "Longitude": 47.64229583688, "Latitude": -122.13694393057 },
  "EntityProperty": { "@odata.id": "http://tempuri.org/Customers(1)", "Id": 1, "Name": "Customer 1" },
  "CoordinateCollectionProperty": [
    { "Longitude": 47.64229583688, "Latitude": -122.13694393057 },
    { "Longitude": -1.25873495895, "Latitude": 36.80558172342 }
  ],
  "EntityCollectionProperty": [
    { "@odata.id": "http://tempuri.org/Customers(1)", "Id": 1, "Name": "Customer 1" },
    { "@odata.id": "http://tempuri.org/Customers(2)", "Id": 2, "Name": "Customer 2" }
  ],
  "DynamicComplexProperty": { "@odata.type": "#NS.Coordinate", "Longitude": 47.64229583688, "Latitude": -122.13694393057 },
  "DynamicComplexCollectionProperty@odata.type": "#Collection(NS.Coordinate)",
  "DynamicComplexCollectionProperty": [
    { "@odata.type": "#NS.Coordinate", "Longitude": 47.64229583688, "Latitude": -122.13694393057 },
    { "@odata.type": "#NS.Coordinate", "Longitude": -1.25873495895, "Latitude": 36.80558172342 }
  ]
}
```