### PR TITLE
Fix the yaml to enable test case running

### DIFF
--- a/Build.props
+++ b/Build.props
@@ -44,10 +44,6 @@
     <DefineConstants>$(DefineConstants);SUPPRESS_SECURITY_RULES;</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup>
-      <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net8.0;net9.0</TargetFrameworks>
-  </PropertyGroup>
-
   <PropertyGroup Condition ="'$(TargetFrameworkIdentifier)' == 'net45'">
     <DefineConstants>$(DefineConstants);SUPPRESS_SECURITY_RULES;</DefineConstants>
   </PropertyGroup>

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -13,7 +13,6 @@ schedules:
   branches:
    include:
     - main
-    - dev-8.x
 
 resources:
   repositories:
@@ -47,7 +46,7 @@ extends:
       - job:  Debug	
         timeoutInMinutes: 120
         variables:	
-            buildPlatform: 'Any CPU'	
+            buildPlatform: 'AnyCPU'
             buildConfiguration: 'Debug'	
             skipComponentGovernanceDetection: true	
             snExe: 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\sn.exe'	
@@ -73,7 +72,7 @@ extends:
       - job:  Release
         timeoutInMinutes: 120
         variables:
-            buildPlatform: 'Any CPU'
+            buildPlatform: 'AnyCPU'
             buildConfiguration: 'Release'
             skipComponentGovernanceDetection: true
             snExe: 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\sn.exe'

--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -7,7 +7,6 @@ trigger:
   branches:
     include:
     - main
-    - dev-8.x
    
 # Pull request (PR) triggers
 pr:
@@ -16,7 +15,6 @@ pr:
 
     include:
     - main
-    - dev-8.x
 
 resources:
   repositories:
@@ -48,11 +46,9 @@ extends:
       jobs:
       - job:  Debug	
         variables:	
-          buildPlatform: 'Any CPU'	
+          buildPlatform: 'AnyCPU'
           buildConfiguration: 'Debug'	
           skipComponentGovernanceDetection: true	
-          snExe: 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\sn.exe'	
-          snExe64: 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\sn.exe'	
           gacUtil: '$(Build.SourcesDirectory)\test\CommonAssemblies\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll'	
           productBinPathEdm: '$(Build.SourcesDirectory)\src\Microsoft.OData.Edm\bin\$(buildConfiguration)'	
           mainDllEdm: 'Microsoft.OData.Edm.dll'	
@@ -67,11 +63,9 @@ extends:
           - template: /credscan.yml@self
       - job:  Release
         variables:
-          buildPlatform: 'Any CPU'
+          buildPlatform: 'AnyCPU'
           buildConfiguration: 'Release'
           skipComponentGovernanceDetection: true
-          snExe: 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\sn.exe'
-          snExe64: 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\sn.exe'
           gacUtil: '$(Build.SourcesDirectory)\test\CommonAssemblies\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll'
           productBinPathEdm: '$(Build.SourcesDirectory)\src\Microsoft.OData.Edm\bin\$(buildConfiguration)'
           mainDllEdm: 'Microsoft.OData.Edm.dll'

--- a/buildandtest.yml
+++ b/buildandtest.yml
@@ -27,7 +27,7 @@ steps:
   displayName: 'Build'  
   inputs:
     command: 'build'
-    arguments: '--configuration $(BuildConfiguration) --no-incremental'
+    arguments: '--configuration $(buildConfiguration) --no-incremental'
     projects: |
      $(Build.SourcesDirectory)\sln\OData.Pipeline.sln
 

--- a/nightly.yml
+++ b/nightly.yml
@@ -94,8 +94,6 @@
       displayName: 'Get Nuget Package Metadata'
       inputs:
         solution: '$(Build.SourcesDirectory)\tools\CustomMSBuild\GetNugetPackageMetadata.proj'
-        platform: '$(buildPlatform)'
-        configuration: '$(buildPlatform)'
 
     - task: NuGetCommand@2
       displayName: 'NuGet - pack Microsoft.Spatial.Nightly.Release'


### PR DESCRIPTION


<!-- markdownlint-disable MD002 MD041 -->

### Issues

Each project has TargetFramework, meanwhile Build.prop at root has TargetFrameWorks setting.

It seems this is a conflict and make the xunit runner failed to identify the test cases.

In this PR, I remove the 'TargetFrameworks' from 'Build.prop' because:

1) If check the released ODL version at nuget.org, it only contains 'net8.0' dlls.
2) No test running 


### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
