### PR TITLE
Add support for collection parameters in URI functions

### DIFF
--- a/src/Microsoft.OData.Core/SRResources.Designer.cs
+++ b/src/Microsoft.OData.Core/SRResources.Designer.cs
@@ -1520,6 +1520,15 @@ namespace Microsoft.OData.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The argument for an invocation of a function with name &apos;{0}&apos; is not a single value or collection. Arguments for this function must be either a single value or collection..
+        /// </summary>
+        internal static string MetadataBinder_FunctionArgumentNotSingleValueOrCollectionNode {
+            get {
+                return ResourceManager.GetString("MetadataBinder_FunctionArgumentNotSingleValueOrCollectionNode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Encountered invalid type cast. &apos;{0}&apos; is not assignable from &apos;{1}&apos;..
         /// </summary>
         internal static string MetadataBinder_HierarchyNotFollowed {

--- a/src/Microsoft.OData.Core/SRResources.resx
+++ b/src/Microsoft.OData.Core/SRResources.resx
@@ -2624,4 +2624,7 @@
   <data name="TaskUtils_NullContinuationTask" xml:space="preserve">
     <value>The continuation task returned by the operation cannot be null.</value>
   </data>
+  <data name="MetadataBinder_FunctionArgumentNotSingleValueOrCollectionNode" xml:space="preserve">
+    <value>The argument for an invocation of a function with name '{0}' is not a single value or collection. Arguments for this function must be either a single value or collection.</value>
+  </data>
 </root>

--- a/src/Microsoft.OData.Core/SRResources.resx
+++ b/src/Microsoft.OData.Core/SRResources.resx
@@ -2627,4 +2627,7 @@
   <data name="ODataJsonDeserializer_AssertJsonConditionFailed" xml:space="preserve">
     <value>JSON condition failed: the JsonReader is on node {0} (Value: {1}) but it was expected be on {2}.</value>
   </data>
+  <data name="MetadataBinder_FunctionArgumentNotSingleValueOrCollectionNode" xml:space="preserve">
+    <value>The argument for an invocation of a function with name '{0}' is not a single value or collection. Arguments for this function must be either a single value or collection.</value>
+  </data>
 </root>

--- a/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
@@ -671,19 +671,19 @@ namespace Microsoft.OData
                 {
                     ODataJsonPropertyAndValueDeserializer deserializer = new ODataJsonPropertyAndValueDeserializer(context);
 
-                    // TODO: The way JSON array literals look in the URI is different that response payload with an array in it.
+                    // TODO: The way JSON array literals look in the URI is different than response payload with an array in it.
                     // The fact that we have to manually setup the underlying reader shows this different in the protocol.
                     // There is a discussion on if we should change this or not.
                     deserializer.JsonReader.Read(); // Move to first thing
                     object rawResult = deserializer.ReadNonEntityValue(
-                        null /*payloadTypeName*/,
-                        typeReference,
-                        null /*DuplicatePropertyNameChecker*/,
-                        null /*CollectionWithoutExpectedTypeValidator*/,
-                        true /*validateNullValue*/,
-                        false /*isTopLevelPropertyValue*/,
-                        false /*insideResourceValue*/,
-                        null /*propertyName*/);
+                        payloadTypeName: null,
+                        expectedValueTypeReference: typeReference,
+                        propertyAndAnnotationCollector: null,
+                        collectionValidator: null,
+                        validateNullValue: true,
+                        isTopLevelPropertyValue: false,
+                        insideResourceValue: false,
+                        propertyName: null);
                     deserializer.ReadPayloadEnd(false);
 
                     return rawResult;

--- a/src/Microsoft.OData.Core/Uri/ODataUriUtils.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriUtils.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OData
 
             if (model == null)
             {
-                model = Microsoft.OData.Edm.EdmCoreModel.Instance;
+                model = EdmCoreModel.Instance;
             }
 
             // Let ExpressionLexer try to get a primitive
@@ -149,7 +149,7 @@ namespace Microsoft.OData
 
             if (model == null)
             {
-                model = Microsoft.OData.Edm.EdmCoreModel.Instance;
+                model = EdmCoreModel.Instance;
             }
 
             ODataNullValue nullValue = value as ODataNullValue;

--- a/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
@@ -47,45 +47,87 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         /// <param name="signature">The signature to match the types to.</param>
         /// <param name="argumentNodes">The types to promote.</param>
-        internal static void TypePromoteArguments(FunctionSignatureWithReturnType signature, List<QueryNode> argumentNodes)
+        internal static void TypePromoteArguments(
+            FunctionSignatureWithReturnType signature,
+            (QueryNode Node, IEdmTypeReference TypeReference)[] argumentsMetadata)
         {
             // Convert all argument nodes to the best signature argument type
-            Debug.Assert(signature.ArgumentTypes.Length == argumentNodes.Count, "The best signature match doesn't have the same number of arguments.");
-            for (int i = 0; i < argumentNodes.Count; i++)
+            Debug.Assert(signature.ArgumentTypes.Length == argumentsMetadata.Length,
+                "The best signature match doesn't have the same number of arguments.");
+
+            for (int i = 0; i < argumentsMetadata.Length; i++)
             {
-                Debug.Assert(argumentNodes[i] is SingleValueNode, "We should have already verified that all arguments are single values.");
-                SingleValueNode argumentNode = (SingleValueNode)argumentNodes[i];
+                Debug.Assert(argumentsMetadata[i].Node is SingleValueNode or CollectionNode,
+                    "We should have already verified that all arguments are single- or collection-valued.");
                 IEdmTypeReference signatureArgumentType = signature.ArgumentTypes[i];
-                Debug.Assert(signatureArgumentType.IsODataPrimitiveTypeKind() || signatureArgumentType.IsODataEnumTypeKind(), "Only primitive or enum types should be able to get here.");
-                argumentNodes[i] = MetadataBindingUtils.ConvertToTypeIfNeeded(argumentNode, signatureArgumentType);
+                
+                if (argumentsMetadata[i].Node is SingleValueNode singleValueNode)
+                {
+                    if (signatureArgumentType.IsCollection() && singleValueNode is ConstantNode constantNode && constantNode.TypeReference.IsString())
+                    {
+                        if (!TypePromotionUtils.TryParseCollectionConstantNode(constantNode, signatureArgumentType.AsCollection(), out CollectionConstantNode collectionConstantNode))
+                        {
+                            Debug.Assert(false, "Only constant node with bracketed expression that is possible to convert to a collection that can be promoted should be able to get here.");
+                        }
+
+                        CollectionNode collectionNode = MetadataBindingUtils.ConvertToTypeIfNeeded(collectionConstantNode, signatureArgumentType);
+                        argumentsMetadata[i].Node = collectionNode;
+                        argumentsMetadata[i].TypeReference = collectionNode.CollectionType;
+                        continue;
+                    }
+
+                    Debug.Assert(signatureArgumentType.IsODataPrimitiveTypeKind() || signatureArgumentType.IsODataEnumTypeKind(),
+                        "Only primitive or enum types should be able to get here.");
+                    SingleValueNode queryNode = MetadataBindingUtils.ConvertToTypeIfNeeded(singleValueNode, signatureArgumentType);
+                    argumentsMetadata[i].Node = queryNode;
+                    argumentsMetadata[i].TypeReference = queryNode.TypeReference;
+                }
+                else
+                {
+                    Debug.Assert(signatureArgumentType is IEdmCollectionTypeReference signatureCollectionType
+                        && (signatureCollectionType.ElementType().IsODataPrimitiveTypeKind() || signatureCollectionType.ElementType().IsODataEnumTypeKind()),
+                        "Only primitive or enum collection element types should be able to get here.");
+
+                    CollectionNode collectionNode = MetadataBindingUtils.ConvertToTypeIfNeeded(
+                        (CollectionNode)argumentsMetadata[i].Node,
+                        signatureArgumentType);
+                    argumentsMetadata[i].Node = collectionNode;
+                    argumentsMetadata[i].TypeReference = collectionNode.CollectionType;
+                }
             }
         }
 
         /// <summary>
-        /// Checks that all arguments are SingleValueNodes
+        /// Checks that all arguments are single-valued or collection-valued nodes.
         /// </summary>
         /// <param name="functionName">The name of the function the arguments are from.</param>
         /// <param name="argumentNodes">The arguments to validate.</param>
-        /// <returns>SingleValueNode array</returns>
-        internal static SingleValueNode[] ValidateArgumentsAreSingleValue(string functionName, List<QueryNode> argumentNodes)
+        internal static (QueryNode Node, IEdmTypeReference TypeReference)[] ValidateArgumentNodes(string functionName, List<QueryNode> argumentNodes)
         {
-            ExceptionUtils.CheckArgumentNotNull(functionName, "functionCallToken");
-            ExceptionUtils.CheckArgumentNotNull(argumentNodes, "argumentNodes");
+            ExceptionUtils.CheckArgumentNotNull(functionName, $"{nameof(functionName)}");
+            ExceptionUtils.CheckArgumentNotNull(argumentNodes, $"{nameof(argumentNodes)}");
 
-            // Right now all functions take a single value for all arguments
-            SingleValueNode[] ret = new SingleValueNode[argumentNodes.Count];
+            (QueryNode Node, IEdmTypeReference TypeReference)[] argumentsMetadata = new (QueryNode, IEdmTypeReference)[argumentNodes.Count];
+
+            // Functions take a single-valued or collection-valued arguments
             for (int i = 0; i < argumentNodes.Count; i++)
             {
-                SingleValueNode argumentNode = argumentNodes[i] as SingleValueNode;
-                if (argumentNode == null)
+                QueryNode argumentNode = argumentNodes[i];
+                if (argumentNode is SingleValueNode singleValueNode)
                 {
-                    throw new ODataException(Error.Format(SRResources.MetadataBinder_FunctionArgumentNotSingleValue, functionName));
+                    argumentsMetadata[i] = (singleValueNode, singleValueNode.TypeReference);
                 }
-
-                ret[i] = argumentNode;
+                else if (argumentNode is CollectionNode collectionNode)
+                {
+                    argumentsMetadata[i] = (collectionNode, collectionNode.CollectionType);
+                }
+                else
+                {
+                    throw new ODataException(Error.Format(SRResources.MetadataBinder_FunctionArgumentNotSingleValueOrCollectionNode, functionName));
+                }
             }
 
-            return ret;
+            return argumentsMetadata;
         }
 
         /// <summary>
@@ -95,24 +137,24 @@ namespace Microsoft.OData.UriParser
         /// <param name="argumentNodes">The nodes of the arguments, can be new {null,null}.</param>
         /// <param name="nameSignatures">The name-signature pairs to match against</param>
         /// <returns>Returns the matching signature or throws</returns>
-        internal static KeyValuePair<string, FunctionSignatureWithReturnType> MatchSignatureToUriFunction(string functionCallToken, SingleValueNode[] argumentNodes,
+        internal static KeyValuePair<string, FunctionSignatureWithReturnType> MatchSignatureToUriFunction(
+            string functionCallToken,
+            (QueryNode Node, IEdmTypeReference TypeReference)[] argumentsMetadata,
             IList<KeyValuePair<string, FunctionSignatureWithReturnType>> nameSignatures)
         {
             KeyValuePair<string, FunctionSignatureWithReturnType> nameSignature;
 
-            IEdmTypeReference[] argumentTypes = argumentNodes.Select(s => s.TypeReference).ToArray();
-
             // Handle the cases where we don't have type information (null literal, open properties) for ANY of the arguments
-            int argumentCount = argumentTypes.Length;
-            if (argumentTypes.All(a => a == null) && argumentCount > 0)
+            int argumentsCount = argumentsMetadata.Length;
+            if (argumentsMetadata.All(n => n.TypeReference == null) && argumentsCount > 0)
             {
                 // we specifically want to find just the first function that matches the number of arguments, we don't care about
                 // ambiguity here because we're already in an ambiguous case where we don't know what kind of types
                 // those arguments are.
-                KeyValuePair<string, FunctionSignatureWithReturnType> found = nameSignatures.FirstOrDefault(pair => pair.Value.ArgumentTypes.Length == argumentCount);
+                KeyValuePair<string, FunctionSignatureWithReturnType> found = nameSignatures.FirstOrDefault(pair => pair.Value.ArgumentTypes.Length == argumentsCount);
                 if (found.Equals(TypePromotionUtils.NotFoundKeyValuePair))
                 {
-                    throw new ODataException(Error.Format(SRResources.FunctionCallBinder_CannotFindASuitableOverload, functionCallToken, argumentTypes.Length));
+                    throw new ODataException(Error.Format(SRResources.FunctionCallBinder_CannotFindASuitableOverload, functionCallToken, argumentsMetadata.Length));
                 }
                 else
                 {
@@ -124,8 +166,7 @@ namespace Microsoft.OData.UriParser
             }
             else
             {
-                nameSignature =
-                    TypePromotionUtils.FindBestFunctionSignature(nameSignatures, argumentNodes, functionCallToken);
+                nameSignature = TypePromotionUtils.FindBestFunctionSignature(functionCallToken, nameSignatures, argumentsMetadata);
                 if (nameSignature.Equals(TypePromotionUtils.NotFoundKeyValuePair))
                 {
                     throw new ODataException(Error.Format(SRResources.MetadataBinder_NoApplicableFunctionFound,
@@ -303,15 +344,19 @@ namespace Microsoft.OData.UriParser
             IList<KeyValuePair<string, FunctionSignatureWithReturnType>> nameSignatures = GetUriFunctionSignatures(functionCallToken.Name,
                 this.state.Configuration.EnableCaseInsensitiveUriFunctionIdentifier);
 
-            SingleValueNode[] argumentNodeArray = ValidateArgumentsAreSingleValue(functionCallToken.Name, argumentNodes);
-            KeyValuePair<string, FunctionSignatureWithReturnType> nameSignature = MatchSignatureToUriFunction(functionCallToken.Name, argumentNodeArray, nameSignatures);
+            (QueryNode Node, IEdmTypeReference TypeReference)[] argumentsMetadata = ValidateArgumentNodes(functionCallToken.Name, argumentNodes);
+            KeyValuePair<string, FunctionSignatureWithReturnType> nameSignature = MatchSignatureToUriFunction(functionCallToken.Name, argumentsMetadata, nameSignatures);
             Debug.Assert(nameSignature.Key != null, "nameSignature.Key != null");
 
             string canonicalName = nameSignature.Key;
             FunctionSignatureWithReturnType signature = nameSignature.Value;
             if (signature != null)
             {
-                TypePromoteArguments(signature, argumentNodes);
+                TypePromoteArguments(signature, argumentsMetadata);
+                for (int i = 0; i < argumentsMetadata.Length; i++)
+                {
+                    argumentNodes[i] = argumentsMetadata[i].Node;
+                }
             }
 
             if (signature.ReturnType != null && signature.ReturnType.IsStructured())
@@ -388,7 +433,7 @@ namespace Microsoft.OData.UriParser
             IEdmFunction function = (IEdmFunction)operation;
 
             // TODO:  $filter $orderby parameter expression which contains complex or collection should NOT be supported in this way
-            //     but should be parsed into token tree, and binded to node tree: parsedParameters.Select(p => this.bindMethod(p));
+            //     but should be parsed into token tree, and bound to node tree: parsedParameters.Select(p => this.bindMethod(p));
             ICollection<FunctionParameterToken> parsedParameters = HandleComplexOrCollectionParameterValueIfExists(state.Configuration.Model, function, syntacticArguments, state.Configuration.Resolver.EnableCaseInsensitive);
 
             IEnumerable<QueryNode> boundArguments = parsedParameters.Select(p => this.bindMethod(p));
@@ -430,13 +475,21 @@ namespace Microsoft.OData.UriParser
         /// Bind path segment's operation or operationImport's parameters.
         /// </summary>
         /// <param name="configuration">The ODataUriParserConfiguration.</param>
-        /// <param name="functionOrOpertion">The function or operation.</param>
-        /// <param name="segmentParameterTokens">The parameter tokens to be binded.</param>
-        /// <returns>The binded semantic nodes.</returns>
-        internal static List<OperationSegmentParameter> BindSegmentParameters(ODataUriParserConfiguration configuration, IEdmOperation functionOrOpertion, ICollection<FunctionParameterToken> segmentParameterTokens)
+        /// <param name="functionOrOperation">The function or operation.</param>
+        /// <param name="segmentParameterTokens">The parameter tokens to be bound.</param>
+        /// <returns>The bound semantic nodes.</returns>
+        internal static List<OperationSegmentParameter> BindSegmentParameters(
+            ODataUriParserConfiguration configuration,
+            IEdmOperation functionOrOperation,
+            ICollection<FunctionParameterToken> segmentParameterTokens)
         {
-            // TODO: HandleComplexOrCollectionParameterValueIfExists is temp work around for single copmlex or colleciton type, it can't handle nested complex or collection value.
-            ICollection<FunctionParameterToken> parametersParsed = FunctionCallBinder.HandleComplexOrCollectionParameterValueIfExists(configuration.Model, functionOrOpertion, segmentParameterTokens, configuration.Resolver.EnableCaseInsensitive, configuration.EnableUriTemplateParsing);
+            // TODO: HandleComplexOrCollectionParameterValueIfExists is temp work around for single complex or collection type, it can't handle nested complex or collection value.
+            ICollection<FunctionParameterToken> parametersParsed = HandleComplexOrCollectionParameterValueIfExists(
+                configuration.Model,
+                functionOrOperation,
+                segmentParameterTokens,
+                configuration.Resolver.EnableCaseInsensitive,
+                configuration.EnableUriTemplateParsing);
 
             // Bind it to metadata
             BindingState state = new BindingState(configuration);
@@ -445,6 +498,8 @@ namespace Microsoft.OData.UriParser
             MetadataBinder binder = new MetadataBinder(state);
             List<OperationSegmentParameter> boundParameters = new List<OperationSegmentParameter>();
 
+            // TODO: Why does this method only handle SingleValueNode?
+            // What about other QueryNode types like CollectionNode?
             IDictionary<string, SingleValueNode> input = new Dictionary<string, SingleValueNode>(StringComparer.Ordinal);
             foreach (FunctionParameterToken paraToken in parametersParsed)
             {
@@ -463,7 +518,7 @@ namespace Microsoft.OData.UriParser
                 }
             }
 
-            IDictionary<IEdmOperationParameter, SingleValueNode> result = configuration.Resolver.ResolveOperationParameters(functionOrOpertion, input);
+            IDictionary<IEdmOperationParameter, SingleValueNode> result = configuration.Resolver.ResolveOperationParameters(functionOrOperation, input);
 
             foreach (KeyValuePair<IEdmOperationParameter, SingleValueNode> item in result)
             {
@@ -553,7 +608,7 @@ namespace Microsoft.OData.UriParser
         /// This is temp work around for $filter $orderby parameter expression which contains complex or collection
         ///     like "Fully.Qualified.Namespace.CanMoveToAddresses(addresses=[{\"Street\":\"NE 24th St.\",\"City\":\"Redmond\"},{\"Street\":\"Pine St.\",\"City\":\"Seattle\"}])";
         /// TODO:  $filter $orderby parameter expression which contains nested complex or collection should NOT be supported in this way
-        ///     but should be parsed into token tree, and binded to node tree: parsedParameters.Select(p => this.bindMethod(p));
+        ///     but should be parsed into token tree, and bound to node tree: parsedParameters.Select(p => this.bindMethod(p));
         /// </summary>
         /// <param name="model">The model.</param>
         /// <param name="operation">IEdmFunction or IEdmOperation</param>
@@ -590,7 +645,7 @@ namespace Microsoft.OData.UriParser
                 string valueStr = null;
                 if (valueToken != null && (valueStr = valueToken.Value as string) != null && !string.IsNullOrEmpty(valueToken.OriginalText))
                 {
-                    ExpressionLexer lexer = new ExpressionLexer(valueToken.OriginalText, true /*moveToFirstToken*/, false /*useSemicolonDelimiter*/, true /*parsingFunctionParameters*/);
+                    ExpressionLexer lexer = new ExpressionLexer(valueToken.OriginalText, moveToFirstToken: true, useSemicolonDelimiter: false, parsingFunctionParameters: true);
                     if (lexer.CurrentToken.Kind == ExpressionTokenKind.BracketedExpression || lexer.CurrentToken.Kind == ExpressionTokenKind.BracedExpression)
                     {
                         object result;
@@ -608,7 +663,7 @@ namespace Microsoft.OData.UriParser
                         }
                         else
                         {
-                            // For complex & colleciton of complex directly return the raw string.
+                            // For complex & collection of complex directly return the raw string.
                             partiallyParsedParametersWithComplexOrCollection.Add(funcParaToken);
                             continue;
                         }

--- a/src/Microsoft.OData.Core/UriParser/Binders/LiteralBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/LiteralBinder.cs
@@ -6,7 +6,7 @@
 
 namespace Microsoft.OData.UriParser
 {
-    using System.Diagnostics;
+    using Microsoft.OData.Edm;
 
     /// <summary>
     /// Class that knows how to bind literal values.
@@ -48,8 +48,8 @@ namespace Microsoft.OData.UriParser
             {
                 if (literalToken.ExpectedEdmTypeReference != null)
                 {
-                    OData.Edm.IEdmCollectionTypeReference collectionReference =
-                        literalToken.ExpectedEdmTypeReference as OData.Edm.IEdmCollectionTypeReference;
+                    IEdmCollectionTypeReference collectionReference =
+                        literalToken.ExpectedEdmTypeReference as IEdmCollectionTypeReference;
                     if (collectionReference != null)
                     {
                         ODataCollectionValue collectionValue = literalToken.Value as ODataCollectionValue;

--- a/src/Microsoft.OData.Core/UriParser/Binders/MetadataBindingUtils.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/MetadataBindingUtils.cs
@@ -7,6 +7,7 @@
 namespace Microsoft.OData.UriParser
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using Microsoft.OData;
     using Microsoft.OData.Core;
@@ -73,7 +74,7 @@ namespace Microsoft.OData.UriParser
                     {
                         if(enumType.TryParse(memberIntegralValue, out IEdmEnumMember enumMember))
                         {
-                            string literalText = ODataUriUtils.ConvertToUriLiteral(enumMember.Name, default(ODataVersion));
+                            string literalText = ODataUriUtils.ConvertToUriLiteral(enumMember.Name, default);
                             return new ConstantNode(new ODataEnumValue(enumMember.Name, enumType.ToString()), literalText, targetTypeReference);
                         }
                         
@@ -82,7 +83,7 @@ namespace Microsoft.OData.UriParser
                             string flagsValue = enumType.ParseFlagsFromIntegralValue(memberIntegralValue);
                             if(!string.IsNullOrEmpty(flagsValue))
                             {
-                                string literalText = ODataUriUtils.ConvertToUriLiteral(flagsValue, default(ODataVersion));
+                                string literalText = ODataUriUtils.ConvertToUriLiteral(flagsValue, default);
                                 return new ConstantNode(new ODataEnumValue(flagsValue, enumType.ToString()), literalText, targetTypeReference);
                             }
                         }
@@ -142,8 +143,8 @@ namespace Microsoft.OData.UriParser
                             var targetDecimalType = (IEdmDecimalTypeReference)targetTypeReference;
                             return decimalType.Precision == targetDecimalType.Precision &&
                                    decimalType.Scale == targetDecimalType.Scale ?
-                                   (SingleValueNode)candidate :
-                                   (SingleValueNode)(new ConvertNode(candidate, targetTypeReference));
+                                   candidate :
+                                   new ConvertNode(candidate, targetTypeReference);
                         }
                         else
                         {
@@ -163,6 +164,140 @@ namespace Microsoft.OData.UriParser
                 // cause we don't know for sure.
                 return new ConvertNode(source, targetTypeReference);
             }
+        }
+
+        /// <summary>
+        /// Converts a collection node's element type to <paramref name="targetTypeReference"/> when possible,
+        /// materializing a new <see cref="CollectionConstantNode"/> for constant collections;
+        /// leaves non-constant/open or non-convertible collections unchanged.
+        /// </summary>
+        /// <param name="source">Source collection node.</param>
+        /// <param name="targetTypeReference">Desired collection type (must be a collection).</param>
+        /// <returns>Converted collection node or original source.</returns>
+        internal static CollectionNode ConvertToTypeIfNeeded(CollectionNode source, IEdmTypeReference targetTypeReference)
+        {
+            Debug.Assert(source != null, "source != null");
+
+            if (targetTypeReference == null)
+            {
+                return source;
+            }
+
+            IEdmCollectionTypeReference sourceCollectionType = source.CollectionType;
+            if (sourceCollectionType == null) // Open collection? Leave as is
+            {
+                return source;
+            }
+
+            if (!targetTypeReference.IsCollection())
+            {
+                throw new ODataException(Error.Format(SRResources.MetadataBinder_CannotConvertToType, source.CollectionType.FullName(), targetTypeReference.FullName()));
+            }
+
+            IEdmCollectionTypeReference targetCollectionType = targetTypeReference.AsCollection();
+
+            if (sourceCollectionType.IsEquivalentTo(targetCollectionType))
+            {
+                IEdmTypeReference sourceElemType = sourceCollectionType.ElementType();
+                IEdmTypeReference targetElemType = targetCollectionType.ElementType();
+                if (source is CollectionConstantNode colConstantNode
+                    && sourceElemType.IsTypeDefinition()
+                    && targetElemType.IsPrimitive()
+                    && sourceElemType.AsPrimitive().PrimitiveKind() == targetElemType.AsPrimitive().PrimitiveKind())
+                {
+                    List<ConstantNode> convertedNodes = ConvertNodes(colConstantNode.Collection, targetElemType);
+                    
+                    return new CollectionConstantNode(convertedNodes, BuildCollectionLiteral(convertedNodes, targetElemType), targetCollectionType);
+                }
+
+                return source;
+            }
+
+            IEdmTypeReference sourceElementType = sourceCollectionType.ElementType();
+            IEdmTypeReference targetElementType = targetCollectionType.ElementType();
+
+            if (!TypePromotionUtils.CanConvertTo(null, sourceElementType, targetElementType))
+            {
+                throw new ODataException(Error.Format(SRResources.MetadataBinder_CannotConvertToType, sourceElementType.FullName(), targetElementType.FullName()));
+            }
+            
+            if (source is CollectionConstantNode collectionConstantNode)
+            {
+                List<ConstantNode> convertedNodes = ConvertNodes(collectionConstantNode.Collection, targetElementType);
+
+                return new CollectionConstantNode(convertedNodes, BuildCollectionLiteral(convertedNodes, targetElementType), targetCollectionType);
+            }
+
+            // Non-constant collections: leave as-is (conversion implicit)
+            return source;
+        }
+
+        /// <summary>
+        /// Converts each constant value to <paramref name="targetElementType"/>, applying enum/numeric coercion; preserves null items.
+        /// </summary>
+        /// <param name="nodes">Original constant value nodes.</param>
+        /// <param name="targetElementType">The target primitive type.</param>
+        /// <returns>List of converted constant nodes.</returns>
+        private static List<ConstantNode> ConvertNodes(IList<ConstantNode> nodes, IEdmTypeReference targetElementType)
+        {
+            List<ConstantNode> convertedNodes = new List<ConstantNode>(nodes.Count);
+
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                ConstantNode item = nodes[i];
+                if (item == null)
+                {
+                    // Preserve null
+                    convertedNodes.Add(new ConstantNode(null, "null", targetElementType));
+                    continue;
+                }
+
+                ConstantNode convertedNode = ConvertToTypeIfNeeded(item, targetElementType) as ConstantNode;
+
+                // If ConvertToTypeIfNeeded returned a ConvertNode, force materialization into a ConstantNode
+                if (convertedNode == null)
+                {
+                    // Try to keep original literal text if meaningful
+                    string literal = item.LiteralText ?? ODataUriUtils.ConvertToUriLiteral(item.Value, ODataVersion.V4);
+                    convertedNode = new ConstantNode(item.Value, literal, targetElementType);
+                }
+
+                convertedNodes.Add(convertedNode);
+            }
+
+            return convertedNodes;
+        }
+
+        /// <summary>
+        /// Builds a bracketed collection literal (e.g. [1,2,3]) from constant nodes, quoting/escaping strings and preserving nulls.
+        /// </summary>
+        /// <param name="nodes">Constant nodes representing items.</param>
+        /// <param name="typeReference">Element type for string quoting rules.</param>
+        /// <returns>OData collection literal text.</returns>
+        private static string BuildCollectionLiteral(List<ConstantNode> nodes, IEdmTypeReference typeReference)
+        {
+            Debug.Assert(typeReference != null, $"{nameof(typeReference)} != null");
+
+            List<string> list = new List<string>();
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                ConstantNode node = nodes[i];
+                if (node == null || node.Value == null)
+                {
+                    list.Add("null");
+                    continue;
+                }
+                
+                string literal = node.LiteralText ?? ODataUriUtils.ConvertToUriLiteral(node.Value, ODataVersion.V4);
+                if (typeReference.IsString() && !(literal.Length > 1 && literal[0] == '\'' && literal[^1] == '\''))
+                {
+                    literal = $"'{literal.Replace("'", "''", StringComparison.Ordinal)}'";
+                }
+
+                list.Add(literal);
+            }
+
+            return "(" + string.Join(",", list) + ")";
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/Binders/ParameterAliasBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/ParameterAliasBinder.cs
@@ -112,7 +112,7 @@ namespace Microsoft.OData.UriParser
             string valueStr;
             if (valueToken != null && (valueStr = valueToken.Value as string) != null && !string.IsNullOrEmpty(valueToken.OriginalText))
             {
-                var lexer = new ExpressionLexer(valueToken.OriginalText, true /*moveToFirstToken*/, false /*useSemicolonDelimiter*/, true /*parsingFunctionParameters*/);
+                var lexer = new ExpressionLexer(valueToken.OriginalText, moveToFirstToken: true, useSemicolonDelimiter: false, parsingFunctionParameters: true);
                 if (lexer.CurrentToken.Kind == ExpressionTokenKind.BracketedExpression || lexer.CurrentToken.Kind == ExpressionTokenKind.BracedExpression)
                 {
                     object result = valueStr;

--- a/src/Microsoft.OData.Core/UriParser/ODataUriParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataUriParser.cs
@@ -482,12 +482,13 @@ namespace Microsoft.OData.UriParser
             ExceptionUtils.CheckArgumentNotNull(this.uri, "uri");
 
             ODataPath path = this.ParsePath();
+            // NOTE: ParseCompute should be called before ParseSelectAndExpand because $compute may add computed properties to the select/expand clause.
+            ComputeClause compute = this.ParseCompute();
             SelectExpandClause selectExpand = this.ParseSelectAndExpand();
             FilterClause filter = this.ParseFilter();
             OrderByClause orderBy = this.ParseOrderBy();
             SearchClause search = this.ParseSearch();
             ApplyClause apply = this.ParseApply();
-            ComputeClause compute = this.ParseCompute();
             long? top = this.ParseTop();
             long? skip = this.ParseSkip();
             long? index = this.ParseIndex();

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/CollectionConstantNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/CollectionConstantNode.cs
@@ -59,6 +59,30 @@ namespace Microsoft.OData.UriParser
         }
 
         /// <summary>
+        /// CreateS a CollectionConstantNode.
+        /// </summary>
+        /// <param name="nodeCollection">A ConstantNode collection.</param>
+        /// <param name="literalText">The literal text for this node's value, formatted according to the OData URI literal formatting rules.</param>
+        /// <param name="collectionType">The reference to the collection type.</param>
+        /// <exception cref="System.ArgumentNullException">Throws if the input literalText is null.</exception>
+        internal CollectionConstantNode(IEnumerable<ConstantNode> nodeCollection, string literalText, IEdmCollectionTypeReference collectionType)
+        {
+            ExceptionUtils.CheckArgumentNotNull(nodeCollection, nameof(nodeCollection));
+            ExceptionUtils.CheckArgumentStringNotNullOrEmpty(literalText, nameof(literalText));
+            ExceptionUtils.CheckArgumentNotNull(collectionType, nameof(collectionType));
+
+            this.LiteralText = literalText;
+            EdmCollectionType edmCollectionType = collectionType.Definition as EdmCollectionType;
+            this.itemType = edmCollectionType.ElementType;
+            this.collectionTypeReference = collectionType;
+
+            foreach (ConstantNode item in nodeCollection)
+            {
+                this.collection.Add(item);
+            }
+        }
+
+        /// <summary>
         /// Gets the collection of ConstantNodes.
         /// </summary>
         public IList<ConstantNode> Collection

--- a/src/Microsoft.OData.Core/UriParser/TypePromotionUtils.cs
+++ b/src/Microsoft.OData.Core/UriParser/TypePromotionUtils.cs
@@ -78,12 +78,12 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// Signature for add
         /// </summary>
-        private static readonly FunctionSignature[] AdditionSignatures = arithmeticSignatures.Concat(GetAdditionTermporalSignatures()).ToArray();
+        private static readonly FunctionSignature[] AdditionSignatures = arithmeticSignatures.Concat(GetAdditionTemporalSignatures()).ToArray();
 
         /// <summary>
         /// Signature for sub
         /// </summary>
-        private static readonly FunctionSignature[] SubtractionSignatures = arithmeticSignatures.Concat(GetSubtractionTermporalSignatures()).ToArray();
+        private static readonly FunctionSignature[] SubtractionSignatures = arithmeticSignatures.Concat(GetSubtractionTemporalSignatures()).ToArray();
 
         /// <summary>Function signatures for relational operators (eq, ne, lt, le, gt, ge).</summary>
         private static readonly FunctionSignature[] relationalSignatures = new FunctionSignature[]
@@ -377,25 +377,26 @@ namespace Microsoft.OData.UriParser
         }
 
         /// <summary>Finds the best fitting function for the specified arguments.</summary>
-        /// <param name="nameFunctions">Functions with names to consider.</param>
-        /// <param name="argumentNodes">Nodes of the arguments for the function, can be new {null,null}.</param>
         /// <param name="functionCallToken">Function call token used for case-sensitive matching to resolve ambiguous cases.</param>
+        /// <param name="nameFunctions">Functions with names to consider.</param>
+        /// <param name="argumentMetadata">Nodes of the arguments for the function, can be new {null,null}.</param>
         /// <returns>The best fitting function; null if none found or ambiguous.</returns>
         internal static KeyValuePair<string, FunctionSignatureWithReturnType> FindBestFunctionSignature(
+            string functionCallToken,
             IList<KeyValuePair<string, FunctionSignatureWithReturnType>> nameFunctions,
-            SingleValueNode[] argumentNodes, string functionCallToken)
+            (QueryNode Node, IEdmTypeReference TypeReference)[] argumentMetadata)
         {
-            IEdmTypeReference[] argumentTypes = argumentNodes.Select(s => s.TypeReference).ToArray();
-            Debug.Assert(nameFunctions != null, "nameFunctions != null");
-            Debug.Assert(argumentTypes != null, "argumentTypes != null");
-            Debug.Assert(functionCallToken != null, "functionCallToken != null");
+            Debug.Assert(nameFunctions != null, $"{nameof(nameFunctions)} != null");
+            Debug.Assert(argumentMetadata != null, $"{nameof(argumentMetadata)} != null");
+            Debug.Assert(functionCallToken != null, $"{nameof(functionCallToken)} != null");
+
             IList<KeyValuePair<string, FunctionSignatureWithReturnType>> applicableNameFunctions
                 = new List<KeyValuePair<string, FunctionSignatureWithReturnType>>(nameFunctions.Count);
 
             // Build a list of applicable functions (and cache their promoted arguments).
             foreach (KeyValuePair<string, FunctionSignatureWithReturnType> candidate in nameFunctions)
             {
-                if (candidate.Value.ArgumentTypes.Length != argumentTypes.Length)
+                if (candidate.Value.ArgumentTypes.Length != argumentMetadata.Length)
                 {
                     continue;
                 }
@@ -403,7 +404,7 @@ namespace Microsoft.OData.UriParser
                 bool argumentsMatch = true;
                 for (int i = 0; i < candidate.Value.ArgumentTypes.Length; i++)
                 {
-                    if (!CanPromoteNodeTo(argumentNodes[i], argumentTypes[i], candidate.Value.ArgumentTypes[i]))
+                    if (!CanPromoteNodeTo(argumentMetadata[i].Node, argumentMetadata[i].TypeReference, candidate.Value.ArgumentTypes[i]))
                     {
                         argumentsMatch = false;
                         break;
@@ -428,6 +429,7 @@ namespace Microsoft.OData.UriParser
             }
             else
             {
+                // TODO: Verify when this block is hit in practice and determine how it'd handle collection node arguments.
                 // Find a single function which is better than all others.
                 IList<KeyValuePair<string, FunctionSignatureWithReturnType>> equallyArgumentsMatchingNameFunctions =
                     new List<KeyValuePair<string, FunctionSignatureWithReturnType>>();
@@ -436,7 +438,10 @@ namespace Microsoft.OData.UriParser
                     bool betterThanAllOthers = true;
                     for (int j = 0; j < applicableNameFunctions.Count; j++)
                     {
-                        if (i != j && MatchesArgumentTypesBetterThan(argumentTypes, applicableNameFunctions[j].Value.ArgumentTypes, applicableNameFunctions[i].Value.ArgumentTypes))
+                        if (i != j && MatchesArgumentTypesBetterThan(
+                            argumentMetadata.Select(d => d.TypeReference).ToArray(),
+                            applicableNameFunctions[j].Value.ArgumentTypes,
+                            applicableNameFunctions[i].Value.ArgumentTypes))
                         {
                             betterThanAllOthers = false;
                             break;
@@ -555,7 +560,7 @@ namespace Microsoft.OData.UriParser
         /// function signatures for temporal
         /// </summary>
         /// <returns>temporal function signatures for temporal for add</returns>
-        private static IEnumerable<FunctionSignature> GetAdditionTermporalSignatures()
+        private static IEnumerable<FunctionSignature> GetAdditionTemporalSignatures()
         {
             yield return new FunctionSignature(new[] { EdmCoreModel.Instance.GetDateTimeOffset(false), EdmCoreModel.Instance.GetDuration(false) },
                                                new FunctionSignature.CreateArgumentTypeWithFacets[]
@@ -623,7 +628,7 @@ namespace Microsoft.OData.UriParser
         /// function signatures for temporal
         /// </summary>
         /// <returns>temporal function signatures for temporal for sub</returns>
-        private static IEnumerable<FunctionSignature> GetSubtractionTermporalSignatures()
+        private static IEnumerable<FunctionSignature> GetSubtractionTemporalSignatures()
         {
             yield return new FunctionSignature(new[] { EdmCoreModel.Instance.GetDateTimeOffset(false), EdmCoreModel.Instance.GetDuration(false) },
                                                new FunctionSignature.CreateArgumentTypeWithFacets[]
@@ -848,6 +853,219 @@ namespace Microsoft.OData.UriParser
                 {
                     return true;
                 }
+            }
+
+            return false;
+        }
+
+        /// <summary>Promotes the specified expression to the given type if necessary.</summary>
+        /// <param name="sourceNodeOrNull">The actual argument node, may be null.</param>
+        /// <param name="sourceType">The actual argument type.</param>
+        /// <param name="targetType">The required type to promote to.</param>
+        /// <returns>True if the <paramref name="sourceType"/> could be promoted; otherwise false.</returns>
+        private static bool CanPromoteNodeTo(CollectionNode sourceNodeOrNull, IEdmTypeReference sourceType, IEdmTypeReference targetType)
+        {
+            Debug.Assert(targetType != null, "targetType != null");
+
+            if (sourceType == null)
+            {
+                // Null or open collection - allow if target collection is nullable
+                return targetType.IsNullable;
+            }
+
+            IEdmCollectionTypeReference sourceCollectionType = sourceType.AsCollectionOrNull();
+            IEdmCollectionTypeReference targetCollectionType = targetType.AsCollectionOrNull();
+            if (sourceCollectionType == null || targetCollectionType == null)
+            {
+                return false;
+            }
+
+            IEdmTypeReference sourceElementType = sourceCollectionType.ElementType();
+            IEdmTypeReference targetElementType = targetCollectionType.ElementType();
+            Debug.Assert(targetElementType.IsODataPrimitiveTypeKind() || targetElementType.IsODataEnumTypeKind(),
+                "Type promotion only supported for primitive or enum collection types.");
+
+            if (sourceElementType.IsEquivalentTo(targetElementType))
+            {
+                return true;
+            }
+
+            if (CanConvertTo(null, sourceElementType, targetElementType))
+            {
+                return true;
+            }
+
+            // Allow promotion from nullable<T> to non-nullable by directly accessing underlying value.
+            if (sourceElementType.IsNullable && targetElementType.IsODataValueType())
+            {
+                // COMPAT 40: Type promotion in the product allows promotion from a nullable type to arbitrary value types
+                IEdmTypeReference nonNullableSourceType = sourceElementType.Definition.ToTypeReference(false);
+                if (CanConvertTo(null, nonNullableSourceType, targetElementType))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether a syntactic or already-semantic <see cref="QueryNode"/> can be promoted to (or is already compatible with) a target Edm type,
+        /// including support for promoting a string literal that represents a bracketed collection expression into a <see cref="CollectionConstantNode"/>.
+        /// </summary>
+        /// <param name="sourceNodeOrNull">
+        /// The source node. May be null (null literal / open property),
+        /// a <see cref="ConstantNode"/>, a <see cref="CollectionNode"/> or a <see cref="SingleValueNode"/>.
+        /// </param>
+        /// <param name="sourceType">The current (inferred or declared) Edm type reference of the source node; may be null for null/open cases.</param>
+        /// <param name="targetType">The desired Edm type reference to promote to. May be a collection or single-valued type.</param>
+        /// <returns><c>true</c> if the source can be used as (or promoted to) the target; <c>false</c> otherwise.</returns>
+        /// <remarks>
+        /// This overload centralizes promotion logic for both single and collection-valued arguments used during function overload resolution.
+        /// It defers conversion of bracketed collection text (e.g. "[1,2,3]", "['A','B']", "[]") embedded in a <see cref="ConstantNode"/> until this stage
+        /// because at this stage the target function parameter type known. Deferring to this stage makes it possible to:
+        /// 1) Correctly interpret empty collections or collections whose items are all null (which are promotable to ANY collection element type),
+        /// 2) Avoid allocating intermediate collection node variants that may later mismatch chosen overloads, and
+        /// 3) Fail early for incompatible element types (e.g. "[true,false]" when the target expects a numeric collection) without guessing.
+        /// Workflow:
+        /// 1) If the target is collection-valued:
+        ///    a) Existing <see cref="CollectionNode"/> instances delegate to collection element promotion.
+        ///    b) Null source type succeed only if the target collection type is nullable.
+        ///    c) A string <see cref="ConstantNode"/> whose literal text parses as an OData collection literal is heuristically converted via
+        ///       <see cref="TryParseCollectionConstantNode"/> and then validated against the target collection element type.
+        /// 2) If the target is single-valued, collections cannot be promoted; otherwise delegate to primitive/enum promotion rules.
+        public static bool CanPromoteNodeTo(QueryNode sourceNodeOrNull, IEdmTypeReference sourceType, IEdmTypeReference targetType)
+        {
+            Debug.Assert(targetType != null, "targetType != null");
+
+            if (targetType.IsCollection())
+            {
+                // Case 1: Source is already a CollectionNode
+                if (sourceNodeOrNull is CollectionNode || (sourceType?.IsCollection() == true))
+                {
+                    return CanPromoteNodeTo(sourceNodeOrNull as CollectionNode, sourceType, targetType);
+                }
+
+                // Case 2: Source is null or open-typed
+                if (sourceType == null)
+                {
+                    return targetType.IsNullable;
+                }
+
+                // Case 3: Source is a ConstantNode with LiteralText that could be a bracketed expression
+                if (sourceNodeOrNull is ConstantNode constantNode
+                    && sourceType.IsString()
+                    && !string.IsNullOrEmpty(constantNode.LiteralText))
+                {
+                    if (TryParseCollectionConstantNode(constantNode, targetType.AsCollection(), out CollectionConstantNode collectionConstantNode))
+                    {
+                        return CanPromoteNodeTo(
+                            collectionConstantNode,
+                            collectionConstantNode.CollectionType,
+                            targetType);
+                    }
+
+                    return false;
+                }
+
+                return false;
+            }
+
+            // Non-collection target type
+            if (sourceNodeOrNull is CollectionNode)
+            {
+                // Cannot promote a collection to a single value
+                return false;
+            }
+
+            return CanPromoteNodeTo(sourceNodeOrNull as SingleValueNode, sourceType, targetType);
+        }
+
+        /// <summary>
+        /// Attempts to parse and wrap a string literal contained in a <see cref="ConstantNode"/> as an OData collection literal,
+        /// producing a semantic <see cref="CollectionConstantNode"/> suitable for later promotion against a target collection type.
+        /// </summary>
+        /// <param name="constantNode">The original constant node whose <c>LiteralText</c> may represent a bracketed collection (e.g. "[1,2,3]", "['A','B']", "[]").</param>
+        /// <param name="targetType">The function parameter or expected <see cref="IEdmCollectionTypeReference"/> the caller is trying to promote to.</param>
+        /// <param name="collectionConstantNode">Outputs the constructed collection constant node when parsing succeeds; null otherwise.</param>
+        /// <returns><c>true</c> if parsing produced an <see cref="ODataCollectionValue"/> and a corresponding <see cref="CollectionConstantNode"/>;
+        /// <c>false</c> if parsing fails or the literal is not a collection.</returns>
+        /// <remarks>
+        /// Parsing is delegated to <see cref="ODataUriUtils.ConvertFromUriLiteral(string,ODataVersion,IEdmModel,IEdmTypeReference)"/>
+        /// using heuristic typing (no model supplied) to deserialize the bracketed expression.
+        /// If the literal represents an empty collection or all items are null, we cannot infer an element type from content;
+        /// the collection can be promoted to ANY element type,
+        /// so we construct a <see cref="CollectionConstantNode"/> using the caller's <paramref name="targetType"/>.
+        /// If at least one non-null item exists, its CLR type is mapped to an Edm primitive type
+        /// and used to build the node's collection type. This enables early rejection of incompatible element scenarios
+        /// (e.g. string items when a numeric collection is required).
+        /// NOTE:
+        /// This transformation is intentionally performed late (during promotion) because at this stage we have the target type available to guide parsing.
+        /// Performing conversion early would require guessing or defaulting element types, making empty arrays ambiguous
+        /// and complicating overload resolution. By deferring, we align parsing outcome with the concrete expected type, simplifying validation and error messages.
+        /// </remarks>
+        public static bool TryParseCollectionConstantNode(ConstantNode constantNode, IEdmCollectionTypeReference targetType, out CollectionConstantNode collectionConstantNode)
+        {
+            Debug.Assert(constantNode != null, "constantNode != null");
+            Debug.Assert(targetType != null, "targetType != null");
+
+            collectionConstantNode = null;
+
+            // How would we reuse the result in FunctionCallBinder.TypePromoteArguments?
+            try
+            {
+                object result = ODataUriUtils.ConvertFromUriLiteral(
+                    value: constantNode.LiteralText,
+                    version: ODataVersion.V4,
+                    model: null,
+                    typeReference: null); // Parsing type reference when there's no model available results into an exception. Type will be evaluated heuristically.
+
+                if (result != null && result is ODataCollectionValue collectionValue)
+                {
+                    // NOTE: Looping through all items to determine if the items are homogeneous is potentially expensive.
+                    // We just check the first item and let an exception be thrown later if the items are not homogeneous.
+                    object collectionItem = null;
+                    bool collectionIsEmpty;
+                    using (IEnumerator<object> enumerator = collectionValue.Items.GetEnumerator())
+                    {
+                        collectionIsEmpty = !enumerator.MoveNext();
+                        if (!collectionIsEmpty)
+                        {
+                            collectionItem = enumerator.Current;
+                        }
+                    }
+
+                    if (collectionIsEmpty || (collectionItem == null && targetType.IsNullable))
+                    {
+                        // Empty collection or all items are null - can promote to any collection type
+                        collectionConstantNode = new CollectionConstantNode(collectionValue.Items, constantNode.LiteralText, targetType.AsCollection());
+
+                        return true;
+                    }
+                    
+                    if (collectionItem == null)
+                    {
+                        // First item is null but the target [collection] type is not nullable - cannot promote
+                        return false;
+                    }
+
+                    Type collectionItemType = collectionItem.GetType();
+                    IEdmTypeReference collectionItemTypeReference = EdmLibraryExtensions.GetPrimitiveTypeReference(collectionItemType);
+                    // TODO: Handle enum types
+                    if (!collectionItemTypeReference.IsPrimitive())
+                    {
+                        return false;
+                    }
+
+                    IEdmCollectionTypeReference collectionTypeReference = new EdmCollectionTypeReference(new EdmCollectionType(collectionItemTypeReference));
+                    collectionConstantNode = new CollectionConstantNode(collectionValue.Items, constantNode.LiteralText, collectionTypeReference);
+
+                    return true;
+                }
+            }
+            catch (ODataException)
+            {
+                return false;
             }
 
             return false;

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Binders/FunctionCallBinderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Binders/FunctionCallBinderTests.cs
@@ -7,10 +7,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.OData.UriParser;
-using Microsoft.OData.Edm;
-using Xunit;
 using Microsoft.OData.Core;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+using Xunit;
 
 namespace Microsoft.OData.Tests.UriParser.Binders
 {
@@ -114,11 +114,12 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public void TypePromoteArguments()
         {
             var signature = this.GetSingleSubstringFunctionSignatureForTest();
-            List<QueryNode> nodes = new List<QueryNode>()
-                                        {
-                                            new ConstantNode("Hello"),
-                                            new ConstantNode(3)
-                                        };
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new ConstantNode("Hello"), EdmCoreModel.Instance.GetString(false)),
+                (new ConstantNode(3), EdmCoreModel.Instance.GetInt32(false))
+            };
+
             FunctionCallBinder.TypePromoteArguments(signature, nodes);
             AssertSignatureTypesMatchArguments(signature, nodes);
         }
@@ -127,14 +128,15 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public void TypePromoteArgumentsWithNullLiteralExpectConvert()
         {
             var signature = this.GetSingleSubstringFunctionSignatureForTest();
-            List<QueryNode> nodes = new List<QueryNode>()
-                                        {
-                                            new ConstantNode(null),
-                                            new ConstantNode(3)
-                                        };
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new ConstantNode(null), null),
+                (new ConstantNode(3), EdmCoreModel.Instance.GetInt32(false))
+            };
+
             FunctionCallBinder.TypePromoteArguments(signature, nodes);
-            nodes[0].ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.String).Source.ShouldBeConstantQueryNode<object>(null);
-            nodes[1].ShouldBeConstantQueryNode(3);
+            nodes[0].Node.ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.String).Source.ShouldBeConstantQueryNode<object>(null);
+            nodes[1].Node.ShouldBeConstantQueryNode(3);
 
             AssertSignatureTypesMatchArguments(signature, nodes);
         }
@@ -143,14 +145,15 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public void TypePromoteAllArgumentsAreNullLiteralsExpectConvert()
         {
             var signature = this.GetSingleSubstringFunctionSignatureForTest();
-            List<QueryNode> nodes = new List<QueryNode>()
-                                        {
-                                            new ConstantNode(null),
-                                            new ConstantNode(null)
-                                        };
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new ConstantNode(null), null),
+                (new ConstantNode(null), null)
+            };
+
             FunctionCallBinder.TypePromoteArguments(signature, nodes);
-            nodes[0].ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.String).Source.ShouldBeConstantQueryNode<object>(null);
-            nodes[1].ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.Int32).Source.ShouldBeConstantQueryNode<object>(null);
+            nodes[0].Node.ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.String).Source.ShouldBeConstantQueryNode<object>(null);
+            nodes[1].Node.ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.Int32).Source.ShouldBeConstantQueryNode<object>(null);
 
             AssertSignatureTypesMatchArguments(signature, nodes);
         }
@@ -159,15 +162,16 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public void TypePromoteArgumentsWithOpenPropertyExpectConvert()
         {
             var signature = this.GetSingleSubstringFunctionSignatureForTest();
-            List<QueryNode> nodes = new List<QueryNode>()
-                                        {
-                                            new SingleValueOpenPropertyAccessNode(new ConstantNode(null), OpenPropertyName),
-                                            new ConstantNode(3)
-                                        };
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new SingleValueOpenPropertyAccessNode(new ConstantNode(null), OpenPropertyName), null),
+                (new ConstantNode(3), EdmCoreModel.Instance.GetInt32(false))
+            };
+
             FunctionCallBinder.TypePromoteArguments(signature, nodes);
-            nodes[0].ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.String)
+            nodes[0].Node.ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.String)
                     .Source.ShouldBeSingleValueOpenPropertyAccessQueryNode(OpenPropertyName);
-            nodes[1].ShouldBeConstantQueryNode(3);
+            nodes[1].Node.ShouldBeConstantQueryNode(3);
 
             AssertSignatureTypesMatchArguments(signature, nodes);
         }
@@ -176,15 +180,16 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public void TypePromoteAllArgumentsAreOpenPropertiesExpectConvert()
         {
             var signature = this.GetSingleSubstringFunctionSignatureForTest();
-            List<QueryNode> nodes = new List<QueryNode>()
-                                        {
-                                            new SingleValueOpenPropertyAccessNode(new ConstantNode(null), OpenPropertyName),
-                                            new SingleValueOpenPropertyAccessNode(new ConstantNode(null), OpenPropertyName + "1")
-                                        };
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new SingleValueOpenPropertyAccessNode(new ConstantNode(null), OpenPropertyName), null),
+                (new SingleValueOpenPropertyAccessNode(new ConstantNode(null), OpenPropertyName + "1"), null)
+            };
+
             FunctionCallBinder.TypePromoteArguments(signature, nodes);
-            nodes[0].ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.String)
+            nodes[0].Node.ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.String)
                     .Source.ShouldBeSingleValueOpenPropertyAccessQueryNode(OpenPropertyName);
-            nodes[1].ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.Int32)
+            nodes[1].Node.ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.Int32)
                     .Source.ShouldBeSingleValueOpenPropertyAccessQueryNode(OpenPropertyName + "1");
 
             AssertSignatureTypesMatchArguments(signature, nodes);
@@ -194,15 +199,16 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public void TypePromoteArgumentsAreNullAndOpenPropertiesExpectConvert()
         {
             var signature = this.GetSingleSubstringFunctionSignatureForTest();
-            List<QueryNode> nodes = new List<QueryNode>()
-                                        {
-                                            new SingleValueOpenPropertyAccessNode(new ConstantNode(null), OpenPropertyName),
-                                            new ConstantNode(null)
-                                        };
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new SingleValueOpenPropertyAccessNode(new ConstantNode(null), OpenPropertyName), null),
+                (new ConstantNode(null), null)
+            };
+
             FunctionCallBinder.TypePromoteArguments(signature, nodes);
-            nodes[0].ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.String)
+            nodes[0].Node.ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.String)
                     .Source.ShouldBeSingleValueOpenPropertyAccessQueryNode(OpenPropertyName);
-            nodes[1].ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.Int32)
+            nodes[1].Node.ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.Int32)
                     .Source.ShouldBeConstantQueryNode<object>(null);
 
             AssertSignatureTypesMatchArguments(signature, nodes);
@@ -212,11 +218,12 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public void TypePromoteArgumentsMismatchedTypes()
         {
             var signature = this.GetSingleSubstringFunctionSignatureForTest();
-            List<QueryNode> nodes = new List<QueryNode>()
-                                        {
-                                            new ConstantNode(3),
-                                            new ConstantNode("Hello"),
-                                        };
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new ConstantNode(3), EdmCoreModel.Instance.GetInt32(false)),
+                (new ConstantNode("Hello"), EdmCoreModel.Instance.GetString(false)  ),
+            };
+
             Action a = () => FunctionCallBinder.TypePromoteArguments(signature, nodes);
             a.Throws<ODataException>(Error.Format(SRResources.MetadataBinder_CannotConvertToType, "Edm.Int32", "Edm.String"));
         }
@@ -225,11 +232,12 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public void TypePromoteArgumentsMismatchedTypeAndNull()
         {
             var signature = this.GetSingleSubstringFunctionSignatureForTest();
-            List<QueryNode> nodes = new List<QueryNode>()
-                                        {
-                                            new ConstantNode(null),
-                                            new ConstantNode("Hello")
-                                        };
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new ConstantNode(null), null),
+                (new ConstantNode("Hello"), EdmCoreModel.Instance.GetString(false))
+            };
+
             Action a = () => FunctionCallBinder.TypePromoteArguments(signature, nodes);
             a.Throws<ODataException>(Error.Format(SRResources.MetadataBinder_CannotConvertToType, "Edm.String", "Edm.Int32"));
         }
@@ -239,11 +247,12 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public void TypePromoteArgumentsMismatchedTypeAndOpenProperty()
         {
             var signature = this.GetSingleSubstringFunctionSignatureForTest();
-            List<QueryNode> nodes = new List<QueryNode>()
-                                        {
-                                            new SingleValueOpenPropertyAccessNode(new ConstantNode(null), "SomeProperty"),
-                                            new ConstantNode("Hello")
-                                        };
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new SingleValueOpenPropertyAccessNode(new ConstantNode(null), "SomeProperty"), null),
+                (new ConstantNode("Hello"), EdmCoreModel.Instance.GetString(false))
+            };
+
             Action a = () => FunctionCallBinder.TypePromoteArguments(signature, nodes);
             a.Throws<ODataException>(Error.Format(SRResources.MetadataBinder_CannotConvertToType, "Edm.String", "Edm.Int32"));
         }
@@ -258,10 +267,11 @@ namespace Microsoft.OData.Tests.UriParser.Binders
             FunctionSignatureWithReturnType signature =
                 new FunctionSignatureWithReturnType(EdmCoreModel.Instance.GetDouble(false), enumTypeRef);
 
-            List<QueryNode> nodes = new List<QueryNode>()
-                                        {
-                                            new ConstantNode("MyValue", "MyNS.MyName'MyValue'", enumTypeRef),
-                                        };
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new ConstantNode("MyValue", "MyNS.MyName'MyValue'", enumTypeRef), enumTypeRef)
+            };
+
             FunctionCallBinder.TypePromoteArguments(signature, nodes);
             AssertSignatureTypesMatchArguments(signature, nodes);
         }
@@ -270,33 +280,20 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         [Fact]
         public void EnsureArgumentsAreSingleValue()
         {
-            List<QueryNode> argumentNodes =
-               new List<QueryNode>()
-                {
-                    new ConstantNode(new DateTimeOffset(2012, 11, 19, 1, 1, 1, 1, new TimeSpan(0, 1, 1, 0)))
-                };
-            var result = FunctionCallBinder.ValidateArgumentsAreSingleValue("year", argumentNodes);
-            Assert.Single(result);
-            Assert.Equal("Edm.DateTimeOffset", result[0].TypeReference.Definition.FullTypeName());
-        }
+            List<QueryNode> argumentNodes = new List<QueryNode>()
+            {
+                new ConstantNode(new DateTimeOffset(2012, 11, 19, 1, 1, 1, 1, new TimeSpan(0, 1, 1, 0)))
+            };
 
-        [Fact]
-        public void ShouldThrowWhenArgumentsAreNotSingleValue()
-        {
-            List<QueryNode> argumentNodes =
-                new List<QueryNode>()
-                {
-                    new CollectionNavigationNode(HardCodedTestModel.GetDogsSet(), HardCodedTestModel.GetDogMyPeopleNavProp(), new EdmPathExpression("MyDog"))
-                };
-
-            Action bind = () => FunctionCallBinder.ValidateArgumentsAreSingleValue("year", argumentNodes);
-            bind.Throws<ODataException>(Error.Format(SRResources.MetadataBinder_FunctionArgumentNotSingleValue, "year"));
+            var result = FunctionCallBinder.ValidateArgumentNodes("year", argumentNodes);
+            var constantNode = Assert.IsType<ConstantNode>(Assert.Single(result).Node);
+            Assert.Equal("Edm.DateTimeOffset", constantNode.TypeReference.Definition.FullTypeName());
         }
 
         [Fact]
         public void EnsureArgumentsAreSingleValueNoArguments()
         {
-            var result = FunctionCallBinder.ValidateArgumentsAreSingleValue("year", new List<QueryNode>());
+            var result = FunctionCallBinder.ValidateArgumentNodes("year", new List<QueryNode>());
             Assert.Empty(result);
         }
 
@@ -304,19 +301,20 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         [Fact]
         public void MatchArgumentsToSignatureDuplicateSignature()
         {
-            List<QueryNode> argumentNodes =
-                new List<QueryNode>()
-                {
-                    new ConstantNode("grr" ),
-                    new ConstantNode("grr" )
-                };
             var nameSignatures = this.GetDuplicateIndexOfFunctionSignatureForTest();
 
             Action bind = () => FunctionCallBinder.MatchSignatureToUriFunction(
                 "IndexOf",
-                new SingleValueNode[] {
-                     new SingleValuePropertyAccessNode(new ConstantNode(null)/*parent*/, new EdmStructuralProperty(new EdmEntityType("MyNamespace", "MyEntityType"), "myPropertyName", argumentNodes[0].GetEdmTypeReference())),
-                     new SingleValuePropertyAccessNode(new ConstantNode(null)/*parent*/, new EdmStructuralProperty(new EdmEntityType("MyNamespace", "MyEntityType"), "myPropertyName", argumentNodes[1].GetEdmTypeReference()))},
+                new (QueryNode Node, IEdmTypeReference TypeReference)[] {
+                     (new SingleValuePropertyAccessNode(
+                         new ConstantNode(null)/*parent*/,
+                         new EdmStructuralProperty(new EdmEntityType("MyNamespace", "MyEntityType"), "myPropertyName", EdmCoreModel.Instance.GetString(false))),
+                         EdmCoreModel.Instance.GetString(false)),
+                     (new SingleValuePropertyAccessNode(
+                         new ConstantNode(null)/*parent*/,
+                         new EdmStructuralProperty(new EdmEntityType("MyNamespace", "MyEntityType"), "myPropertyName", EdmCoreModel.Instance.GetString(false))),
+                         EdmCoreModel.Instance.GetString(false))
+                },
                 nameSignatures);
 
             bind.Throws<ODataException>(Error.Format(SRResources.MetadataBinder_NoApplicableFunctionFound,
@@ -327,17 +325,13 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         [Fact]
         public void MatchArgumentsToSignature()
         {
-            List<QueryNode> argumentNodes =
-                new List<QueryNode>()
-                {
-                    new ConstantNode(new DateTimeOffset(2012, 11, 19, 1, 1, 1, 1, new TimeSpan(0, 1, 1, 0)))
-                };
+            var argumentNodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new ConstantNode(new DateTimeOffset(2012, 11, 19, 1, 1, 1, 1, new TimeSpan(0, 1, 1, 0))), EdmCoreModel.Instance.GetDateTimeOffset(false))
+            };
             var signatures = this.GetHardCodedYearFunctionSignatureForTest();
 
-            var result = FunctionCallBinder.MatchSignatureToUriFunction(
-                "year",
-                argumentNodes.Select(s => (SingleValueNode)s).ToArray(),
-                signatures);
+            var result = FunctionCallBinder.MatchSignatureToUriFunction("year", argumentNodes, signatures);
 
             Assert.Equal("Edm.Int32", result.Value.ReturnType.FullName());
             Assert.Equal("Edm.DateTimeOffset", result.Value.ArgumentTypes[0].FullName());
@@ -346,16 +340,15 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         [Fact]
         public void MatchArgumentsToSignatureNoMatchEmpty()
         {
-            List<QueryNode> argumentNodes =
-                new List<QueryNode>()
-                {
-                    new ConstantNode(4)
-                };
-
             Action bind = () => FunctionCallBinder.MatchSignatureToUriFunction(
                 "year",
-                new SingleValueNode[] {
-                     new SingleValuePropertyAccessNode(new ConstantNode(null)/*parent*/, new EdmStructuralProperty(new EdmEntityType("MyNamespace", "MyEntityType"), "myPropertyName", argumentNodes[0].GetEdmTypeReference()))},
+                new (QueryNode Node, IEdmTypeReference TypeReference)[]
+                {
+                     (new SingleValuePropertyAccessNode(
+                         new ConstantNode(null)/*parent*/,
+                         new EdmStructuralProperty(new EdmEntityType("MyNamespace", "MyEntityType"), "myPropertyName", EdmCoreModel.Instance.GetInt32(false))),
+                         EdmCoreModel.Instance.GetInt32(false))
+                },
                 new List<KeyValuePair<string, FunctionSignatureWithReturnType>>());
 
             bind.Throws<ODataException>(Error.Format(SRResources.MetadataBinder_NoApplicableFunctionFound,
@@ -366,16 +359,15 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         [Fact]
         public void MatchArgumentsToSignatureNoMatchContainsSignatures()
         {
-            List<QueryNode> argumentNodes =
-                new List<QueryNode>()
-                {
-                    new ConstantNode(4)
-                };
-
             Action bind = () => FunctionCallBinder.MatchSignatureToUriFunction(
                 "year",
-                new SingleValueNode[] {
-                     new SingleValuePropertyAccessNode(new ConstantNode(null)/*parent*/, new EdmStructuralProperty(new EdmEntityType("MyNamespace", "MyEntityType"), "myPropertyName", argumentNodes[0].GetEdmTypeReference()))},
+                new (QueryNode Node, IEdmTypeReference TypeReference)[]
+                {
+                     (new SingleValuePropertyAccessNode(
+                         new ConstantNode(null)/*parent*/,
+                         new EdmStructuralProperty(new EdmEntityType("MyNamespace", "MyEntityType"), "myPropertyName", EdmCoreModel.Instance.GetInt32(false))),
+                         EdmCoreModel.Instance.GetInt32(false))
+                },
                 this.GetHardCodedYearFunctionSignatureForTest());
 
             bind.Throws<ODataException>(Error.Format(SRResources.MetadataBinder_NoApplicableFunctionFound,
@@ -390,9 +382,14 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         {
             var result = FunctionCallBinder.MatchSignatureToUriFunction(
                 "substring",
-                 new SingleValueNode[] {
-                     new SingleValuePropertyAccessNode(new ConstantNode(null)/*parent*/, new EdmStructuralProperty(new EdmEntityType("MyNamespace", "MyEntityType"), "myPropertyName", EdmCoreModel.Instance.GetString(true))),
-                     new SingleValueOpenPropertyAccessNode(new ConstantNode(null)/*parent*/, "myOpenPropertyname")}, // open property's TypeReference is null
+                 new (QueryNode Node, IEdmTypeReference TypeReference)[]
+                 {
+                     (new SingleValuePropertyAccessNode(
+                         new ConstantNode(null), /*parent*/
+                         new EdmStructuralProperty(new EdmEntityType("MyNamespace", "MyEntityType"), "myPropertyName", EdmCoreModel.Instance.GetString(true))),
+                         EdmCoreModel.Instance.GetString(true)),
+                     (new SingleValueOpenPropertyAccessNode(new ConstantNode(null)/*parent*/, "myOpenPropertyname"), null) // open property's TypeReference is null
+                 },
                  FunctionCallBinder.GetUriFunctionSignatures("substring"));
 
             FunctionSignatureWithReturnType sig = result.Value;
@@ -1396,6 +1393,268 @@ namespace Microsoft.OData.Tests.UriParser.Binders
             }
         }
 
+        [Fact]
+        public void TypePromoteArguments_CollectionPropertyAccessNode()
+        {
+            var functionSignature = new FunctionSignatureWithReturnType(
+                EdmCoreModel.Instance.GetDecimal(false),
+                EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetDecimal(false)));
+            var collectionType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(false)));
+            var overtimeHoursProperty = new EdmStructuralProperty(new EdmEntityType("NS", "Employee"), "OvertimeHours", collectionType);
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new CollectionPropertyAccessNode(new ConstantNode(null), overtimeHoursProperty), collectionType)
+            };
+
+            FunctionCallBinder.TypePromoteArguments(functionSignature, nodes);
+            var collectionPropertyAccessNode = nodes[0].Node.ShouldBeCollectionPropertyAccessQueryNode(overtimeHoursProperty);
+            // Conversion should be implicit
+            Assert.True(collectionPropertyAccessNode.CollectionType.IsEquivalentTo(EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetInt32(false))));
+            Assert.True(collectionPropertyAccessNode.ItemType.IsEquivalentTo(EdmCoreModel.Instance.GetInt32(false)));
+        }
+
+        [Fact]
+        public void TypePromoteArguments_CollectionConstantNode()
+        {
+            var functionSignature = new FunctionSignatureWithReturnType(
+                EdmCoreModel.Instance.GetInt64(false),
+                EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetInt64(false)));
+            var collectionType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(false)));
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new CollectionConstantNode(new List<object> { 1, 2, 3 }, "[1,2,3]", collectionType), collectionType)
+            };
+
+            FunctionCallBinder.TypePromoteArguments(functionSignature, nodes);
+            var collectionConstantNode = nodes[0].Node.ShouldBeCollectionConstantNode(EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetInt64(false)));
+            Assert.Equal(3, collectionConstantNode.Collection.Count);
+            collectionConstantNode.Collection[0].ShouldBeConstantQueryNode(1L);
+            collectionConstantNode.Collection[1].ShouldBeConstantQueryNode(2L);
+            collectionConstantNode.Collection[2].ShouldBeConstantQueryNode(3L);
+        }
+
+        [Fact]
+        public void TypePromoteArguments_ConstantNodeToCollectionConstantNode()
+        {
+            var functionSignature = new FunctionSignatureWithReturnType(
+                EdmCoreModel.Instance.GetInt64(false),
+                EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetInt64(false)));
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new ConstantNode("[1,2,3]", "[1,2,3]"), EdmCoreModel.Instance.GetString(false))
+            };
+
+            FunctionCallBinder.TypePromoteArguments(functionSignature, nodes);
+            var collectionConstantNode = nodes[0].Node.ShouldBeCollectionConstantNode(EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetInt64(false)));
+            Assert.Equal(3, collectionConstantNode.Collection.Count);
+            collectionConstantNode.Collection[0].ShouldBeConstantQueryNode(1L);
+            collectionConstantNode.Collection[1].ShouldBeConstantQueryNode(2L);
+            collectionConstantNode.Collection[2].ShouldBeConstantQueryNode(3L);
+        }
+
+        [Fact]
+        public void MatchSignatureToUriFunction_CollectionPropertyAccessNode()
+        {
+            var functionSignature = new FunctionSignatureWithReturnType(
+                EdmCoreModel.Instance.GetDecimal(false),
+                EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetDecimal(false)));
+            var otherFunctionSignature = new FunctionSignatureWithReturnType(
+                EdmCoreModel.Instance.GetInt32(false),
+                EdmCoreModel.Instance.GetInt32(false));
+
+            var collectionType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(false)));
+            var overtimeHoursProperty = new EdmStructuralProperty(new EdmEntityType("NS", "Employee"), "OvertimeHours", collectionType);
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new CollectionPropertyAccessNode(new ConstantNode(null), overtimeHoursProperty), collectionType)
+            };
+
+            var result = FunctionCallBinder.MatchSignatureToUriFunction(
+                "func1",
+                nodes,
+                new List<KeyValuePair<string, FunctionSignatureWithReturnType>>
+                {
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func0", functionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func1", functionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func1", otherFunctionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func2", otherFunctionSignature)
+                });
+
+            Assert.Equal("func1", result.Key);
+            Assert.Same(functionSignature, result.Value);
+            Assert.Equal("Edm.Decimal", result.Value.ReturnType.FullName());
+            Assert.Single(result.Value.ArgumentTypes);
+            Assert.Equal("Collection(Edm.Decimal)", result.Value.ArgumentTypes[0].FullName());
+        }
+
+        [Fact]
+        public void MatchSignatureToUriFunction_CollectionPropertyAccessNode_SourceTypeMatchingTargetType()
+        {
+            var functionSignature = new FunctionSignatureWithReturnType(
+                EdmCoreModel.Instance.GetDecimal(false),
+                EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetDecimal(false)));
+            var otherFunctionSignature = new FunctionSignatureWithReturnType(
+                EdmCoreModel.Instance.GetDecimal(false),
+                EdmCoreModel.Instance.GetDecimal(false));
+
+            var collectionType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetDecimal(false)));
+            var overtimeHoursProperty = new EdmStructuralProperty(new EdmEntityType("NS", "Employee"), "OvertimeHours", collectionType);
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new CollectionPropertyAccessNode(new ConstantNode(null), overtimeHoursProperty), collectionType)
+            };
+
+            var result = FunctionCallBinder.MatchSignatureToUriFunction(
+                "func1",
+                nodes,
+                new List<KeyValuePair<string, FunctionSignatureWithReturnType>>
+                {
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func0", functionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func1", functionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func1", otherFunctionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func2", otherFunctionSignature)
+                });
+
+            Assert.Equal("func1", result.Key);
+            Assert.Same(functionSignature, result.Value);
+            Assert.Equal("Edm.Decimal", result.Value.ReturnType.FullName());
+            Assert.Single(result.Value.ArgumentTypes);
+            Assert.Equal("Collection(Edm.Decimal)", result.Value.ArgumentTypes[0].FullName());
+        }
+
+        [Fact]
+        public void MatchSignatureToUriFunction_CollectionConstantNode()
+        {
+            var functionSignature = new FunctionSignatureWithReturnType(
+                EdmCoreModel.Instance.GetInt64(false),
+                EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetInt64(false)));
+            var otherFunctionSignature = new FunctionSignatureWithReturnType(
+                EdmCoreModel.Instance.GetInt32(false),
+                EdmCoreModel.Instance.GetInt32(false));
+
+            var collectionType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(false)));
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new CollectionConstantNode(new List<object> { 1, 2, 3 }, "[1,2,3]", collectionType), collectionType)
+            };
+
+            var result = FunctionCallBinder.MatchSignatureToUriFunction(
+                "func1",
+                nodes,
+                new List<KeyValuePair<string, FunctionSignatureWithReturnType>>
+                {
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func0", functionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func1", functionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func1", otherFunctionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func2", otherFunctionSignature)
+                });
+
+            Assert.Equal("func1", result.Key);
+            Assert.Same(functionSignature, result.Value);
+            Assert.Equal("Edm.Int64", result.Value.ReturnType.FullName());
+            Assert.Single(result.Value.ArgumentTypes);
+            Assert.Equal("Collection(Edm.Int64)", result.Value.ArgumentTypes[0].FullName());
+        }
+
+        [Fact]
+        public void MatchSignatureToUriFunction_ConstantNodeToCollectionConstantNode()
+        {
+            var functionSignature = new FunctionSignatureWithReturnType(
+                EdmCoreModel.Instance.GetInt64(false),
+                EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetInt64(false)));
+            var otherFunctionSignature = new FunctionSignatureWithReturnType(
+                EdmCoreModel.Instance.GetInt32(false),
+                EdmCoreModel.Instance.GetInt32(false));
+
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new ConstantNode("[1,2,3]", "[1,2,3]"), EdmCoreModel.Instance.GetString(false))
+            };
+
+            var result = FunctionCallBinder.MatchSignatureToUriFunction(
+                "func1",
+                nodes,
+                new List<KeyValuePair<string, FunctionSignatureWithReturnType>>
+                {
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func0", functionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func1", functionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func1", otherFunctionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func2", otherFunctionSignature)
+                });
+
+            Assert.Equal("func1", result.Key);
+            Assert.Same(functionSignature, result.Value);
+            Assert.Equal("Edm.Int64", result.Value.ReturnType.FullName());
+            Assert.Single(result.Value.ArgumentTypes);
+            Assert.Equal("Collection(Edm.Int64)", result.Value.ArgumentTypes[0].FullName());
+        }
+
+        [Fact]
+        public void MatchSignatureToUriFunction_ConstantNodeToCollectionConstantNode_Empty()
+        {
+            var functionSignature = new FunctionSignatureWithReturnType(
+                EdmCoreModel.Instance.GetInt64(false),
+                EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetInt64(false)));
+            var otherFunctionSignature = new FunctionSignatureWithReturnType(
+                EdmCoreModel.Instance.GetInt32(false),
+                EdmCoreModel.Instance.GetInt32(false));
+
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new ConstantNode("[]", "[]"), EdmCoreModel.Instance.GetString(false))
+            };
+
+            var result = FunctionCallBinder.MatchSignatureToUriFunction(
+                "func1",
+                nodes,
+                new List<KeyValuePair<string, FunctionSignatureWithReturnType>>
+                {
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func0", functionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func1", functionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func1", otherFunctionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func2", otherFunctionSignature)
+                });
+
+            Assert.Equal("func1", result.Key);
+            Assert.Same(functionSignature, result.Value);
+            Assert.Equal("Edm.Int64", result.Value.ReturnType.FullName());
+            Assert.Single(result.Value.ArgumentTypes);
+            Assert.Equal("Collection(Edm.Int64)", result.Value.ArgumentTypes[0].FullName());
+        }
+
+        [Fact]
+        public void MatchSignatureToUriFunction_ConstantNodeToCollectionConstantNode_SingleNullItem()
+        {
+            var functionSignature = new FunctionSignatureWithReturnType(
+                EdmCoreModel.Instance.GetInt64(false),
+                EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetInt64(true)));
+            var otherFunctionSignature = new FunctionSignatureWithReturnType(
+                EdmCoreModel.Instance.GetInt32(false),
+                EdmCoreModel.Instance.GetInt32(true));
+
+            var nodes = new (QueryNode Node, IEdmTypeReference TypeReference)[]
+            {
+                (new ConstantNode("[null]", "[null]"), EdmCoreModel.Instance.GetString(false))
+            };
+
+            var result = FunctionCallBinder.MatchSignatureToUriFunction(
+                "func1",
+                nodes,
+                new List<KeyValuePair<string, FunctionSignatureWithReturnType>>
+                {
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func0", functionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func1", functionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func1", otherFunctionSignature),
+                    new KeyValuePair<string, FunctionSignatureWithReturnType>("func2", otherFunctionSignature)
+                });
+
+            Assert.Equal("func1", result.Key);
+            Assert.Same(functionSignature, result.Value);
+            Assert.Equal("Edm.Int64", result.Value.ReturnType.FullName());
+            Assert.Single(result.Value.ArgumentTypes);
+            Assert.Equal("Collection(Edm.Int64)", result.Value.ArgumentTypes[0].FullName());
+        }
+
         private bool RunBindEndPathAsFunctionCall(string endPathIdentifier, out QueryNode functionCallNode)
         {
             var boundFunctionCallToken = new EndPathToken(endPathIdentifier, null);
@@ -1462,11 +1721,11 @@ namespace Microsoft.OData.Tests.UriParser.Binders
             return signatures[0];
         }
 
-        private static void AssertSignatureTypesMatchArguments(FunctionSignatureWithReturnType signature, List<QueryNode> nodes)
+        private static void AssertSignatureTypesMatchArguments(FunctionSignatureWithReturnType signature, (QueryNode Node, IEdmTypeReference Type)[] nodes)
         {
             for (int i = 0; i < signature.ArgumentTypes.Length; ++i)
             {
-                Assert.Same(MetadataBindingUtils.GetEdmType(nodes[i]), signature.ArgumentTypes[i].Definition);
+                Assert.Same(MetadataBindingUtils.GetEdmType(nodes[i].Node), signature.ArgumentTypes[i].Definition);
             }
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/NodeAssertions.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/NodeAssertions.cs
@@ -195,7 +195,7 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.NotNull(node);
             var functionCallNode = Assert.IsType<CollectionResourceFunctionCallNode>(node);
             functionCallNode.Functions.ContainExactly(operationImports);
-            return  functionCallNode;
+            return functionCallNode;
         }
 
         public static SingleValuePropertyAccessNode ShouldBeSingleValuePropertyAccessQueryNode(this QueryNode node, IEdmProperty expectedProperty)
@@ -238,7 +238,7 @@ namespace Microsoft.OData.Tests.UriParser
             var propertyAccessNode = Assert.IsType<CountNode>(node);
             return propertyAccessNode;
         }
-        
+
         public static CollectionOpenPropertyAccessNode ShouldBeCollectionOpenPropertyAccessQueryNode(this QueryNode node, string expectedPropertyName)
         {
             Assert.NotNull(node);
@@ -374,7 +374,7 @@ namespace Microsoft.OData.Tests.UriParser
 
             Assert.Equal(enumType.FullTypeName(), enumNode.TypeReference.FullName());
             Assert.Equal(value, ((ODataEnumValue)enumNode.Value).Value);
-      
+
             return enumNode;
         }
 
@@ -425,6 +425,14 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.Equal(literalText, uriTemplate.LiteralText);
             Assert.True(uriTemplate.ExpectedType.IsEquivalentTo(expectedType));
             return uriTemplate;
+        }
+
+        public static CollectionConstantNode ShouldBeCollectionConstantNode(this QueryNode node, IEdmCollectionTypeReference expectedCollectionTypeReference)
+        {
+            Assert.NotNull(node);
+            var collectionConstantNode = Assert.IsType<CollectionConstantNode>(node);
+            Assert.True(collectionConstantNode.CollectionType.IsEquivalentTo(expectedCollectionTypeReference));
+            return collectionConstantNode;
         }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriFunctionsParsingTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriFunctionsParsingTests.cs
@@ -1,0 +1,396 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataUriFunctionsParsingTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+using Xunit;
+
+namespace Microsoft.OData.Tests.UriParser
+{
+    /// <summary>
+    /// Unit tests for Uri functions parsing tests.
+    /// </summary>
+    public class ODataUriFunctionsParsingTests : IDisposable
+    {
+        private const string CalculateBenefitFunctionName = "calculateBenefit";
+        private const string CalculateTaxablePayFunctionName = "calculateTaxablePay";
+        private const string CalculateAdjustedSalaryFunctionName = "calculateAdjustedSalary";
+        private const string CalculateSalaryBandFunctionName = "calculateSalaryBand";
+
+        private EdmModel model;
+
+        public ODataUriFunctionsParsingTests()
+        {
+            InitializeModel();
+
+            // Function with single-valued parameter
+            CustomUriFunctions.AddCustomUriFunction(
+                CalculateBenefitFunctionName,
+                new FunctionSignatureWithReturnType(
+                    EdmCoreModel.Instance.GetDecimal(false),
+                    EdmCoreModel.Instance.GetDecimal(false)));
+            // Function with collection-valued parameter
+            CustomUriFunctions.AddCustomUriFunction(
+                CalculateTaxablePayFunctionName,
+                new FunctionSignatureWithReturnType(
+                    EdmCoreModel.Instance.GetDecimal(false),
+                    EdmCoreModel.Instance.GetDecimal(false),
+                    EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetDecimal(false))));
+            // Function with single-valued literal parameter
+            CustomUriFunctions.AddCustomUriFunction(
+                CalculateAdjustedSalaryFunctionName,
+                new FunctionSignatureWithReturnType(
+                    EdmCoreModel.Instance.GetDecimal(false),
+                    EdmCoreModel.Instance.GetDecimal(false),
+                    EdmCoreModel.Instance.GetDecimal(false)));
+            // Function with collection-valued literal parameter
+            CustomUriFunctions.AddCustomUriFunction(
+                CalculateSalaryBandFunctionName,
+                new FunctionSignatureWithReturnType(
+                    EdmCoreModel.Instance.GetDecimal(false),
+                    EdmCoreModel.Instance.GetDecimal(false),
+                    EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetDecimal(false))));
+        }
+
+        public void Dispose()
+        {
+            CustomUriFunctions.RemoveCustomUriFunction(CalculateBenefitFunctionName);
+            CustomUriFunctions.RemoveCustomUriFunction(CalculateTaxablePayFunctionName);
+            CustomUriFunctions.RemoveCustomUriFunction(CalculateAdjustedSalaryFunctionName);
+            CustomUriFunctions.RemoveCustomUriFunction(CalculateSalaryBandFunctionName);
+        }
+
+        [Fact]
+        public void ParseUri_WithEdmFunctionInCompute_ParsesSelectAndComputeSuccessfully()
+        {
+            // Arrange
+            var odataUriParser = new ODataUriParser(
+                this.model,
+                new Uri("http://tempuri.org"),
+                new Uri($"http://tempuri.org/Employees(1)?$compute=Default.CalculateBonus(salary=Salary)%20as%20Bonus&$select=Name,Salary,Bonus"));
+
+            // Act
+            var parsedResult = odataUriParser.ParseUri();
+
+            // Assert
+            Assert.NotNull(parsedResult);
+            Assert.NotNull(parsedResult.Compute);
+            var computedItems = parsedResult.Compute.ComputedItems.ToList();
+            Assert.Single(computedItems);
+            var bonusItem = computedItems[0];
+            Assert.Equal("Bonus", bonusItem.Alias);
+            var funcCall = Assert.IsType<SingleValueFunctionCallNode>(bonusItem.Expression);
+            Assert.Equal("Default.CalculateBonus", funcCall.Name);
+            var parameters = funcCall.Parameters.ToList();
+            Assert.Single(parameters);
+            var salaryParameter = Assert.IsType<NamedFunctionParameterNode>(parameters[0]);
+            var salaryParameterValue = Assert.IsType<SingleValuePropertyAccessNode>(salaryParameter.Value);
+            Assert.Equal("Salary", salaryParameterValue.Property.Name);
+            Assert.NotNull(parsedResult.SelectAndExpand);
+            var selectedProps = parsedResult.SelectAndExpand.SelectedItems.OfType<PathSelectItem>().Select(i => i.SelectedPath.LastSegment.Identifier).ToList();
+            Assert.Contains("Name", selectedProps);
+            Assert.Contains("Salary", selectedProps);
+            Assert.Contains("Bonus", selectedProps);
+        }
+
+        [Fact]
+        public void ParseUri_WithEdmFunctionInCompute_CollectionValuedParameter_ParsesSelectAndComputeSuccessfully()
+        {
+            // Arrange
+            var odataUriParser = new ODataUriParser(
+                this.model,
+                new Uri("http://tempuri.org"),
+                new Uri($"http://tempuri.org/Employees(1)?$compute=Default.CalculateOvertimePay(salary=Salary,overtimeHours=OvertimeHours)%20as%20OvertimePay&$select=Name,Salary,OvertimePay"));
+
+            // Act
+            var parsedResult = odataUriParser.ParseUri();
+
+            // Assert
+            Assert.NotNull(parsedResult);
+            Assert.NotNull(parsedResult.Compute);
+            var computedItems = parsedResult.Compute.ComputedItems.ToList();
+            Assert.Single(computedItems);
+            var overtimePayItem = computedItems[0];
+            Assert.Equal("OvertimePay", overtimePayItem.Alias);
+            var funcCall = Assert.IsType<SingleValueFunctionCallNode>(overtimePayItem.Expression);
+            Assert.Equal("Default.CalculateOvertimePay", funcCall.Name);
+            var parameters = funcCall.Parameters.ToList();
+            Assert.Equal(2, parameters.Count);
+            var salaryParameter = Assert.IsType<NamedFunctionParameterNode>(parameters[0]);
+            var overtimeHoursParameter = Assert.IsType<NamedFunctionParameterNode>(parameters[1]);
+            var salaryParameterValue = Assert.IsType<SingleValuePropertyAccessNode>(salaryParameter.Value);
+            var overtimeHoursParameterValue = Assert.IsType<CollectionPropertyAccessNode>(overtimeHoursParameter.Value);
+            Assert.Equal("Salary", salaryParameterValue.Property.Name);
+            Assert.Equal("OvertimeHours", overtimeHoursParameterValue.Property.Name);
+            Assert.NotNull(parsedResult.SelectAndExpand);
+            var selectedProps = parsedResult.SelectAndExpand.SelectedItems.OfType<PathSelectItem>().Select(i => i.SelectedPath.LastSegment.Identifier).ToList();
+            Assert.Contains("Name", selectedProps);
+            Assert.Contains("Salary", selectedProps);
+            Assert.Contains("OvertimePay", selectedProps);
+        }
+
+        [Fact]
+        public void ParseUri_WithEdmFunctionInCompute_SingleValuedLiteral_ParsesSelectAndComputeSuccessfully()
+        {
+            // Arrange
+            var odataUriParser = new ODataUriParser(
+                this.model,
+                new Uri("http://tempuri.org"),
+                new Uri($"http://tempuri.org/Employees(1)?$compute=Default.GetScore(maxScore=100)%20as%20Score&$select=Name,Score"));
+
+            // Act
+            var parsedResult = odataUriParser.ParseUri();
+
+            // Assert
+            Assert.NotNull(parsedResult);
+            Assert.NotNull(parsedResult.Compute);
+            var computedItems = parsedResult.Compute.ComputedItems.ToList();
+            Assert.Single(computedItems);
+            var scoreItem = computedItems[0];
+            Assert.Equal("Score", scoreItem.Alias);
+            var funcCall = Assert.IsType<SingleValueFunctionCallNode>(scoreItem.Expression);
+            Assert.Equal("Default.GetScore", funcCall.Name);
+            var parameters = funcCall.Parameters.ToList();
+            Assert.Single(parameters);
+            var maxScoreParameter = Assert.IsType<NamedFunctionParameterNode>(parameters[0]);
+            var maxScoreLiteral = Assert.IsType<ConstantNode>(maxScoreParameter.Value);
+            Assert.Equal(100, maxScoreLiteral.Value);
+            Assert.NotNull(parsedResult.SelectAndExpand);
+            var selectedProps = parsedResult.SelectAndExpand.SelectedItems.OfType<PathSelectItem>().Select(i => i.SelectedPath.LastSegment.Identifier).ToList();
+            Assert.Contains("Name", selectedProps);
+            Assert.Contains("Score", selectedProps);
+        }
+
+        [Fact]
+        public void ParseUri_WithEdmFunctionInCompute_CollectionValuedLiteral_ParsesSelectAndComputeSuccessfully()
+        {
+            // Arrange
+            var odataUriParser = new ODataUriParser(
+                this.model,
+                new Uri("http://tempuri.org"),
+                new Uri($"http://tempuri.org/Employees(1)?$compute=Default.GetRating(scale=[1,2,3,4,5])%20as%20Rating&$select=Name,Rating"));
+            
+            // Act
+            var parsedResult = odataUriParser.ParseUri();
+            
+            // Assert
+            Assert.NotNull(parsedResult);
+            Assert.NotNull(parsedResult.Compute);
+            var computedItems = parsedResult.Compute.ComputedItems.ToList();
+            Assert.Single(computedItems);
+            var ratingItem = computedItems[0];
+            Assert.Equal("Rating", ratingItem.Alias);
+            var funcCall = Assert.IsType<SingleValueFunctionCallNode>(ratingItem.Expression);
+            Assert.Equal("Default.GetRating", funcCall.Name);
+            var parameters = funcCall.Parameters.ToList();
+            Assert.Single(parameters);
+            var scaleParameter = Assert.IsType<NamedFunctionParameterNode>(parameters[0]);
+            var scaleLiteral = Assert.IsType<ConstantNode>(scaleParameter.Value);
+            Assert.Equal("[1,2,3,4,5]", scaleLiteral.LiteralText);
+            Assert.NotNull(parsedResult.SelectAndExpand);
+            var selectedProps = parsedResult.SelectAndExpand.SelectedItems.OfType<PathSelectItem>().Select(i => i.SelectedPath.LastSegment.Identifier).ToList();
+            Assert.Contains("Name", selectedProps);
+            Assert.Contains("Rating", selectedProps);
+        }
+
+        [Fact]
+        public void ParseUri_WithCustomFunctionInCompute_ParsesSelectAndComputeSuccessfully()
+        {
+            // Arrange
+            var odataUriParser = new ODataUriParser(
+                this.model,
+                new Uri("http://tempuri.org"),
+                new Uri($"http://tempuri.org/Employees?$compute=calculateBenefit(Salary)%20as%20Benefit&$select=Name,Salary,Benefit"));
+
+            // Act
+            var parsedResult = odataUriParser.ParseUri();
+
+            // Assert
+            Assert.NotNull(parsedResult);
+            Assert.NotNull(parsedResult.Compute);
+            var computedItems = parsedResult.Compute.ComputedItems.ToList();
+            Assert.Single(computedItems);
+            var benefitItem = computedItems[0];
+            Assert.Equal("Benefit", benefitItem.Alias);
+            var funcCall = Assert.IsType<SingleValueFunctionCallNode>(benefitItem.Expression);
+            Assert.Equal("calculateBenefit", funcCall.Name);
+            var parameters = funcCall.Parameters.ToList();
+            Assert.Single(parameters);
+            var salaryParameter = Assert.IsType<SingleValuePropertyAccessNode>(parameters[0]);
+            Assert.Equal("Salary", salaryParameter.Property.Name);
+            var selectedProps = parsedResult.SelectAndExpand.SelectedItems.OfType<PathSelectItem>().Select(i => i.SelectedPath.LastSegment.Identifier).ToList();
+            Assert.Contains("Name", selectedProps);
+            Assert.Contains("Salary", selectedProps);
+            Assert.Contains("Benefit", selectedProps);
+        }
+
+        [Fact]
+        public void ParseUri_WithCustomFunctionInCompute_CollectionValuedParameter_ParsesSelectAndComputeSuccessfully()
+        {
+            // Arrange
+            var odataUriParser = new ODataUriParser(
+                this.model,
+                new Uri("http://tempuri.org"),
+                new Uri($"http://tempuri.org/Employees?$compute=calculateTaxablePay(Salary,OvertimeHours)%20as%20TaxablePay&$select=Name,Salary,TaxablePay"));
+
+            // Act
+            var parsedResult = odataUriParser.ParseUri();
+
+            // Assert
+            Assert.NotNull(parsedResult);
+            Assert.NotNull(parsedResult.Compute);
+            var computedItems = parsedResult.Compute.ComputedItems.ToList();
+            Assert.Single(computedItems);
+            var taxablePayItem = computedItems[0];
+            Assert.Equal("TaxablePay", taxablePayItem.Alias);
+            var funcCall = Assert.IsType<SingleValueFunctionCallNode>(taxablePayItem.Expression);
+            Assert.Equal("calculateTaxablePay", funcCall.Name);
+            var parameters = funcCall.Parameters.ToList();
+            Assert.Equal(2, parameters.Count);
+            var salaryParameter = Assert.IsType<SingleValuePropertyAccessNode>(parameters[0]);
+            Assert.Equal("Salary", salaryParameter.Property.Name);
+            var overtimeHoursParameter = Assert.IsType<CollectionPropertyAccessNode>(parameters[1]);
+            Assert.Equal("OvertimeHours", overtimeHoursParameter.Property.Name);
+            var selectedProps = parsedResult.SelectAndExpand.SelectedItems.OfType<PathSelectItem>().Select(i => i.SelectedPath.LastSegment.Identifier).ToList();
+            Assert.Contains("Name", selectedProps);
+            Assert.Contains("Salary", selectedProps);
+            Assert.Contains("TaxablePay", selectedProps);
+        }
+
+        [Fact]
+        public void ParseUri_WithCustomFunctionInCompute_SingleValuedLiteral_ParsesSelectAndComputeSuccessfully()
+        {
+            // Arrange
+            var odataUriParser = new ODataUriParser(
+                this.model,
+                new Uri("http://tempuri.org"),
+                new Uri($"http://tempuri.org/Employees?$compute=calculateAdjustedSalary(Salary,1%2E5)%20as%20AdjustedSalary&$select=Name,AdjustedSalary"));
+
+            // Act
+            var parsedResult = odataUriParser.ParseUri();
+
+            // Assert
+            Assert.NotNull(parsedResult);
+            Assert.NotNull(parsedResult.Compute);
+            var computedItems = parsedResult.Compute.ComputedItems.ToList();
+            Assert.Single(computedItems);
+            var adjustedSalaryItem = computedItems[0];
+            Assert.Equal("AdjustedSalary", adjustedSalaryItem.Alias);
+            var funcCall = Assert.IsType<SingleValueFunctionCallNode>(adjustedSalaryItem.Expression);
+            Assert.Equal("calculateAdjustedSalary", funcCall.Name);
+            var parameters = funcCall.Parameters.ToList();
+            Assert.Equal(2, parameters.Count);
+            var salaryParameter = Assert.IsType<SingleValuePropertyAccessNode>(parameters[0]);
+            Assert.Equal("Salary", salaryParameter.Property.Name);
+            var literalParameter = Assert.IsType<ConstantNode>(parameters[1]);
+            Assert.Equal(1.5m, literalParameter.Value);
+            var selectedProps = parsedResult.SelectAndExpand.SelectedItems.OfType<PathSelectItem>().Select(i => i.SelectedPath.LastSegment.Identifier).ToList();
+            Assert.Contains("Name", selectedProps);
+            Assert.Contains("AdjustedSalary", selectedProps);
+        }
+
+        [Fact]
+        public void ParseUri_WithCustomFunctionInCompute_CollectionValuedLiteral_ParsesSelectAndComputeSuccessfully()
+        {
+            // Arrange
+            var odataUriParser = new ODataUriParser(
+                this.model,
+                new Uri("http://tempuri.org"),
+                new Uri($"http://tempuri.org/Employees?$compute=calculateSalaryBand(Salary,[5000,7000,9000])%20as%20SalaryBand&$select=Name,SalaryBand"));
+
+            // Act
+            var parsedResult = odataUriParser.ParseUri();
+
+            // Assert
+            Assert.NotNull(parsedResult);
+            Assert.NotNull(parsedResult.Compute);
+            var computedItems = parsedResult.Compute.ComputedItems.ToList();
+            Assert.Single(computedItems);
+            var salaryBandItem = computedItems[0];
+            Assert.Equal("SalaryBand", salaryBandItem.Alias);
+            var funcCall = Assert.IsType<SingleValueFunctionCallNode>(salaryBandItem.Expression);
+            Assert.Equal("calculateSalaryBand", funcCall.Name);
+            var parameters = funcCall.Parameters.ToList();
+            Assert.Equal(2, parameters.Count);
+            var salaryParameter = Assert.IsType<SingleValuePropertyAccessNode>(parameters[0]);
+            Assert.Equal("Salary", salaryParameter.Property.Name);
+            var literalParameter = Assert.IsType<CollectionConstantNode>(parameters[1]);
+            var bandValues = literalParameter.Collection.OfType<ConstantNode>().Select(n => (decimal)n.Value).ToList();
+            Assert.Equal(new decimal[] { 5000m, 7000m, 9000m }, bandValues);
+            var selectedProps = parsedResult.SelectAndExpand.SelectedItems.OfType<PathSelectItem>().Select(i => i.SelectedPath.LastSegment.Identifier).ToList();
+            Assert.Contains("Name", selectedProps);
+            Assert.Contains("SalaryBand", selectedProps);
+        }
+
+        private void InitializeModel()
+        {
+            this.model = new EdmModel();
+            var employeeEntityType = this.model.AddEntityType("NS", "Employee");
+            var idProperty = employeeEntityType.AddStructuralProperty("ID", EdmCoreModel.Instance.GetInt32(false));
+            employeeEntityType.AddKeys(idProperty);
+            employeeEntityType.AddStructuralProperty("Name", EdmCoreModel.Instance.GetString(false));
+            employeeEntityType.AddStructuralProperty("Salary", EdmCoreModel.Instance.GetDecimal(false));
+            employeeEntityType.AddStructuralProperty("OvertimeHours", EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetDecimal(false)));
+            this.model.AddElement(employeeEntityType);
+
+            // Function with single-valued parameter
+            var calculateBonusEdmFunction = new EdmFunction(
+                "Default",
+                "CalculateBonus",
+                EdmCoreModel.Instance.GetDecimal(false),
+                true,
+                null,
+                false);
+            calculateBonusEdmFunction.AddParameter("bindingParameter", new EdmEntityTypeReference(employeeEntityType, false));
+            calculateBonusEdmFunction.AddParameter("salary", EdmCoreModel.Instance.GetDecimal(false));
+            this.model.AddElement(calculateBonusEdmFunction);
+
+            // Function with collection-valued parameter
+            var calculateOvertimePayEdmFunction = new EdmFunction(
+                "Default",
+                "CalculateOvertimePay",
+                EdmCoreModel.Instance.GetDecimal(false),
+                true,
+                null,
+                false);
+            calculateOvertimePayEdmFunction.AddParameter("bindingParameter", new EdmEntityTypeReference(employeeEntityType, false));
+            calculateOvertimePayEdmFunction.AddParameter("salary", EdmCoreModel.Instance.GetDecimal(false));
+            calculateOvertimePayEdmFunction.AddParameter("overtimeHours", EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetDecimal(false)));
+            this.model.AddElement(calculateOvertimePayEdmFunction);
+
+            // Function with single-valued literal parameter
+            var getScoreEdmFunction = new EdmFunction(
+                "Default",
+                "GetScore",
+                EdmCoreModel.Instance.GetInt32(false),
+                true,
+                null,
+                false);
+            getScoreEdmFunction.AddParameter("bindingParameter", new EdmEntityTypeReference(employeeEntityType, false));
+            getScoreEdmFunction.AddParameter("maxScore", EdmCoreModel.Instance.GetInt32(false));
+            this.model.AddElement(getScoreEdmFunction);
+
+            // Function with collection-valued literal parameter
+            var getRatingsEdmFunction = new EdmFunction(
+                "Default",
+                "GetRating",
+                EdmCoreModel.Instance.GetInt32(false),
+                true,
+                null,
+                false);
+            getRatingsEdmFunction.AddParameter("bindingParameter", new EdmEntityTypeReference(employeeEntityType, false));
+            getRatingsEdmFunction.AddParameter("scale", EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetInt32(false)));
+            this.model.AddElement(getRatingsEdmFunction);
+
+            var container = this.model.AddEntityContainer("Default", "Container");
+            container.AddEntitySet("Employees", employeeEntityType);
+            container.AddFunctionImport("CalculateBonus", calculateBonusEdmFunction);
+            container.AddFunctionImport("CalculateOvertimePay", calculateOvertimePayEdmFunction);
+        }
+    }
+}

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/CollectionConstantNodeTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/CollectionConstantNodeTests.cs
@@ -9,6 +9,7 @@ using Microsoft.OData.UriParser;
 using Microsoft.OData.Edm;
 using Xunit;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.OData.Tests.UriParser.SemanticAst
 {
@@ -17,11 +18,14 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
     /// </summary>
     public class CollectionConstantNodeTests
     {
+        private static IEdmCollectionTypeReference CollectionOf(IEdmTypeReference element) =>
+            new EdmCollectionTypeReference(new EdmCollectionType(element));
+
         [Fact]
         public void NumberCollectionThroughLiteralTokenIsSetCorrectly()
         {
             const string text = "(1,2,3)";
-            var expectedType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(false)));
+            var expectedType = CollectionOf(EdmCoreModel.Instance.GetInt32(false));
             object collection = ODataUriConversionUtils.ConvertFromCollectionValue("[1,2,3]", HardCodedTestModel.TestModel, expectedType);
             LiteralToken literalToken = new LiteralToken(collection, text, expectedType);
 
@@ -41,7 +45,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         public void StringCollectionThroughLiteralTokenIsSetCorrectly()
         {
             const string text = "('abc','def','ghi')";
-            var expectedType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetString(true)));
+            var expectedType = CollectionOf(EdmCoreModel.Instance.GetString(true));
             object collection = ODataUriConversionUtils.ConvertFromCollectionValue("['abc','def','ghi']", HardCodedTestModel.TestModel, expectedType);
             LiteralToken literalToken = new LiteralToken(collection, text, expectedType);
 
@@ -61,7 +65,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         public void NullableCollectionTypeSetsConstantNodeCorrectly()
         {
             const string text = "('abc','def', null)";
-            var expectedType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetString(true)));
+            var expectedType = CollectionOf(EdmCoreModel.Instance.GetString(true));
             object collection = ODataUriConversionUtils.ConvertFromCollectionValue("['abc','def', null]", HardCodedTestModel.TestModel, expectedType);
             LiteralToken literalToken = new LiteralToken(collection, text, expectedType);
 
@@ -81,7 +85,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         public void TextIsSetCorrectly()
         {
             const string text = "(1,2,3)";
-            var expectedType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(false)));
+            var expectedType = CollectionOf(EdmCoreModel.Instance.GetInt32(false));
             object collection = ODataUriConversionUtils.ConvertFromCollectionValue("[1,2,3]", HardCodedTestModel.TestModel, expectedType);
             LiteralToken literalToken = new LiteralToken(collection, text, expectedType);
 
@@ -95,7 +99,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         public void ItemTypeIsSetCorrectly()
         {
             const string text = "(1,2,3)";
-            var expectedType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(false)));
+            var expectedType = CollectionOf(EdmCoreModel.Instance.GetInt32(false));
             object collection = ODataUriConversionUtils.ConvertFromCollectionValue("[1,2,3]", HardCodedTestModel.TestModel, expectedType);
             LiteralToken literalToken = new LiteralToken(collection, text, expectedType);
 
@@ -109,7 +113,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         public void CollectionTypeIsSetCorrectly()
         {
             const string text = "(1,2,3)";
-            var expectedType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(false)));
+            var expectedType = CollectionOf(EdmCoreModel.Instance.GetInt32(false));
             object collection = ODataUriConversionUtils.ConvertFromCollectionValue("[1,2,3]", HardCodedTestModel.TestModel, expectedType);
             LiteralToken literalToken = new LiteralToken(collection, text, expectedType);
 
@@ -123,7 +127,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         public void KindIsSetCorrectly()
         {
             const string text = "(1,2,3)";
-            var expectedType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(false)));
+            var expectedType = CollectionOf(EdmCoreModel.Instance.GetInt32(false));
             object collection = ODataUriConversionUtils.ConvertFromCollectionValue("[1,2,3]", HardCodedTestModel.TestModel, expectedType);
             LiteralToken literalToken = new LiteralToken(collection, text, expectedType);
 
@@ -137,11 +141,11 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         public void NullValueShouldThrow()
         {
             const string text = "(1,2,3)";
-            var expectedType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(false)));
+            var expectedType = CollectionOf(EdmCoreModel.Instance.GetInt32(false));
             object collection = ODataUriConversionUtils.ConvertFromCollectionValue("[1,2,3]", HardCodedTestModel.TestModel, expectedType);
             LiteralToken literalToken = new LiteralToken(collection, text, expectedType);
 
-            Action target = () => new CollectionConstantNode(null, text, expectedType);
+            Action target = () => new CollectionConstantNode((List<object>)null, text, expectedType);
             Assert.Throws<ArgumentNullException>("objectCollection", target);
         }
 
@@ -149,7 +153,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         public void NullLiteralTextShouldThrow()
         {
             const string text = "(1,2,3)";
-            var expectedType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(false)));
+            var expectedType = CollectionOf(EdmCoreModel.Instance.GetInt32(false));
             object collection = ODataUriConversionUtils.ConvertFromCollectionValue("[1,2,3]", HardCodedTestModel.TestModel, expectedType);
             LiteralToken literalToken = new LiteralToken(collection, text, expectedType);
 
@@ -161,12 +165,114 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         public void NullCollectionTypeShouldThrow()
         {
             const string text = "(1,2,3)";
-            var expectedType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(false)));
+            var expectedType = CollectionOf(EdmCoreModel.Instance.GetInt32(false));
             object collection = ODataUriConversionUtils.ConvertFromCollectionValue("[1,2,3]", HardCodedTestModel.TestModel, expectedType);
             LiteralToken literalToken = new LiteralToken(collection, text, expectedType);
 
             Action target = () => new CollectionConstantNode((literalToken.Value as ODataCollectionValue)?.Items, text, null);
             Assert.Throws<ArgumentNullException>("collectionType", target);
+        }
+
+        [Fact]
+        public void Constructor_WithConstantNodeCollection_ValidCollectionType_DoesNotThrow()
+        {
+            // Arrange
+            const string literalText = "(1, null, 2)";
+            var nodeType = EdmCoreModel.Instance.GetInt32(false);
+            var collectionType = CollectionOf(nodeType);
+            var nodes = new List<ConstantNode>
+            {
+                new ConstantNode(1, "1", nodeType),
+                null,
+                new ConstantNode(2, "2", nodeType)
+            };
+
+            // Act
+            var result = new CollectionConstantNode(nodes, literalText, collectionType);
+
+            // Assert
+            Assert.Same(collectionType, result.CollectionType);
+            Assert.Equal(literalText, result.LiteralText);
+            Assert.Equal(3, result.Collection.Count);
+        }
+
+        [Fact]
+        public void Constructor_WithConstantNodeCollection_NullCollectionType_ThrowsArgumentNull()
+        {
+            // Arrange
+            const string literalText = "(1, null, 2)";
+            var nodeType = EdmCoreModel.Instance.GetInt32(false);
+            var nodes = new List<ConstantNode>
+            {
+                new ConstantNode(1, "1", nodeType),
+                null,
+                new ConstantNode(2, "2", nodeType)
+            };
+
+            // Act
+            var ex = Assert.Throws<ArgumentNullException>(() => new CollectionConstantNode(nodes, literalText, collectionType: null));
+
+            // Assert
+            Assert.Equal("collectionType", ex.ParamName);
+            Assert.Contains("collectionType", ex.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Constructor_WithConstantNodeCollection_NullNodeCollection_ThrowsArgumentNull()
+        {
+            // Arrange
+            const string literalText = "(1,2,3)";
+            var nodeType = EdmCoreModel.Instance.GetInt32(false);
+            var collectionType = CollectionOf(nodeType);
+
+            // Act
+            var ex = Assert.Throws<ArgumentNullException>(() => new CollectionConstantNode((List<ConstantNode>)null, literalText, collectionType));
+
+            // Assert
+            Assert.Equal("nodeCollection", ex.ParamName);
+            Assert.Contains("nodeCollection", ex.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Constructor_WithConstantNodeCollection_NullLiteralText_ThrowsArgumentNull()
+        {
+            // Arrange
+            var nodeType = EdmCoreModel.Instance.GetInt32(false);
+            var collectionType = CollectionOf(nodeType);
+            var nodes = new List<ConstantNode>
+            {
+                new ConstantNode(1, "1", nodeType),
+                new ConstantNode(2, "2", nodeType),
+                new ConstantNode(3, "3", nodeType)
+            };
+
+            // Act
+            var ex = Assert.Throws<ArgumentNullException>(() => new CollectionConstantNode(nodes, literalText: null, collectionType));
+
+            // Assert
+            Assert.Equal("literalText", ex.ParamName);
+            Assert.Contains("literalText", ex.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Constructor_WithConstantNodeCollection_EmptyLiteralText_ThrowsArgumentNull()
+        {
+            // Arrange
+            var nodeType = EdmCoreModel.Instance.GetInt32(false);
+            var collectionType = CollectionOf(nodeType);
+            var nodes = new List<ConstantNode>
+            {
+                new ConstantNode(1, "1", nodeType),
+                new ConstantNode(2, "2", nodeType),
+                new ConstantNode(3, "3", nodeType)
+            };
+
+            // Act
+            var ex = Assert.Throws<ArgumentNullException>(() => new CollectionConstantNode(nodes, literalText: string.Empty, collectionType));
+
+            // Assert
+            Assert.Equal("literalText", ex.ParamName);
+            Assert.Contains("literalText", ex.Message, StringComparison.Ordinal);
         }
 
         private static void VerifyCollectionConstantNode(IList<ConstantNode> actual, ConstantNode[] expected)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3385.*

### Description

This pull request adds first-class support for passing collection-valued properties and collection-valued literals as parameters to functions invoked inside the `$compute` query option, and fixes a parse-order defect that prevented selecting a computed property in `$select` when defined via `$compute`.

#### Before these changes:
- Functions used in `$compute` could only reliably accept single-valued parameters (primitive/scalar).
- Supplying a collection-valued property caused an exception to be thrown.
- Supplying a collection-valued literal (e.g. `[1,2,3]`) was not consistently recognized as a semantic collection.
- `$select` referencing a newly introduced alias from `$compute` (e.g. `&$select=Name,Bonus`) could throw, because `$select/$expand` was parsed before `$compute`, so the alias and function call hadn’t been materialized yet.

#### Key enhancements

1. Collection-valued property parameters in `$compute`
   - You can now pass a collection-valued structural property directly to a custom function (registered via `CustomUriFunctions.AddCustomUriFunction`) or model function inside `$compute`.
   - Example: `$compute=calculateTaxablePay(Salary,OvertimeHours) as TaxablePay&$select=Name,Salary,TaxablePay`.

2. Collection-valued literal parameters
   - Functions invoked in `$compute` can accept a bracketed collection literal as a parameter.
   - Example: `$$compute=calculateSalaryBand(Salary,[5000,7000,9000]) as SalaryBand&$select=Name,SalaryBand`.
   - Literal parsing supports numeric sequences.

3. Edm function collection parameters
   - Edm functions registered accept collection-valued arguments (properties or literals) the same way as custom URI functions.
   - Example: `$compute=Default.CalculateOvertimePay(salary=Salary,overtimeHours=OvertimeHours) as OvertimePay&$select=Name,Salary,OvertimePay`.
   - Example: `$compute=Default.GetRating(scale=[1,2,3,4,5]) as Rating&$select=Name,Rating`.

4. Parse order fix in `ODataUriParser.ParseUri`
   - `ParseCompute()` is now invoked before `ParseSelectAndExpand()`.
   - This ensures computed aliases are available when `$select` is processed, eliminating the previous exception when selecting a computed property.

#### Internal changes

- Function call binding extended to recognize and type-promote collection arguments coming from:
  - Collection-valued properties.
  - Bracketed collection literals in function parameter lists.
- Type promotion utilities updated to interpret bracketed collection literal text only when the target parameter is a collection.
- Ordering change in `ParseUri` prevents premature `$select` binding on non-existent aliases.
- Metadata binding utilities enhanced to convert element types in collection constants where necessary.

#### Backward compatibility

- Existing queries without collection-valued parameters in `$compute` are unaffected.
- The revised call order (`ParseCompute` before `ParseSelectExpand`) only resolves previously failing scenarios; no semantic regressions expected.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

- Update to AspNetCoreOData to take advantage of this change
