### PR TITLE
Cherry-pick: Filter operator "IN" fails to handle empty strings (#3370)

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -274,9 +274,9 @@ namespace Microsoft.OData.UriParser
                     // If prev and next are both double quotes, then it's an empty string.
                     if (input[k - 1] == '"')
                     {
-                        // We append \"\" so as to return "\"\"" instead of "".
-                        // This is to avoid passing an empty string to the ConstantNode.
-                        sb.Append("\\\"\\\"");
+                        // Here, we meet an empty string as "", we should do nothing here becase at the beginning appends a double quote, and at the end appends another double quote.
+                        // So, don't do the following appending.
+                        // sb.Append("\\\"\\\"");
                     }
                     break;
                 }
@@ -334,9 +334,10 @@ namespace Microsoft.OData.UriParser
                                 sb.Append('"');
                                 return k;
                             }
-                            // We append \"\" so as to return "\"\"" instead of "".
-                            // This is to avoid passing an empty string to the ConstantNode.
-                            sb.Append("\\\"\\\"");
+
+                            // Here, we meet an empty string as '', we should do nothing here becase at the beginning appends a double quote, and at the end appends another double quote.
+                            // So, don't do the following appending.
+                            // sb.Append("\\\"\\\"");
                         }
                         // match with single quote ('), stop it.
                         break;

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/ConstantNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/ConstantNode.cs
@@ -15,6 +15,9 @@ namespace Microsoft.OData.UriParser
 
     /// <summary>
     /// Node representing a constant value, can either be primitive, complex, entity, or collection value.
+    /// Be noted:
+    /// If an 'in' clause, for example: $filter=name in ('abc', ''), since the InBinder converts the literal to ["abc", ""], in this case, the literal for second item is an empty string.
+    /// In all other cases, for example: $filter=name eq '', the literal for this node is "''", it's not an empty string.
     /// </summary>
     public sealed class ConstantNode : SingleValueNode
     {
@@ -37,7 +40,8 @@ namespace Microsoft.OData.UriParser
         public ConstantNode(object constantValue, string literalText)
             : this(constantValue)
         {
-            ExceptionUtils.CheckArgumentStringNotNullOrEmpty(literalText, "literalText");
+            ExceptionUtils.CheckArgumentNotNull(literalText, "literalText");
+
             this.LiteralText = literalText;
         }
 
@@ -50,7 +54,7 @@ namespace Microsoft.OData.UriParser
         /// <exception cref="System.ArgumentNullException">Throws if the input literalText is null.</exception>
         public ConstantNode(object constantValue, string literalText, IEdmTypeReference typeReference)
         {
-            ExceptionUtils.CheckArgumentStringNotNullOrEmpty(literalText, "literalText");
+            ExceptionUtils.CheckArgumentNotNull(literalText, "literalText");
 
             this.constantValue = constantValue;
             this.LiteralText = literalText;

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -3076,7 +3076,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             Assert.Equal(1, collectionNode.Collection.Count);
 
             ConstantNode constantNode = collectionNode.Collection.First();
-            Assert.Equal("\"\"", constantNode.LiteralText);
+            Assert.Equal(string.Empty, constantNode.Value);
+
+            // Since in the 'in' clause, the item string is normalized as plain JSON (using [] instead of ()), and the string item has changed from '' to "". 
+            // Thefore, the LiteralText is expected to be string.Empty.
+            Assert.Equal(string.Empty, constantNode.LiteralText);
         }
 
         [Theory]
@@ -3094,7 +3098,27 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             Assert.Equal(1, collectionNode.Collection.Count);
 
             ConstantNode constantNode = collectionNode.Collection.First();
-            Assert.Equal("\"\"", constantNode.LiteralText);
+            Assert.Equal(string.Empty, constantNode.Value);
+            Assert.Equal(string.Empty, constantNode.LiteralText);
+        }
+
+        [Theory]
+        [InlineData("SSN in ('abc', null, '')", 0)] // at the end
+        [InlineData("SSN in ('', 'abc', null)", 1)] // at the start
+        [InlineData("SSN in (null, '', 'abc')", 2)] // in the middle
+        public void FilterWithInOperationWithEmptyStringWithOthersShouldWork(string inLiteral, int index)
+        {
+            FilterClause filter = ParseFilter(inLiteral, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+
+            var inNode = Assert.IsType<InNode>(filter.Expression);
+            Assert.Equal("SSN", Assert.IsType<SingleValuePropertyAccessNode>(inNode.Left).Property.Name);
+
+            CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
+            Assert.Equal(3, collectionNode.Collection.Count);
+
+            collectionNode.Collection.ElementAt((index + 0) % 3).ShouldBeConstantQueryNode("abc");
+            collectionNode.Collection.ElementAt((index + 1) % 3).ShouldBeConstantQueryNode<string>(null);
+            collectionNode.Collection.ElementAt((index + 2) % 3).ShouldBeConstantQueryNode("");
         }
 
         [Theory]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Cherry-pick: Filter operator "IN" fails to handle empty strings (#3370)

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
