### PR TITLE
Remove hard-coded network isolation policies

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -35,10 +35,6 @@ variables:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
-    settings:
-      networkIsolationPolicy: Preferred,Nuget.org,AzureKeyVault,AzureActiveDirectory,AzureStorage
-      # Change to Good,Nuget.org if it gets too restrictive
-      # AzureKeyVault,AzureActiveDirectory,AzureStorage Allow policies required for the ESRP task
     pool:
       name: MSSecurity-1ES-Build-Agents-Pool
       image: MSSecurity-1ES-Windows-2022

--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -37,8 +37,6 @@ variables:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
-    settings:
-      networkIsolationPolicy: Preferred,Nuget.org # Change to Good,Nuget.org if it gets too restrictive
     pool:
       name: MSSecurity-1ES-Build-Agents-Pool
       image: MSSecurity-1ES-Windows-2022


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

We added the network isolation policy settings because of configurations that were rolled out by the Network Isolation team. Without these settings, calls to nuget.org and the ESRP code signing tasks were failing.

We are removing because the Network Isolation team has added all the policies that the OData pipelines needs on their side so we no longer need to hard-code them here anymore.

<img width="2682" height="149" alt="image" src="https://github.com/user-attachments/assets/069a16e5-160c-4153-981a-6a0883614744" />

### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*
