### PR TITLE
Fixes #3357: Regression when parsing query option with no =

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/ODataUriParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataUriParser.cs
@@ -572,6 +572,14 @@ namespace Microsoft.OData.UriParser
             {
                 foreach (var queryOption in queryOptions)
                 {
+                    // for scenario like: ?$filter=Name eq 'Foo'&unknown&$top=5
+                    // for 'unknown', the query option name is 'null', in this case, we can definitely add it as custom query option.
+                    if (string.IsNullOrEmpty(queryOption.Name))
+                    {
+                        customQueryOptions.Add(new KeyValuePair<string, string>(queryOption.Name, queryOption.Value));
+                        continue;
+                    }
+
                     string queryOptionName = queryOption.Name;
 
                     // If EnableNoDollarQueryOptions is true, we will treat all reserved OData query options without "$" prefix as odata query options.

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -16,11 +16,11 @@ using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OData.Edm.Vocabularies.Community.V1;
+using Microsoft.OData.Metadata;
 using Microsoft.OData.UriParser;
 using Microsoft.OData.UriParser.Aggregation;
 using Microsoft.OData.UriParser.Validation;
 using Xunit;
-using Microsoft.OData.Metadata;
 
 namespace Microsoft.OData.Tests.UriParser
 {
@@ -771,6 +771,23 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.NotNull(parser.ParseSearch());
             Assert.Equal("abc", parser.ParseSkipToken());
             Assert.Equal("def", parser.ParseDeltaToken());
+            Assert.Equal(2, parser.CustomQueryOptions.Count);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ParseQueryOptionsShouldWorkForUnknownQueryOptions(bool enableNoDollarQueryOptions)
+        {
+            string relativeUriString = "People?$filter=Name eq 'Foo'&unknown&whatif&unknown=&$top=5";
+            var parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri(relativeUriString, UriKind.Relative));
+            parser.EnableNoDollarQueryOptions = enableNoDollarQueryOptions;
+
+            Assert.NotNull(parser.ParseFilter());
+            Assert.Equal(3, parser.CustomQueryOptions.Count);
+            Assert.Equal(new KeyValuePair<string, string>(null, "unknown"), parser.CustomQueryOptions.ElementAt(0));
+            Assert.Equal(new KeyValuePair<string, string>(null, "whatif"), parser.CustomQueryOptions.ElementAt(1));
+            Assert.Equal(new KeyValuePair<string, string>("unknown", ""), parser.CustomQueryOptions.ElementAt(2));
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3357.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
