### PR TITLE
Fix race condition when writing property name in WriteValueAsync hook

### DIFF
--- a/src/Microsoft.OData.Serializer/Json/State/WriteStack.cs
+++ b/src/Microsoft.OData.Serializer/Json/State/WriteStack.cs
@@ -58,6 +58,10 @@ internal class WriteStack<TCustomState>
         }
     }
 
+    // NOTE: This can be accessed even when the stack is empty or is unwinding to the
+    // root of the serializer. It can be accessed asynchronouly by a pending task
+    // while the serializer is unwining the stack. So we should ensure its state
+    // is not modified by the serializer until the pending task is completed.
     internal ref WriteStackFrame<TCustomState> LastSuspendedFrame
     {
         get

--- a/test/UnitTests/Microsoft.OData.Serializer.Tests/StreamWriterChunckedTextStreamingTests.cs
+++ b/test/UnitTests/Microsoft.OData.Serializer.Tests/StreamWriterChunckedTextStreamingTests.cs
@@ -49,6 +49,7 @@ public class StreamWriterChunkedTextStreamingTests
                         var buffer = ArrayPool<byte>.Shared.Rent(4096);
                         var decodedBuffer = ArrayPool<char>.Shared.Rent(4096);
 
+                        await Task.Yield(); // ensure async behaviour since MemoryStream can complete synchronously
                         var bytesRead = await stream.ReadAsync(buffer);
                         do
                         {

--- a/test/UnitTests/Microsoft.OData.Serializer.Tests/StreamWriterChunkedByteStreamingTests.cs
+++ b/test/UnitTests/Microsoft.OData.Serializer.Tests/StreamWriterChunkedByteStreamingTests.cs
@@ -46,6 +46,7 @@ public class StreamWriterChunkedByteStreamingTests
                         using var stream = post.GetContents();
                         var buffer = ArrayPool<byte>.Shared.Rent(4096);
 
+                        await Task.Yield(); // ensure asynchronous behavior since MemoryStream may complete synchronously
                         var bytesRead = await stream.ReadAsync(buffer);
                         do
                         {

--- a/test/UnitTests/Microsoft.OData.Serializer.Tests/SupportForCustomAsyncPropertyValueWriterWithPropertyValue.cs
+++ b/test/UnitTests/Microsoft.OData.Serializer.Tests/SupportForCustomAsyncPropertyValueWriterWithPropertyValue.cs
@@ -96,6 +96,7 @@ public class SupportForCustomAsyncPropertyValueWriterWithPropertyValue
             IStreamValueWriter<CustomState> writer,
             ODataWriterState<CustomState> state)
         {
+            await Task.Yield(); // ensure asynchronous behavior since MemoryStream may complete synchronously
             if (resource.HasContentStream)
             {
                 await using var stream = state.CustomState.StreamProvider.GetContentStream(resource.Id);

--- a/test/UnitTests/Microsoft.OData.Serializer.Tests/WriteValueHookSkipsPropertyIfNoValueWrittenTests.cs
+++ b/test/UnitTests/Microsoft.OData.Serializer.Tests/WriteValueHookSkipsPropertyIfNoValueWrittenTests.cs
@@ -136,6 +136,7 @@ public class WriteValueHookSkipsPropertyIfNoValueWrittenTests
                     Name = "Content",
                     WriteValueAsync = async static (post, writer, state) =>
                     {
+                        await Task.Yield();
                         if (post.Content != null)
                         {
                             await writer.WriteValueAsync(post.Content, state);
@@ -261,6 +262,7 @@ public class WriteValueHookSkipsPropertyIfNoValueWrittenTests
     {
         public override async ValueTask WriteValueAsync(BlogPostWithAsyncWriter resource, string propertyValue, IStreamValueWriter<DefaultState> writer, ODataWriterState<DefaultState> state)
         {
+            await Task.Yield();
             if (propertyValue != null)
             {
                 await writer.WriteValueAsync(propertyValue, state);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Fix #3427 

### Description

The issue was due to a race condition: The serializer pauses when the async WriteValueAsync starts, and the serializer unwinds the stack to the root so that it can await the pending task. Unwinding the stack modifies the `Current` stack frame, and at the root, the stack is "empty" and accessing `Current` throws the `InvalidOperationException`. However, the `WriteValueAsync` method concurrently accesses `stack.Current` to check if the property name has already been written, before writing the value. This concurrent access of `stack.Current` from the serializer unwinding and the `WriteValueAsync` is what was causing the error. I've made changes to avoid concurrent access to `stack.Current` when a `WriteValueAsync` task is in progress.

This issue was not appearing in tests because most async tests are based on `MemoryStream`, which completes synchronously. I've forced async behaviour using `Task.Yield()`.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
