### PR TITLE
Introduce non-capturing overloads of InterceptException and InterceptExceptionAsync in ODataReaderCore for improved performance

### DIFF
--- a/src/Microsoft.OData.Core/Batch/ODataBatchReader.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchReader.cs
@@ -140,7 +140,7 @@ namespace Microsoft.OData
         public bool Read()
         {
             this.VerifyCanRead(true);
-            return this.InterceptException((thisParam) => thisParam.ReadSynchronously());
+            return this.InterceptException(static (thisParam) => thisParam.ReadSynchronously());
         }
 
         /// <summary>Asynchronously reads the next part from the batch message payload.</summary>
@@ -148,7 +148,7 @@ namespace Microsoft.OData
         public Task<bool> ReadAsync()
         {
             this.VerifyCanRead(false);
-            return this.InterceptExceptionAsync((thisParam) => thisParam.ReadAsynchronously());
+            return this.InterceptExceptionAsync(static (thisParam) => thisParam.ReadAsynchronously());
         }
 
         /// <summary>Returns an <see cref="ODataBatchOperationRequestMessage" /> for reading the content of a batch operation.</summary>
@@ -157,7 +157,7 @@ namespace Microsoft.OData
         {
             this.VerifyCanCreateOperationRequestMessage(synchronousCall: true);
             ODataBatchOperationRequestMessage result =
-                this.InterceptException((thisParam) => thisParam.CreateOperationRequestMessageImplementation());
+                this.InterceptException(static (thisParam) => thisParam.CreateOperationRequestMessageImplementation());
             this.ReaderOperationState = OperationState.MessageCreated;
             this.contentIdToAddOnNextRead = result.ContentId;
             return result;
@@ -169,7 +169,7 @@ namespace Microsoft.OData
         {
             this.VerifyCanCreateOperationRequestMessage(synchronousCall: false);
             ODataBatchOperationRequestMessage result = await this.InterceptExceptionAsync(
-                (thisParam) => thisParam.CreateOperationRequestMessageImplementationAsync()).ConfigureAwait(false);
+                static (thisParam) => thisParam.CreateOperationRequestMessageImplementationAsync()).ConfigureAwait(false);
             this.ReaderOperationState = OperationState.MessageCreated;
             this.contentIdToAddOnNextRead = result.ContentId;
 
@@ -182,7 +182,7 @@ namespace Microsoft.OData
         {
             this.VerifyCanCreateOperationResponseMessage(synchronousCall: true);
             ODataBatchOperationResponseMessage result =
-                this.InterceptException((thisParam) => thisParam.CreateOperationResponseMessageImplementation());
+                this.InterceptException(static (thisParam) => thisParam.CreateOperationResponseMessageImplementation());
             this.ReaderOperationState = OperationState.MessageCreated;
             return result;
         }
@@ -193,7 +193,7 @@ namespace Microsoft.OData
         {
             this.VerifyCanCreateOperationResponseMessage(synchronousCall: false);
             ODataBatchOperationResponseMessage result = await this.InterceptExceptionAsync(
-                (thisParam) => thisParam.CreateOperationResponseMessageImplementationAsync()).ConfigureAwait(false);
+                static (thisParam) => thisParam.CreateOperationResponseMessageImplementationAsync()).ConfigureAwait(false);
 
             this.ReaderOperationState = OperationState.MessageCreated;
 

--- a/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
@@ -395,7 +395,7 @@ namespace Microsoft.OData
             this.VerifyCanFlush(false);
 
             // Make sure we switch to writer state Error if an exception is thrown during flushing.
-            return this.InterceptExceptionAsync((thisParam) => thisParam.FlushAsynchronously());
+            return this.InterceptExceptionAsync(static (thisParam) => thisParam.FlushAsynchronously());
         }
 
         /// <summary>
@@ -501,7 +501,7 @@ namespace Microsoft.OData
         /// <param name="newState">The writer state to transition into.</param>
         protected void SetState(BatchWriterState newState)
         {
-            this.InterceptException((thisParam, newStateParam) => thisParam.ValidateTransition(newStateParam), newState);
+            this.InterceptException(static (thisParam, newStateParam) => thisParam.ValidateTransition(newStateParam), newState);
 
             this.state = newState;
         }
@@ -813,11 +813,11 @@ namespace Microsoft.OData
         {
             if (!this.isInChangeset)
             {
-                this.InterceptException((thisParam) => thisParam.IncreaseBatchSize());
+                this.InterceptException(static (thisParam) => thisParam.IncreaseBatchSize());
             }
             else
             {
-                this.InterceptException((thisParam) => thisParam.IncreaseChangeSetSize());
+                this.InterceptException(static (thisParam) => thisParam.IncreaseChangeSetSize());
             }
 
             // Add a potential Content-ID header to the URL resolver so that it will be available
@@ -830,7 +830,7 @@ namespace Microsoft.OData
                 this.payloadUriConverter.AddContentId(this.currentOperationContentId);
             }
 
-            uri = this.InterceptException((thisParam, uriParam) =>
+            uri = this.InterceptException(static (thisParam, uriParam) =>
                 ODataBatchUtils.CreateOperationRequestUri(uriParam, thisParam.outputContext.MessageWriterSettings.BaseUri, thisParam.payloadUriConverter),
                 uri);
 
@@ -872,11 +872,11 @@ namespace Microsoft.OData
         {
             if (!this.isInChangeset)
             {
-                this.InterceptException((thisParam) => thisParam.IncreaseBatchSize());
+                this.InterceptException(static (thisParam) => thisParam.IncreaseBatchSize());
             }
             else
             {
-                this.InterceptException((thisParam) => thisParam.IncreaseChangeSetSize());
+                this.InterceptException(static (thisParam) => thisParam.IncreaseChangeSetSize());
             }
 
             // Add a potential Content-ID header to the URL resolver so that it will be available
@@ -889,7 +889,7 @@ namespace Microsoft.OData
                 this.payloadUriConverter.AddContentId(this.currentOperationContentId);
             }
 
-            uri = this.InterceptException((thisParam, uriParam) =>
+            uri = this.InterceptException(static (thisParam, uriParam) =>
                 ODataBatchUtils.CreateOperationRequestUri(uriParam, thisParam.outputContext.MessageWriterSettings.BaseUri, thisParam.payloadUriConverter),
                 uri);
 
@@ -922,7 +922,7 @@ namespace Microsoft.OData
 
             // reset the size of the current changeset and increase the size of the batch.
             this.ResetChangeSetSize();
-            this.InterceptException((thisParam) => thisParam.IncreaseBatchSize());
+            this.InterceptException(static (thisParam) => thisParam.IncreaseBatchSize());
             this.isInChangeset = true;
         }
 

--- a/src/Microsoft.OData.Core/ODataCollectionReaderCore.cs
+++ b/src/Microsoft.OData.Core/ODataCollectionReaderCore.cs
@@ -145,7 +145,7 @@ namespace Microsoft.OData
         {
             this.VerifyCanRead(true);
 
-            return this.InterceptException((thisParam) => thisParam.ReadSynchronously());
+            return this.InterceptException(static (thisParam) => thisParam.ReadSynchronously());
         }
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace Microsoft.OData
         {
             this.VerifyCanRead(false);
 
-            return this.InterceptExceptionAsync((thisParam) => thisParam.ReadAsynchronously());
+            return this.InterceptExceptionAsync(static (thisParam) => thisParam.ReadAsynchronously());
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataCollectionWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataCollectionWriterCore.cs
@@ -388,11 +388,11 @@ namespace Microsoft.OData
             this.StartPayloadInStartState();
             this.EnterScope(CollectionWriterState.Collection, collectionStart);
             this.InterceptException(
-                (thisParam, collectionStartParam) =>
+                static (thisParam, collectionStartParam) =>
                 {
                     if (thisParam.expectedItemType == null)
                     {
-                        thisParam.collectionValidator = new CollectionWithoutExpectedTypeValidator(/*expectedItemTypeName*/ null);
+                        thisParam.collectionValidator = new CollectionWithoutExpectedTypeValidator(itemTypeNameFromCollection: null);
                     }
 
                     thisParam.StartCollection(collectionStartParam);
@@ -422,7 +422,7 @@ namespace Microsoft.OData
             }
 
             this.InterceptException(
-                (thisParam, itemParam) =>
+                static (thisParam, itemParam) =>
                 {
                     ValidationUtils.ValidateCollectionItem(itemParam, true /* isNullable */);
                     thisParam.WriteCollectionItem(itemParam, thisParam.expectedItemType);
@@ -445,7 +445,7 @@ namespace Microsoft.OData
         private void WriteEndImplementation()
         {
             this.InterceptException(
-                (thisParam) =>
+                static (thisParam) =>
                 {
                     Scope currentScope = thisParam.scopes.Peek();
 
@@ -511,7 +511,7 @@ namespace Microsoft.OData
             Scope current = this.scopes.Peek();
             if (current.State == CollectionWriterState.Start)
             {
-                this.InterceptException((thisParam) => thisParam.StartPayload());
+                this.InterceptException(static (thisParam) => thisParam.StartPayload());
             }
         }
 
@@ -596,7 +596,7 @@ namespace Microsoft.OData
         /// <param name="item">The item to associate with the new scope.</param>
         private void EnterScope(CollectionWriterState newState, object item)
         {
-            this.InterceptException((thisParam, newStateParam) => thisParam.ValidateTransition(newStateParam), newState);
+            this.InterceptException(static (thisParam, newStateParam) => thisParam.ValidateTransition(newStateParam), newState);
             this.scopes.Push(new Scope(newState, item));
             this.NotifyListener(newState);
         }
@@ -617,7 +617,7 @@ namespace Microsoft.OData
             {
                 this.scopes.Pop();
                 this.scopes.Push(new Scope(CollectionWriterState.Completed, null));
-                this.InterceptException((thisParam) => thisParam.EndPayload());
+                this.InterceptException(static (thisParam) => thisParam.EndPayload());
                 this.NotifyListener(CollectionWriterState.Completed);
             }
         }
@@ -750,7 +750,7 @@ namespace Microsoft.OData
             Scope current = this.scopes.Peek();
             if (current.State == CollectionWriterState.Start)
             {
-                return this.InterceptExceptionAsync((thisParam) => thisParam.StartPayloadAsync());
+                return this.InterceptExceptionAsync(static (thisParam) => thisParam.StartPayloadAsync());
             }
 
             return TaskUtils.CompletedTask;
@@ -767,7 +767,7 @@ namespace Microsoft.OData
                 .ConfigureAwait(false);
             this.EnterScope(CollectionWriterState.Collection, collectionStart);
             await this.InterceptExceptionAsync(
-                async (thisParam, collectionStartParam) =>
+                static async (thisParam, collectionStartParam) =>
                 {
                     if (thisParam.expectedItemType == null)
                     {
@@ -786,7 +786,7 @@ namespace Microsoft.OData
         /// <returns>A task that represents the asynchronous write operation.</returns>
         private Task WriteEndImplementationAsync()
         {
-            return this.InterceptExceptionAsync(async (thisParam) =>
+            return this.InterceptExceptionAsync(static async (thisParam) =>
             {
                 Scope currentScope = thisParam.scopes.Peek();
 
@@ -827,7 +827,7 @@ namespace Microsoft.OData
             }
 
             await this.InterceptExceptionAsync(
-                async(thisParam, itemParam) =>
+                static async (thisParam, itemParam) =>
                 {
                     ValidationUtils.ValidateCollectionItem(itemParam, true /* isNullable */);
                     await thisParam.WriteCollectionItemAsync(itemParam, thisParam.expectedItemType)
@@ -853,7 +853,7 @@ namespace Microsoft.OData
             {
                 this.scopes.Pop();
                 this.scopes.Push(new Scope(CollectionWriterState.Completed, null));
-                await this.InterceptExceptionAsync((thisParam) => thisParam.EndPayloadAsync())
+                await this.InterceptExceptionAsync(static (thisParam) => thisParam.EndPayloadAsync())
                     .ConfigureAwait(false);
                 this.NotifyListener(CollectionWriterState.Completed);
             }

--- a/src/Microsoft.OData.Core/ODataParameterReaderCore.cs
+++ b/src/Microsoft.OData.Core/ODataParameterReaderCore.cs
@@ -185,7 +185,7 @@ namespace Microsoft.OData
         public override sealed bool Read()
         {
             this.VerifyCanRead(true);
-            return this.InterceptException((thisParam) => thisParam.ReadSynchronously());
+            return this.InterceptException(static (thisParam) => thisParam.ReadSynchronously());
         }
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace Microsoft.OData
         public override sealed Task<bool> ReadAsync()
         {
             this.VerifyCanRead(false);
-            return this.InterceptExceptionAsync((thisParam) => thisParam.ReadAsynchronously());
+            return this.InterceptExceptionAsync(static (thisParam) => thisParam.ReadAsynchronously());
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
@@ -105,7 +105,7 @@ namespace Microsoft.OData
             this.VerifyCanFlush(true /*synchronousCall*/);
 
             // make sure we switch to writer state Error if an exception is thrown during flushing.
-            this.InterceptException((thisParam) => thisParam.FlushSynchronously());
+            this.InterceptException(static (thisParam) => thisParam.FlushSynchronously());
         }
 
 
@@ -118,7 +118,7 @@ namespace Microsoft.OData
             this.VerifyCanFlush(false /*synchronousCall*/);
 
             // make sure we switch to writer state Error if an exception is thrown during flushing.
-            return this.InterceptExceptionAsync((thisParam) => thisParam.FlushAsynchronously());
+            return this.InterceptExceptionAsync(static (thisParam) => thisParam.FlushAsynchronously());
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace Microsoft.OData
         public sealed override void WriteStart()
         {
             this.VerifyCanWriteStart(true /*synchronousCall*/);
-            this.InterceptException((thisParam) => thisParam.WriteStartImplementation());
+            this.InterceptException(static (thisParam) => thisParam.WriteStartImplementation());
         }
 
 
@@ -139,7 +139,7 @@ namespace Microsoft.OData
         {
             this.VerifyCanWriteStart(false /*synchronousCall*/);
             return this.InterceptExceptionAsync(
-                (thisParam) => thisParam.WriteStartImplementationAsync());
+                static (thisParam) => thisParam.WriteStartImplementationAsync());
         }
 
         /// <summary>
@@ -152,8 +152,8 @@ namespace Microsoft.OData
             ExceptionUtils.CheckArgumentStringNotNullOrEmpty(parameterName, "parameterName");
             IEdmTypeReference expectedTypeReference = this.VerifyCanWriteValueParameter(true /*synchronousCall*/, parameterName, parameterValue);
             this.InterceptException(
-                (thisParam, parameterNameParam, parameterValueParam, expectedTypeReferenceParam) => 
-                    thisParam.WriteValueImplementation(parameterName, parameterValue, expectedTypeReference),
+                static (thisParam, parameterNameParam, parameterValueParam, expectedTypeReferenceParam) => 
+                    thisParam.WriteValueImplementation(parameterNameParam, parameterValueParam, expectedTypeReferenceParam),
                 parameterName, parameterValue, expectedTypeReference);
         }
 
@@ -169,7 +169,7 @@ namespace Microsoft.OData
             ExceptionUtils.CheckArgumentStringNotNullOrEmpty(parameterName, "parameterName");
             IEdmTypeReference expectedTypeReference = this.VerifyCanWriteValueParameter(false /*synchronousCall*/, parameterName, parameterValue);
             return this.InterceptExceptionAsync(
-                (thisParam, parameterNameParam, parameterValueParam, expectedTypeReferenceParam) => 
+                static (thisParam, parameterNameParam, parameterValueParam, expectedTypeReferenceParam) => 
                     thisParam.WriteValueImplementationAsync(parameterNameParam, parameterValueParam, expectedTypeReferenceParam),
                 parameterName, parameterValue, expectedTypeReference);
         }
@@ -184,7 +184,7 @@ namespace Microsoft.OData
             ExceptionUtils.CheckArgumentStringNotNullOrEmpty(parameterName, "parameterName");
             IEdmTypeReference itemTypeReference = this.VerifyCanCreateCollectionWriter(true /*synchronousCall*/, parameterName);
             return this.InterceptException(
-                (thisParam, parameterNameParam, itemTypeReferenceParam) => 
+                static (thisParam, parameterNameParam, itemTypeReferenceParam) => 
                     thisParam.CreateCollectionWriterImplementation(parameterNameParam, itemTypeReferenceParam),
                 parameterName, itemTypeReference);
         }
@@ -201,7 +201,7 @@ namespace Microsoft.OData
             IEdmTypeReference itemTypeReference = this.VerifyCanCreateCollectionWriter(false /*synchronousCall*/, parameterName);
 
             return this.InterceptExceptionAsync(
-                (thisParam, parameterNameParam, itemTypeReferenceParam) =>
+                static (thisParam, parameterNameParam, itemTypeReferenceParam) =>
                     thisParam.CreateCollectionWriterImplementationAsync(parameterNameParam, itemTypeReferenceParam),
                 parameterName, itemTypeReference);
         }
@@ -214,7 +214,7 @@ namespace Microsoft.OData
             ExceptionUtils.CheckArgumentStringNotNullOrEmpty(parameterName, "parameterName");
             IEdmTypeReference itemTypeReference = this.VerifyCanCreateResourceWriter(true /*synchronousCall*/, parameterName);
             return this.InterceptException(
-                (thisParam, parameterNameParam, itemTypeReferenceParam) =>
+                static (thisParam, parameterNameParam, itemTypeReferenceParam) =>
                     thisParam.CreateResourceWriterImplementation(parameterNameParam, itemTypeReferenceParam),
                 parameterName, itemTypeReference);
         }
@@ -229,7 +229,7 @@ namespace Microsoft.OData
             IEdmTypeReference itemTypeReference = this.VerifyCanCreateResourceWriter(false /*synchronousCall*/, parameterName);
 
             return this.InterceptExceptionAsync(
-                (thisParam, parameterNameParam, itemTypeReferenceParam) =>
+                static (thisParam, parameterNameParam, itemTypeReferenceParam) =>
                     thisParam.CreateResourceWriterImplementationAsync(parameterNameParam, itemTypeReferenceParam),
                 parameterName, itemTypeReference);
         }
@@ -242,7 +242,7 @@ namespace Microsoft.OData
             ExceptionUtils.CheckArgumentStringNotNullOrEmpty(parameterName, "parameterName");
             IEdmTypeReference itemTypeReference = this.VerifyCanCreateResourceSetWriter(true /*synchronousCall*/, parameterName);
             return this.InterceptException(
-                (thisParam, parameterNameParam, itemTypeReferenceParam) =>
+                static (thisParam, parameterNameParam, itemTypeReferenceParam) =>
                     thisParam.CreateResourceSetWriterImplementation(parameterNameParam, itemTypeReferenceParam),
                 parameterName, itemTypeReference);
         }
@@ -257,7 +257,7 @@ namespace Microsoft.OData
             IEdmTypeReference itemTypeReference = this.VerifyCanCreateResourceSetWriter(false /*synchronousCall*/, parameterName);
 
             return this.InterceptExceptionAsync(
-                (thisParam, parameterNameParam, itemTypeReferenceParam) =>
+                static (thisParam, parameterNameParam, itemTypeReferenceParam) =>
                     thisParam.CreateResourceSetWriterImplementationAsync(parameterNameParam, itemTypeReferenceParam),
                 parameterName, itemTypeReference);
         }
@@ -268,7 +268,7 @@ namespace Microsoft.OData
         public sealed override void WriteEnd()
         {
             this.VerifyCanWriteEnd(true /*synchronousCall*/);
-            this.InterceptException((thisParam) => thisParam.WriteEndImplementation());
+            this.InterceptException(static (thisParam) => thisParam.WriteEndImplementation());
             if (this.State == ParameterWriterState.Completed)
             {
                 // Note that we intentionally go through the public API so that if the Flush fails the writer moves to the Error state.
@@ -284,7 +284,7 @@ namespace Microsoft.OData
         {
             this.VerifyCanWriteEnd(false /*synchronousCall*/);
             return this.InterceptExceptionAsync(
-                async (thisParam) =>
+                static async (thisParam) =>
                 {
                     await thisParam.WriteEndImplementationAsync()
                         .ConfigureAwait(false);
@@ -462,7 +462,7 @@ namespace Microsoft.OData
         private void WriteStartImplementation()
         {
             Debug.Assert(this.State == ParameterWriterState.Start, "this.State == ParameterWriterState.Start");
-            this.InterceptException((thisParam) => thisParam.StartPayload());
+            this.InterceptException(static (thisParam) => thisParam.StartPayload());
             this.EnterScope(ParameterWriterState.CanWriteParameter);
         }
 
@@ -604,8 +604,8 @@ namespace Microsoft.OData
         {
             Debug.Assert(this.State == ParameterWriterState.CanWriteParameter, "this.State == ParameterWriterState.CanWriteParameter");
             this.InterceptException(
-                (thisParam, parameterNameParam, parameterValueParam, expectedTypeReferenceParam) =>
-                    thisParam.WriteValueParameter(parameterName, parameterValue, expectedTypeReference),
+                static (thisParam, parameterNameParam, parameterValueParam, expectedTypeReferenceParam) =>
+                    thisParam.WriteValueParameter(parameterNameParam, parameterValueParam, expectedTypeReferenceParam),
                 parameterName, parameterValue, expectedTypeReference);
         }
 
@@ -706,7 +706,7 @@ namespace Microsoft.OData
         /// </summary>
         private void WriteEndImplementation()
         {
-            this.InterceptException((thisParam) => thisParam.EndPayload());
+            this.InterceptException(static (thisParam) => thisParam.EndPayload());
             this.LeaveScope();
         }
 
@@ -1060,7 +1060,7 @@ namespace Microsoft.OData
         {
             Debug.Assert(this.State == ParameterWriterState.Start, "this.State == ParameterWriterState.Start");
 
-            await this.InterceptExceptionAsync((thisParam) => thisParam.StartPayloadAsync())
+            await this.InterceptExceptionAsync(static (thisParam) => thisParam.StartPayloadAsync())
                 .ConfigureAwait(false);
             this.EnterScope(ParameterWriterState.CanWriteParameter);
         }
@@ -1076,7 +1076,7 @@ namespace Microsoft.OData
         {
             Debug.Assert(this.State == ParameterWriterState.CanWriteParameter, "this.State == ParameterWriterState.CanWriteParameter");
 
-            return this.InterceptExceptionAsync((
+            return this.InterceptExceptionAsync(static (
                 thisParam,
                 parameterNameParam,
                 parameterValueParam,
@@ -1148,7 +1148,7 @@ namespace Microsoft.OData
         /// <returns>A task that represents the asynchronous write operation.</returns>
         private async Task WriteEndImplementationAsync()
         {
-            await this.InterceptExceptionAsync((thisParam) => thisParam.EndPayloadAsync())
+            await this.InterceptExceptionAsync(static (thisParam) => thisParam.EndPayloadAsync())
                 .ConfigureAwait(false);
             this.LeaveScope();
         }

--- a/src/Microsoft.OData.Core/ODataReaderCore.cs
+++ b/src/Microsoft.OData.Core/ODataReaderCore.cs
@@ -18,6 +18,7 @@ namespace Microsoft.OData
     using Microsoft.OData.Core;
     using Microsoft.OData.Edm;
     using Microsoft.OData.Metadata;
+    using static Microsoft.OData.ODataWriterCore;
 
     #endregion Namespaces
 
@@ -388,7 +389,7 @@ namespace Microsoft.OData
         public override sealed bool Read()
         {
             this.VerifyCanRead(true);
-            return this.InterceptException(this.ReadSynchronously);
+            return this.InterceptException(static (thisParam) => thisParam.ReadSynchronously());
         }
 
         /// <summary>
@@ -398,7 +399,7 @@ namespace Microsoft.OData
         public override sealed Task<bool> ReadAsync()
         {
             this.VerifyCanRead(false);
-            return this.InterceptExceptionAsync(thisParam => thisParam.ReadAsynchronously());
+            return this.InterceptExceptionAsync(static (thisParam) => thisParam.ReadAsynchronously());
         }
 
         /// <summary>
@@ -420,7 +421,7 @@ namespace Microsoft.OData
             }
 
             scope.StreamingState = StreamingState.Streaming;
-            return new ODataNotificationStream(this.InterceptException(this.CreateReadStreamImplementation), this);
+            return new ODataNotificationStream(this.InterceptException(static (thisParam) => thisParam.CreateReadStreamImplementation()), this);
         }
 
         /// <summary>
@@ -439,7 +440,7 @@ namespace Microsoft.OData
                 }
 
                 scope.StreamingState = StreamingState.Streaming;
-                return new ODataNotificationReader(this.InterceptException(this.CreateTextReaderImplementation), this);
+                return new ODataNotificationReader(this.InterceptException(static (thisParam) => thisParam.CreateTextReaderImplementation()), this);
             }
             else
             {
@@ -935,11 +936,11 @@ namespace Microsoft.OData
         /// <typeparam name="T">The type returned from the <paramref name="action"/> to execute.</typeparam>
         /// <param name="action">The action to execute.</param>
         /// <returns>The result of executing the <paramref name="action"/>.</returns>
-        private T InterceptException<T>(Func<T> action)
+        private T InterceptException<T>(Func<ODataReaderCore, T> action)
         {
             try
             {
-                return action();
+                return action(this);
             }
             catch (Exception e)
             {

--- a/src/Microsoft.OData.Core/ODataReaderCoreAsync.cs
+++ b/src/Microsoft.OData.Core/ODataReaderCoreAsync.cs
@@ -332,7 +332,7 @@ namespace Microsoft.OData
 
             scope.StreamingState = StreamingState.Streaming;
             return new ODataNotificationStream(
-                underlyingStream: await this.InterceptExceptionAsync(thisParam => thisParam.CreateReadStreamImplementationAsync()).ConfigureAwait(false),
+                underlyingStream: await this.InterceptExceptionAsync(static (thisParam) => thisParam.CreateReadStreamImplementationAsync()).ConfigureAwait(false),
                 listener: this,
                 synchronous: false);
         }
@@ -358,7 +358,7 @@ namespace Microsoft.OData
 
             scope.StreamingState = StreamingState.Streaming;
             return new ODataNotificationReader(
-                textReader: await this.InterceptExceptionAsync(thisParam => thisParam.CreateTextReaderImplementationAsync()).ConfigureAwait(false),
+                textReader: await this.InterceptExceptionAsync(static (thisParam) => thisParam.CreateTextReaderImplementationAsync()).ConfigureAwait(false),
                 listener: this,
                 synchronous: false);
         }

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -438,7 +438,7 @@ namespace Microsoft.OData
             this.VerifyCanFlush(false);
 
             // Make sure we switch to writer state Error if an exception is thrown during flushing.
-            return this.InterceptExceptionAsync((thisParam) => thisParam.FlushAsynchronously(), null);
+            return this.InterceptExceptionAsync(static (thisParam) => thisParam.FlushAsynchronously(), null);
         }
 
         /// <summary>
@@ -1583,7 +1583,7 @@ namespace Microsoft.OData
             if (!this.SkipWriting)
             {
                 this.InterceptException(
-                    (thisParam, resourceSetParam) =>
+                    static (thisParam, resourceSetParam) =>
                     {
                         // Verify query count
                         if (resourceSetParam.Count.HasValue)
@@ -1625,7 +1625,7 @@ namespace Microsoft.OData
             this.EnterScope(WriterState.DeltaResourceSet, deltaResourceSet);
 
             this.InterceptException(
-                (thisParam, deltaResourceSetParam) =>
+                static (thisParam, deltaResourceSetParam) =>
                 {
                     // Check that links are not set for requests
                     if (!thisParam.outputContext.WritingResponse)
@@ -1683,7 +1683,7 @@ namespace Microsoft.OData
             {
                 this.IncreaseResourceDepth();
                 this.InterceptException(
-                    (thisParam, resourceParam) =>
+                    static (thisParam, resourceParam) =>
                     {
                         if (resourceParam != null)
                         {
@@ -1715,7 +1715,7 @@ namespace Microsoft.OData
             this.IncreaseResourceDepth();
 
             this.InterceptException(
-                (thisParam, resourceParam) =>
+                static (thisParam, resourceParam) =>
                 {
                     DeletedResourceScope resourceScope = thisParam.CurrentScope as DeletedResourceScope;
                     thisParam.ValidateResourceForResourceSet(resourceParam, resourceScope);
@@ -1751,7 +1751,7 @@ namespace Microsoft.OData
             if (!this.SkipWriting)
             {
                 this.InterceptException(
-                    (thisParam, propertyParam) =>
+                    static (thisParam, propertyParam) =>
                     {
                         thisParam.StartProperty(propertyParam);
                         if (propertyParam is ODataProperty)
@@ -1838,7 +1838,7 @@ namespace Microsoft.OData
         private void WritePrimitiveValueImplementation(ODataPrimitiveValue primitiveValue)
         {
             this.InterceptException(
-                (thisParam, primitiveValueParam) =>
+                static (thisParam, primitiveValueParam) =>
                 {
                     thisParam.EnterScope(WriterState.Primitive, primitiveValueParam);
                     if (!(thisParam.CurrentResourceSetValidator == null) && primitiveValueParam != null)
@@ -1863,13 +1863,13 @@ namespace Microsoft.OData
             EnterScope(WriterState.Primitive, primitiveValue);
 
             return InterceptExceptionAsync(
-                async (thisParam, primiteValueParam) =>
+                static async (thisParam, primiteValueParam) =>
                 {
-                    if (!(CurrentResourceSetValidator == null) && primiteValueParam != null)
+                    if (!(thisParam.CurrentResourceSetValidator == null) && primiteValueParam != null)
                     {
                         Debug.Assert(primiteValueParam.Value != null, "PrimitiveValue.Value should never be null!");
                         IEdmType itemType = EdmLibraryExtensions.GetPrimitiveTypeReference(primiteValueParam.Value.GetType()).Definition;
-                        CurrentResourceSetValidator.ValidateResource(itemType);
+                        thisParam.CurrentResourceSetValidator.ValidateResource(itemType);
                     }
 
                     await thisParam.WritePrimitiveValueAsync(primiteValueParam)
@@ -1935,7 +1935,7 @@ namespace Microsoft.OData
         private void WriteEndImplementation()
         {
             this.InterceptException(
-                (thisParam) =>
+                static (thisParam) =>
                 {
                     Scope currentScope = thisParam.CurrentScope;
 
@@ -2093,7 +2093,7 @@ namespace Microsoft.OData
             if (!this.SkipWriting)
             {
                 this.InterceptException(
-                    (thisParam, entityReferenceLinkParam) =>
+                    static (thisParam, entityReferenceLinkParam) =>
                     {
                         WriterValidationUtils.ValidateEntityReferenceLink(entityReferenceLinkParam);
 
@@ -2171,7 +2171,7 @@ namespace Microsoft.OData
         {
             if (this.State == WriterState.Start)
             {
-                this.InterceptException((thisParam) => thisParam.StartPayload());
+                this.InterceptException(static (thisParam) => thisParam.StartPayload());
             }
         }
 
@@ -2194,7 +2194,7 @@ namespace Microsoft.OData
             {
                 ODataNestedResourceInfo currentNestedResourceInfo = (ODataNestedResourceInfo)currentScope.Item;
                 this.InterceptException(
-                    (thisParam, currentNestedResourceInfoParam, contentPayloadKindParam) =>
+                    static (thisParam, currentNestedResourceInfoParam, contentPayloadKindParam) =>
                     {
                         if (thisParam.ParentResourceType != null)
                         {
@@ -2249,7 +2249,7 @@ namespace Microsoft.OData
                     if (!this.SkipWriting)
                     {
                         this.InterceptException(
-                            (thisParam, currentNestedResourceInfoParam) =>
+                            static (thisParam, currentNestedResourceInfoParam) =>
                             {
                                 if (!(currentNestedResourceInfoParam.SerializationInfo != null && currentNestedResourceInfoParam.SerializationInfo.IsComplex)
                                     && (thisParam.CurrentScope.ItemType == null || thisParam.CurrentScope.ItemType.IsEntityOrEntityCollectionType()))
@@ -2552,7 +2552,7 @@ namespace Microsoft.OData
         [SuppressMessage("Microsoft.Performance", "CA1800:DoNotCastUnnecessarily", Justification = "Debug only cast.")]
         private void EnterScope(WriterState newState, ODataItem item)
         {
-            this.InterceptException((thisParam, newStateParam) => thisParam.ValidateTransition(newStateParam), newState);
+            this.InterceptException(static (thisParam, newStateParam) => thisParam.ValidateTransition(newStateParam), newState);
 
             // If the parent scope was marked for skipping content, the new child scope should be as well.
             bool skipWriting = this.SkipWriting;
@@ -2908,7 +2908,7 @@ namespace Microsoft.OData
                     selectedProperties: startScope.SelectedProperties,
                     odataUri: startScope.ODataUri,
                     derivedTypeConstraints: null);
-                this.InterceptException((thisParam) => thisParam.EndPayload());
+                this.InterceptException(static (thisParam) => thisParam.EndPayload());
                 this.NotifyListener(WriterState.Completed);
             }
         }
@@ -3240,7 +3240,7 @@ namespace Microsoft.OData
             if (!this.SkipWriting)
             {
                 await this.InterceptExceptionAsync(
-                    async (thisParam, resourceSetParam) =>
+                    static async (thisParam, resourceSetParam) =>
                     {
                         // Verify query count
                         if (resourceSetParam.Count.HasValue)
@@ -3285,7 +3285,7 @@ namespace Microsoft.OData
             this.EnterScope(WriterState.DeltaResourceSet, deltaResourceSet);
 
             await this.InterceptExceptionAsync(
-                async (thisParam, deltaResourceSetParam) =>
+                static async (thisParam, deltaResourceSetParam) =>
                 {
                     if (!thisParam.outputContext.WritingResponse)
                     {
@@ -3323,7 +3323,7 @@ namespace Microsoft.OData
             {
                 this.IncreaseResourceDepth();
                 await this.InterceptExceptionAsync(
-                    async (thisParam, resourceParam) =>
+                    static async (thisParam, resourceParam) =>
                     {
                         if (resourceParam != null)
                         {
@@ -3359,7 +3359,7 @@ namespace Microsoft.OData
             this.IncreaseResourceDepth();
 
             await this.InterceptExceptionAsync(
-                async (thisParam, resourceParam) =>
+                static async (thisParam, resourceParam) =>
                 {
                     DeletedResourceScope resourceScope = thisParam.CurrentScope as DeletedResourceScope;
                     thisParam.ValidateResourceForResourceSet(resourceParam, resourceScope);
@@ -3386,7 +3386,7 @@ namespace Microsoft.OData
             if (!this.SkipWriting)
             {
                 return this.InterceptExceptionAsync(
-                    async (thisParam, propertyParam) =>
+                    static async (thisParam, propertyParam) =>
                     {
                         await thisParam.StartPropertyAsync(propertyParam)
                             .ConfigureAwait(false);
@@ -3438,7 +3438,7 @@ namespace Microsoft.OData
         private Task WriteEndImplementationAsync()
         {
             return this.InterceptExceptionAsync(
-                async (thisParam) =>
+                static async (thisParam) =>
                 {
                     Scope currentScope = thisParam.CurrentScope;
 
@@ -3563,7 +3563,7 @@ namespace Microsoft.OData
             if (!this.SkipWriting)
             {
                 await this.InterceptExceptionAsync(
-                    async (thisParam, entityReferenceLinkParam) =>
+                    static async (thisParam, entityReferenceLinkParam) =>
                     {
                         WriterValidationUtils.ValidateEntityReferenceLink(entityReferenceLinkParam);
 
@@ -3589,7 +3589,7 @@ namespace Microsoft.OData
         {
             if (this.State == WriterState.Start)
             {
-                return this.InterceptExceptionAsync((thisParam) => thisParam.StartPayloadAsync(), this.CurrentScope.Item);
+                return this.InterceptExceptionAsync(static (thisParam) => thisParam.StartPayloadAsync(), this.CurrentScope.Item);
             }
 
             return TaskUtils.CompletedTask;
@@ -3616,7 +3616,7 @@ namespace Microsoft.OData
                 ODataNestedResourceInfo currentNestedResourceInfo = (ODataNestedResourceInfo)currentScope.Item;
 
                 this.InterceptException(
-                    (thisParam, currentNestedResourceInfoParam, contentPayloadKindParam) =>
+                    static (thisParam, currentNestedResourceInfoParam, contentPayloadKindParam) =>
                     {
                         if (thisParam.ParentResourceType != null)
                         {
@@ -3676,7 +3676,7 @@ namespace Microsoft.OData
                     if (!this.SkipWriting)
                     {
                         await this.InterceptExceptionAsync(
-                            async (thisParam, currentNestedResourceInfoParam) =>
+                            static async (thisParam, currentNestedResourceInfoParam) =>
                             {
                                 if (!(currentNestedResourceInfoParam.SerializationInfo != null && currentNestedResourceInfoParam.SerializationInfo.IsComplex)
                                     && (thisParam.CurrentScope.ItemType == null || thisParam.CurrentScope.ItemType.IsEntityOrEntityCollectionType()))
@@ -3728,7 +3728,7 @@ namespace Microsoft.OData
                     startScope.SelectedProperties,
                     startScope.ODataUri,
                     /*derivedTypeConstraints*/ null);
-                await this.InterceptExceptionAsync((thisParam) => thisParam.EndPayloadAsync(), this.CurrentScope.Item)
+                await this.InterceptExceptionAsync(static (thisParam) => thisParam.EndPayloadAsync(), this.CurrentScope.Item)
                     .ConfigureAwait(false);
                 this.NotifyListener(WriterState.Completed);
             }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3355.*

### Description

Introduce non-capturing overloads of `InterceptException` and `InterceptExceptionAsync` in `ODataReaderCore` for improved performance

### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*