### PR TITLE
Fixes the failing test cases related to the empty string in 'in' operator

### DIFF
--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -3653,7 +3653,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Theory]
-        [InlineData("example in ('')", "\"\"")] // No space
+        [InlineData("example in ('')", "")] // No space
         [InlineData("example in (' ')", " ")] // 1 space
         [InlineData("example in ( '   ' )", "   ")] // 3 spaces
         [InlineData("example in ( \"  \" )", "  ")] // 2 spaces
@@ -3672,9 +3672,9 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Theory]
-        [InlineData("example in ('', \"  \")", "\"\"", "  ")]
-        [InlineData("example in (' ', \"\")", " ", "\"\"")]
-        [InlineData("example in ( '   ', '' )", "   ", "\"\"")]
+        [InlineData("example in ('', \"  \")", "", "  ")]
+        [InlineData("example in (' ', \"\")", " ", "")]
+        [InlineData("example in ( '   ', '' )", "   ", "")]
         [InlineData("example in ( \"  \", \" \" )", "  ", " ")]
         [InlineData("example in ( \"    \", ' ' )", "    ", " ")]
         public void FilterWithInOperationWithOpenTypesInMultipleEmptyStrings(string filterQueryString, string expectedFirstLiteral, string expectedSecondLiteral)


### PR DESCRIPTION


<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
