### PR TITLE
Fixes #3363: Filter operator "IN" fails to handle empty strings

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -274,9 +274,9 @@ namespace Microsoft.OData.UriParser
                     // If prev and next are both double quotes, then it's an empty string.
                     if (input[k - 1] == '"')
                     {
-                        // We append \"\" so as to return "\"\"" instead of "".
-                        // This is to avoid passing an empty string to the ConstantNode.
-                        sb.Append("\\\"\\\"");
+                        // Here, we meet an empty string as "", we should do nothing here becase at the beginning appends a double quote, and at the end appends another double quote.
+                        // So, don't do the following appending.
+                        // sb.Append("\\\"\\\"");
                     }
                     break;
                 }
@@ -334,9 +334,10 @@ namespace Microsoft.OData.UriParser
                                 sb.Append('"');
                                 return k;
                             }
-                            // We append \"\" so as to return "\"\"" instead of "".
-                            // This is to avoid passing an empty string to the ConstantNode.
-                            sb.Append("\\\"\\\"");
+
+                            // Here, we meet an empty string as '', we should do nothing here becase at the beginning appends a double quote, and at the end appends another double quote.
+                            // So, don't do the following appending.
+                            // sb.Append("\\\"\\\"");
                         }
                         // match with single quote ('), stop it.
                         break;

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/ConstantNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/ConstantNode.cs
@@ -15,6 +15,9 @@ namespace Microsoft.OData.UriParser
 
     /// <summary>
     /// Node representing a constant value, can either be primitive, complex, entity, or collection value.
+    /// Be noted:
+    /// If an 'in' clause, for example: $filter=name in ('abc', ''), since the InBinder converts the literal to ["abc", ""], in this case, the literal for second item is an empty string.
+    /// In all other cases, for example: $filter=name eq '', the literal for this node is "''", it's not an empty string.
     /// </summary>
     public sealed class ConstantNode : SingleValueNode
     {
@@ -37,7 +40,8 @@ namespace Microsoft.OData.UriParser
         public ConstantNode(object constantValue, string literalText)
             : this(constantValue)
         {
-            ExceptionUtils.CheckArgumentStringNotNullOrEmpty(literalText, "literalText");
+            ExceptionUtils.CheckArgumentNotNull(literalText, "literalText");
+
             this.LiteralText = literalText;
         }
 
@@ -50,7 +54,7 @@ namespace Microsoft.OData.UriParser
         /// <exception cref="System.ArgumentNullException">Throws if the input literalText is null.</exception>
         public ConstantNode(object constantValue, string literalText, IEdmTypeReference typeReference)
         {
-            ExceptionUtils.CheckArgumentStringNotNullOrEmpty(literalText, "literalText");
+            ExceptionUtils.CheckArgumentNotNull(literalText, "literalText");
 
             this.constantValue = constantValue;
             this.LiteralText = literalText;


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3363*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
