### PR TITLE
Cherry-Pick: Add CustomQueryOptionNode #3318 and Cherry-Pick: Regression when parsing query option without '='

### DIFF
--- a/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,8 @@
+Microsoft.OData.UriParser.CustomQueryOptionNode
+Microsoft.OData.UriParser.CustomQueryOptionNode.CustomQueryOptionNode(string name, string value) -> void
+Microsoft.OData.UriParser.CustomQueryOptionNode.Name.get -> string
+Microsoft.OData.UriParser.CustomQueryOptionNode.Value.get -> string
+Microsoft.OData.UriParser.QueryNodeKind.CustomQueryOption = 35 -> Microsoft.OData.UriParser.QueryNodeKind
+override Microsoft.OData.UriParser.CustomQueryOptionNode.Accept<T>(Microsoft.OData.UriParser.QueryNodeVisitor<T> visitor) -> T
+override Microsoft.OData.UriParser.CustomQueryOptionNode.Kind.get -> Microsoft.OData.UriParser.QueryNodeKind
+virtual Microsoft.OData.UriParser.QueryNodeVisitor<T>.Visit(Microsoft.OData.UriParser.CustomQueryOptionNode nodeIn) -> T

--- a/src/Microsoft.OData.Core/Uri/NodeToStringBuilder.cs
+++ b/src/Microsoft.OData.Core/Uri/NodeToStringBuilder.cs
@@ -231,6 +231,17 @@ namespace Microsoft.OData
         }
 
         /// <summary>
+        /// Translates a <see cref="CustomQueryOptionNode"/> into a corresponding <see cref="String"/>.
+        /// </summary>
+        /// <param name="node">The node to translate.</param>
+        /// <returns>The translated String.</returns>
+        public override String Visit(CustomQueryOptionNode node)
+        {
+            ExceptionUtils.CheckArgumentNotNull(node, "node");
+            return string.IsNullOrEmpty(node.Name) ? node.Value : string.Concat(node.Name, "=", node.Value);
+        }
+
+        /// <summary>
         /// Translates a <see cref="NonResourceRangeVariableReferenceNode"/> into a corresponding <see cref="String"/>.
         /// </summary>
         /// <param name="node">The node to translate.</param>
@@ -570,6 +581,30 @@ namespace Microsoft.OData
                     {
                         String tmp = this.TranslateNode(keyValuePair.Value);
                         result = string.IsNullOrEmpty(tmp) ? result : string.Concat(result, String.IsNullOrEmpty(result) ? null : ExpressionConstants.SymbolQueryConcatenate, keyValuePair.Key, ExpressionConstants.SymbolEqual, Uri.EscapeDataString(tmp));
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Translates a collection of custom query options into a query string representation.
+        /// </summary>
+        /// <param name="customQueryOptions">A collection of <see cref="QueryNode"/> objects representing the custom query options to be translated.</param>
+        /// <returns>A string containing the translated query options in a query string format.  Returns <see langword="null"/>
+        /// if no valid query options are provided.</returns>
+        internal string TranslateCustomQueryOptions(IEnumerable<QueryNode> customQueryOptions)
+        {
+            String result = null;
+            if (customQueryOptions != null)
+            {
+                foreach (QueryNode queryNode in customQueryOptions)
+                {
+                    if (queryNode != null)
+                    {
+                        String tmp = this.TranslateNode(queryNode);
+                        result = string.IsNullOrEmpty(tmp) ? result : string.Concat(result, String.IsNullOrEmpty(result)? null : ExpressionConstants.SymbolQueryConcatenate, tmp);
                     }
                 }
             }

--- a/src/Microsoft.OData.Core/Uri/ODataUriExtensions.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriExtensions.cs
@@ -121,6 +121,13 @@ namespace Microsoft.OData
                 writeQueryPrefix = false;
             }
 
+            if (odataUri.CustomQueryOptions != null)
+            {
+                string customQueryOptionsNode = nodeToStringBuilder.TranslateCustomQueryOptions(odataUri.CustomQueryOptions);
+                queryOptions = String.IsNullOrEmpty(customQueryOptionsNode) ? queryOptions : String.Concat(WriteQueryPrefixOrSeparator(writeQueryPrefix, queryOptions), customQueryOptionsNode);
+                writeQueryPrefix = false;
+            }
+
             string res = String.Concat(odataUri.Path.ToResourcePathString(urlKeyDelimiter), queryOptions);
             return odataUri.ServiceRoot == null ? new Uri(res, UriKind.Relative) : new Uri(odataUri.ServiceRoot, new Uri(res, UriKind.Relative));
         }

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/CustomQueryOptionNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/CustomQueryOptionNode.cs
@@ -1,0 +1,59 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="CustomQueryOptionNode.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+
+namespace Microsoft.OData.UriParser
+{
+    /// <summary>
+    /// Base class for all custom query options.
+    /// </summary>
+    public class CustomQueryOptionNode : QueryNode
+    {
+        /// <summary>
+        /// Create a NameValueCustomQueryOptionNode
+        /// </summary>
+        /// <param name="name">This node's primitive value. May be null.</param>
+        /// <param name="value">The literal text for this node's value. May be null.</param>
+        public CustomQueryOptionNode(string name, string value)
+        {
+            Name = name;
+            Value = value;
+        }
+
+        /// Gets the Query Option Name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the Query Option Value.
+        /// </summary>
+        public string Value { get; }
+
+        /// <summary>
+        /// Gets the kind of this node.
+        /// </summary>
+        public override QueryNodeKind Kind => (QueryNodeKind)this.InternalKind;
+
+        /// <summary>
+        /// Gets the kind of the query node.
+        /// </summary>
+        internal override InternalQueryNodeKind InternalKind => InternalQueryNodeKind.CustomQueryOption;
+
+        /// <summary>
+        /// Accept a <see cref="QueryNodeVisitor{T}"/> to walk a tree of <see cref="QueryNode"/>s.
+        /// </summary>
+        /// <typeparam name="T">Type that the visitor will return after visiting this token.</typeparam>
+        /// <param name="visitor">An implementation of the visitor interface.</param>
+        /// <returns>An object whose type is determined by the type parameter of the visitor.</returns>
+        /// <exception cref="System.ArgumentNullException">Throws if the input visitor is null.</exception>
+        public override T Accept<T>(QueryNodeVisitor<T> visitor)
+        {
+            ExceptionUtils.CheckArgumentNotNull(visitor, "visitor");
+            return visitor.Visit(this);
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/UriParser/TreeNodeKinds/QueryNodeKind.cs
+++ b/src/Microsoft.OData.Core/UriParser/TreeNodeKinds/QueryNodeKind.cs
@@ -188,6 +188,11 @@ namespace Microsoft.OData.UriParser
        /// Node that represents a $root path
        /// </summary>
         RootPath = InternalQueryNodeKind.RootPath,
+
+        /// <summary>
+        /// Node that represents a custom query option
+        /// </summary>
+        CustomQueryOption = InternalQueryNodeKind.CustomQueryOption,
     }
 
     /// <summary>
@@ -368,6 +373,11 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// Node that represetns a $root path
         /// </summary>
-        RootPath,
+        RootPath = 34,
+
+        /// <summary>
+        /// Node that represents a custom query option
+        /// </summary>
+        CustomQueryOption = 35,
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Visitors/QueryNodeVisitor.cs
+++ b/src/Microsoft.OData.Core/UriParser/Visitors/QueryNodeVisitor.cs
@@ -323,5 +323,15 @@ namespace Microsoft.OData.UriParser
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Visit an CustomQueryOptionNode
+        /// </summary>
+        /// <param name="nodeIn">the node to visit</param>
+        /// <returns>Defined by the implementer</returns>
+        public virtual T Visit(CustomQueryOptionNode nodeIn)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/QueryOptionBuilderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/QueryOptionBuilderTests.cs
@@ -1,0 +1,54 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="QueryOptionBuilderTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using Xunit;
+
+namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
+{
+    public class QueryOptionBuilderTests : UriBuilderTestBase
+    {
+        [Fact]
+        public void CustomQueryOptionWorks()
+        {
+            Uri queryUri = new Uri("People?customQueryOption=customValue", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal(new Uri("http://gobbledygook/People?customQueryOption=customValue"), actualUri);
+        }
+
+        [Fact]
+        public void MultipleCustomQueryOptionsWorks()
+        {
+            Uri queryUri = new Uri("People?customQueryOption1=customValue1&customQueryOption2=customValue2", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal(new Uri("http://gobbledygook/People?customQueryOption1=customValue1&customQueryOption2=customValue2"), actualUri);
+        }
+
+        [Fact]
+        public void NonKeyValueCustomQueryOptionWorks()
+        {
+            Uri queryUri = new Uri("People?customQueryOption1", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal(new Uri("http://gobbledygook/People?customQueryOption1"), actualUri);
+        }
+
+        [Fact]
+        public void KeyNoValueCustomQueryOptionWorks()
+        {
+            Uri queryUri = new Uri("People?customQueryOption1=", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal(new Uri("http://gobbledygook/People?customQueryOption1="), actualUri);
+        }
+
+        [Fact]
+        public void DuplicatedCustomQueryOptionWorks()
+        {
+            Uri queryUri = new Uri("People?customQueryOption=value1;customQueryOption=value2", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal(new Uri("http://gobbledygook/People?customQueryOption=value1;customQueryOption=value2"), actualUri);
+        }
+    }
+}

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Visitors/QueryNodeVisitorTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Visitors/QueryNodeVisitorTests.cs
@@ -155,5 +155,13 @@ namespace Microsoft.OData.Tests.UriParser.Visitors
             Action visitUnaryOperatorNode = () => visitor.Visit(new UnaryOperatorNode(UnaryOperatorKind.Not, new ConstantNode(1)));
             Assert.Throws<NotImplementedException>(visitUnaryOperatorNode);
         }
+
+        [Fact]
+        public void CustomQueryOptionNodeNotImplemented()
+        {
+            FakeVisitor visitor = new FakeVisitor();
+            Action visitCustomQueryOptionNode = () => visitor.Visit(new CustomQueryOptionNode("customOption", "value"));
+            Assert.Throws<NotImplementedException>(visitCustomQueryOptionNode);
+        }
     }
 }


### PR DESCRIPTION

Cherry-Pick: Regression when parsing query option without '='

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
