### PR TITLE
Cherry-pick: Remove hard-coded network isolation policies (#3372)

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -35,10 +35,6 @@ variables:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
-    settings:
-      networkIsolationPolicy: Preferred,Nuget.org,AzureKeyVault,AzureActiveDirectory,AzureStorage
-      # Change to Good,Nuget.org if it gets too restrictive
-      # AzureKeyVault,AzureActiveDirectory,AzureStorage Allow policies required for the ESRP task
     pool:
       name: MSSecurity-1ES-Build-Agents-Pool
       image: MSSecurity-1ES-Windows-2022

--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -37,8 +37,6 @@ variables:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
-    settings:
-      networkIsolationPolicy: Preferred,Nuget.org # Change to Good,Nuget.org if it gets too restrictive
     pool:
       name: MSSecurity-1ES-Build-Agents-Pool
       image: MSSecurity-1ES-Windows-2022


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Cherry-pick: Remove hard-coded network isolation policies (#3372)

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
