### PR TITLE
Cherry-pick: UriUtils.UriInvariantInsensitiveIsBaseOf should be preserve double slashes in base URI - RFC 3986

### DIFF
--- a/src/Microsoft.OData.Core/UriUtils.cs
+++ b/src/Microsoft.OData.Core/UriUtils.cs
@@ -160,9 +160,6 @@ namespace Microsoft.OData
             ReadOnlySpan<char> basePath = absBase.GetComponents(UriComponents.Path, UriFormat.UriEscaped);
             ReadOnlySpan<char> uriPath = absUri.GetComponents(UriComponents.Path, UriFormat.UriEscaped);
 
-            basePath = TrimSingleLeadingSlash(basePath);
-            uriPath = TrimSingleLeadingSlash(uriPath);
-
             // Treat empty or root base path as a base of any path on any host
             if (basePath.Length == 0)
             {

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataUtilsTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataUtilsTests.cs
@@ -363,7 +363,7 @@ namespace Microsoft.OData.Tests
             var u2 = new Uri("http://x/odata/Products"); // different normalization
 
             Assert.True(UriUtils.UriInvariantInsensitiveIsBaseOf(b, u1));
-            Assert.True(UriUtils.UriInvariantInsensitiveIsBaseOf(b, u2));
+            Assert.False(UriUtils.UriInvariantInsensitiveIsBaseOf(b, u2));
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Cherry-pick: UriUtils.UriInvariantInsensitiveIsBaseOf should be preserve double slashes in base URI - RFC 3986

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
