### PR TITLE
Fixes #3441: Remove EnableUntypedCollection and related untyped value reading

### DIFF
--- a/src/Microsoft.OData.Client/ODataMessageReadingHelper.cs
+++ b/src/Microsoft.OData.Client/ODataMessageReadingHelper.cs
@@ -47,10 +47,6 @@ namespace Microsoft.OData.Client
             settings.BaseUri = this.responseInfo.BaseUriResolver.BaseUriOrNull;
             settings.MaxProtocolVersion = CommonUtil.ConvertToODataVersion(this.responseInfo.MaxProtocolVersion);
 
-            // we are defaulting to having untyped collections enabled because we assume that untyped properties are primitive in the materializer, meaning that if we
-            // receive a collection of untyped values, the materializer will throw an exception if the reader labeled it as a just untyped
-            settings.EnableUntypedCollections = true;
-
             if (!this.responseInfo.ThrowOnUndeclaredPropertyForNonOpenType)
             {
                 settings.Validations &= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;

--- a/src/Microsoft.OData.Core/Json/JsonReaderExtensions.cs
+++ b/src/Microsoft.OData.Core/Json/JsonReaderExtensions.cs
@@ -284,71 +284,6 @@ namespace Microsoft.OData.Json
             }
         }
 
-        /// <summary>
-        /// Reads the elements in a JSON array and parses them as <see cref="ODataUntypedValue"/>s
-        /// </summary>
-        /// <param name="jsonReader">The <see cref="IJsonReader"/> that the collection of untyped values should be read from</param>
-        /// <returns>The untyped values in the JSON array in <paramref name="jsonReader"/></returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="jsonReader"/> is <see langword="null"/></exception>
-        /// <exception cref="ODataException">
-        /// Thrown if the <see cref="IJsonReader.NodeType"/> of <paramref name="jsonReader"/> is not <see cref="JsonNodeType.StartArray"/> or the JSON that
-        /// <paramref name="jsonReader"/> is reading is not well-formed
-        /// </exception>
-        internal static IEnumerable<ODataUntypedValue> ReadUntypedCollectionValues(this IJsonReader jsonReader)
-        {
-            if (jsonReader == null)
-            {
-                throw new ArgumentNullException(nameof(jsonReader));
-            }
-
-            return jsonReader.ReadUntypedCollectionValuesIterator();
-        }
-
-        /// <summary>
-        /// Reads the elements in a JSON array and parses them as <see cref="ODataUntypedValue"/>s
-        /// </summary>
-        /// <param name="jsonReader">
-        /// The <see cref="IJsonReader"/> that the collection of untyped values should be read from; assumed to not be <see langword="null"/>
-        /// </param>
-        /// <returns>The untyped values in the JSON array in <paramref name="jsonReader"/></returns>
-        /// <exception cref="ODataException">
-        /// Thrown if the <see cref="IJsonReader.NodeType"/> of <paramref name="jsonReader"/> is not <see cref="JsonNodeType.StartArray"/> or the JSON that
-        /// <paramref name="jsonReader"/> is reading is not well-formed
-        /// </exception>
-        private static IEnumerable<ODataUntypedValue> ReadUntypedCollectionValuesIterator(this IJsonReader jsonReader)
-        {
-            jsonReader.ReadStartArray();
-
-            while (jsonReader.NodeType != JsonNodeType.EndArray)
-            {
-                yield return jsonReader.ReadAsUntypedOrNullValueImplementation();
-            }
-
-            jsonReader.ReadEndArray();
-        }
-
-        internal static ODataValue ReadAsUntypedOrNullValue(this IJsonReader jsonReader)
-        {
-            return jsonReader.ReadAsUntypedOrNullValueImplementation();
-        }
-
-        /// <summary>
-        /// Reads the entirety of the next JSON value (primitive, object or array) in <paramref name="jsonReader"/> as an <see cref="ODataUntypedValue"/>
-        /// </summary>
-        /// <param name="jsonReader">The <see cref="JsonReader"/> to read from.</param>
-        /// <returns>The <see cref="ODataUntypedValue"/> that represents the value read from <paramref name="jsonReader"/></returns>
-        /// <exception cref="ODataException">Thrown if the JSON that <paramref name="jsonReader"/> is reading is not well-formed</exception>
-        private static ODataUntypedValue ReadAsUntypedOrNullValueImplementation(this IJsonReader jsonReader)
-        {
-            StringBuilder builder = new StringBuilder();
-            jsonReader.SkipValue(builder);
-            Debug.Assert(builder.Length > 0, "builder.Length > 0");
-            return new ODataUntypedValue()
-            {
-                RawValue = builder.ToString(),
-            };
-        }
-
         internal static ODataValue ReadODataValue(this IJsonReader jsonReader)
         {
             if (jsonReader.NodeType == JsonNodeType.PrimitiveValue)
@@ -393,10 +328,8 @@ namespace Microsoft.OData.Json
 
                 return collectionValue;
             }
-            else
-            {
-                return jsonReader.ReadAsUntypedOrNullValue();
-            }
+
+            throw CreateException(Error.Format(SRResources.JsonReaderExtensions_UnexpectedNodeDetected, "PrimitiveValue|StartObject|StartArray", jsonReader.NodeType));
         }
 
         /// <summary>
@@ -923,7 +856,7 @@ namespace Microsoft.OData.Json
                     return jsonReader.ReadODataCollectionValueAsync();
 
                 default:
-                    return jsonReader.ReadAsUntypedOrNullValueAsync();
+                    throw CreateException(Error.Format(SRResources.JsonReaderExtensions_UnexpectedNodeDetected, "PrimitiveValue|StartObject|StartArray", jsonReader.NodeType));
             }
         }
 

--- a/src/Microsoft.OData.Core/Json/ODataJsonDeserializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonDeserializer.cs
@@ -899,17 +899,7 @@ namespace Microsoft.OData.Json
         {
             // Read over the name.
             this.JsonReader.Read();
-            object annotationValue;
-            if (this.JsonReader.NodeType != JsonNodeType.PrimitiveValue)
-            {
-                annotationValue = this.JsonReader.ReadAsUntypedOrNullValue();
-            }
-            else
-            {
-                annotationValue = this.JsonReader.GetValue();
-                this.JsonReader.SkipValue();
-            }
-
+            object annotationValue = this.JsonReader.ReadODataValue();
             return annotationValue;
         }
 

--- a/src/Microsoft.OData.Core/Json/ODataJsonPropertyAndValueDeserializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonPropertyAndValueDeserializer.cs
@@ -537,23 +537,16 @@ namespace Microsoft.OData.Json
                 return readerNestedResourceInfo;
             }
 
-            if (!(payloadTypeReference is IEdmUntypedTypeReference))
-            {
-                this.JsonReader.AssertNotBuffering();
-                propertyValue = this.ReadNonEntityValueImplementation(
-                    outerPayloadTypeName,
-                    payloadTypeReference,
-                    /*propertyAndAnnotationCollector*/ null,
-                    /*collectionValidator*/ null,
-                    false, // validateNullValue
-                    isTopLevelPropertyValue,
-                    insideResourceValue,
-                    propertyName);
-            }
-            else
-            {
-                propertyValue = this.JsonReader.ReadAsUntypedOrNullValue();
-            }
+            this.JsonReader.AssertNotBuffering();
+            propertyValue = this.ReadNonEntityValueImplementation(
+                outerPayloadTypeName,
+                payloadTypeReference,
+                /*propertyAndAnnotationCollector*/ null,
+                /*collectionValidator*/ null,
+                false, // validateNullValue
+                isTopLevelPropertyValue,
+                insideResourceValue,
+                propertyName);
 
             this.JsonReader.AssertNotBuffering();
             Debug.Assert(
@@ -2044,7 +2037,7 @@ namespace Microsoft.OData.Json
                         break;
 
                     case EdmTypeKind.Untyped:
-                        result = this.JsonReader.ReadAsUntypedOrNullValue();
+                        result = this.JsonReader.ReadODataValue();
                         break;
 
                     default:

--- a/src/Microsoft.OData.Core/Json/ODataJsonResourceDeserializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonResourceDeserializer.cs
@@ -1618,36 +1618,18 @@ namespace Microsoft.OData.Json
                 }
             }
 
-            if (!(payloadTypeReference is IEdmUntypedTypeReference))
-            {
-                this.JsonReader.AssertNotBuffering();
-                propertyValue = this.ReadNonEntityValue(
-                    outerPayloadTypeName,
-                    payloadTypeReference,
-                    /*propertyAndAnnotationCollector*/ null,
-                    /*collectionValidator*/ null,
-                    /*validateNullValue*/ true,
-                    /*isTopLevelPropertyValue*/ false,
-                    /*insideResourceValue*/ false,
-                    propertyName,
-                    /*isDynamicProperty*/true);
-            }
-            else
-            {
-                if (base.MessageReaderSettings.EnableUntypedCollections && this.JsonReader.NodeType == JsonNodeType.StartArray)
-                {
-                    propertyValue = new ODataCollectionValue()
-                    {
-                        TypeAnnotation = new ODataTypeAnnotation(EdmUntypedStructuredType.Instance.FullName, EdmUntypedStructuredType.Instance),
-                        TypeName = EdmUntypedStructuredType.Instance.FullName,
-                        Items = this.JsonReader.ReadUntypedCollectionValues().ToList(),
-                    };
-                }
-                else
-                {
-                    propertyValue = this.JsonReader.ReadAsUntypedOrNullValue();
-                }
-            }
+            // Primitive property or collection of primitive property.
+            this.JsonReader.AssertNotBuffering();
+            propertyValue = this.ReadNonEntityValue(
+                outerPayloadTypeName,
+                payloadTypeReference,
+                /*propertyAndAnnotationCollector*/ null,
+                /*collectionValidator*/ null,
+                /*validateNullValue*/ true,
+                /*isTopLevelPropertyValue*/ false,
+                /*insideResourceValue*/ false,
+                propertyName,
+                /*isDynamicProperty*/true);
 
             ValidationUtils.ValidateOpenPropertyValue(propertyName, propertyValue);
             AddResourceProperty(resourceState, propertyName, propertyValue);

--- a/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
@@ -151,12 +151,6 @@ namespace Microsoft.OData
         public bool EnableCharactersCheck { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not an untyped property that contains a collection should be considered untyped, or collection of untyped
-        /// elements; when enabled, such properties will be treated as a collection of untyped elements
-        /// </summary>
-        public bool EnableUntypedCollections { get; set; } = false;
-
-        /// <summary>
         /// Gets or sets the maximum OData protocol version the reader should accept and understand.
         /// </summary>
         /// <returns>The maximum OData protocol version the reader should accept and understand.</returns>
@@ -310,7 +304,6 @@ namespace Microsoft.OData
             this.ReadAsStreamFunc = other.ReadAsStreamFunc;
             this.ArrayPool = other.ArrayPool;
             this.EnablePropertyNameCaseInsensitive = other.EnablePropertyNameCaseInsensitive;
-            this.EnableUntypedCollections = other.EnableUntypedCollections;
             this.EnableReadingKeyAsSegment = other.EnableReadingKeyAsSegment;
             this.EnableReadingODataAnnotationWithoutPrefix = other.EnableReadingODataAnnotationWithoutPrefix;
         }

--- a/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -2496,8 +2496,6 @@ virtual Microsoft.OData.UriParser.SelectItemTranslator<T>.Translate(Microsoft.OD
 virtual Microsoft.OData.UriParser.TypeFacetsPromotionRules.GetPromotedPrecision(int? left, int? right) -> int?
 virtual Microsoft.OData.UriParser.TypeFacetsPromotionRules.GetPromotedScale(int? left, int? right) -> int?
 virtual Microsoft.OData.UriParser.UriPathParser.ParsePathIntoSegments(System.Uri fullUri, System.Uri serviceBaseUri) -> System.Collections.Generic.ICollection<string>
-Microsoft.OData.ODataMessageReaderSettings.EnableUntypedCollections.get -> bool
-Microsoft.OData.ODataMessageReaderSettings.EnableUntypedCollections.set -> void
 static Microsoft.OData.UriParser.ODataPathExtensions.EdmType(this Microsoft.OData.UriParser.ODataPath path) -> Microsoft.OData.Edm.IEdmTypeReference
 static Microsoft.OData.UriParser.ODataPathExtensions.IsCollection(this Microsoft.OData.UriParser.ODataPath path) -> bool
 static Microsoft.OData.UriParser.ODataPathExtensions.NavigationSource(this Microsoft.OData.UriParser.ODataPath path) -> Microsoft.OData.Edm.IEdmNavigationSource

--- a/test/UnitTests/Microsoft.OData.Client.Tests/DataServiceContextHttpClientHandlerProviderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/DataServiceContextHttpClientHandlerProviderTests.cs
@@ -38,11 +38,6 @@ namespace Microsoft.OData.Client.Tests
 
         private const string PersonNameValue = "John Doe";
 
-        /// <summary>
-        /// Asserts that a dynamic property which represents a collection of untyped values throws an exception when the
-        /// <see cref="ODataMessageReaderSettings.EnableUntypedCollections"/> behavior flag is not enabled, and that the exception is not present when the flag is
-        /// enabled
-        /// </summary>
         [Fact]
         public void DynamicPropertyCollectionOfUntypedValues()
         { 
@@ -88,19 +83,33 @@ namespace Microsoft.OData.Client.Tests
                     (uri, set, handlerProvider) =>
                     {
                         var directoryDataService = new DirectoryDataService(rootUri);
+                        string name = null;
+                        IList<object> alternativeSecurityIds = null;
+                        directoryDataService.Configurations.ResponsePipeline.OnFeedStarted(args =>
+                        {
+                            Assert.NotNull(name);
+                            Assert.Equal("alternativeSecurityIds", name);
+                            Assert.Null(alternativeSecurityIds);
+                            alternativeSecurityIds = new List<object>();
+                        });
+                        directoryDataService.Configurations.ResponsePipeline.OnNestedResourceInfoStarted(arg =>
+                        {
+                            name = arg.Link.Name;
+                        });
                         directoryDataService.HttpClientFactory = provider;
 
-                        directoryDataService.AddObject(entitySet, new User());
+                        var nameQuery = new DataServiceQuerySingle<User>(directoryDataService, "users/080a1a0e-71bf-4582-b141-fd61bdd35a40");
+                        var user = nameQuery.GetValue();
 
-                        return directoryDataService;
+                        Assert.NotNull(name);
+                        Assert.Equal("alternativeSecurityIds", name);
+                        Assert.NotNull(alternativeSecurityIds);
+                        user.DynamicProperties[name] = alternativeSecurityIds;
+
+                          return directoryDataService;
                     };
 
-                var context = createRequestForEntityWithDynamicCollectionOfUntypedValues(rootUri, entitySet, provider);
-
-                // when enabled, the exception should go away and we should receive an actual repsonse
-                context.Configurations.ResponsePipeline.OnMessageReaderSettingsCreated(args => args.Settings.EnableUntypedCollections = true);
-                var response = context.SaveChanges();
-                Assert.True(response.First().StatusCode >= 200 && response.First().StatusCode < 300);
+                 createRequestForEntityWithDynamicCollectionOfUntypedValues(rootUri, entitySet, provider);
             }
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
@@ -1029,7 +1029,6 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.Json
                 {
                     ShouldIncludeAnnotation = (annotationName) => true,
                     Validations = ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType,
-                    EnableUntypedCollections = true, // Sam: This configuration looks unnecessary? We should consider to remove this configuration when removing/obsolote 'ODataUntypedValue'
                 });
 
             Assert.Equal(2, entry.Properties.Count());
@@ -1085,7 +1084,6 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.Json
             {
                 ShouldIncludeAnnotation = (annotationName) => true,
                 Validations = ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType,
-                EnableUntypedCollections = true,// Sam: This configuration looks unnecessary? We should consider to remove this configuration when removing/obsolote 'ODataUntypedValue'. https://github.com/OData/odata.net/issues/3441
             });
 
             Assert.Equal(2, entry.Properties.Count());

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerUndeclaredTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerUndeclaredTests.cs
@@ -1237,7 +1237,6 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.Json
                 {
                     ShouldIncludeAnnotation = (annotationName) => true,
                     Validations = ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType,
-                    EnableUntypedCollections = true, // Sam: This configuration looks unnecessary? We should consider to remove this configuration when removing/obsolote 'ODataUntypedValue'
                 });
 
             Assert.Equal(2, entry.Properties.Count());
@@ -1293,7 +1292,6 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.Json
             {
                 ShouldIncludeAnnotation = (annotationName) => true,
                 Validations = ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType,
-                EnableUntypedCollections = true, // Sam: This configuration looks unnecessary? We should consider to remove this configuration when removing/obsolote 'ODataUntypedValue'
             });
 
             Assert.Equal(2, entry.Properties.Count());


### PR DESCRIPTION
… reading

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3441.*

'EnableUntypedCollection ' enables to read the collection as 'Collection(ODataUntypedValue)`.

Since, ODL 9.x reads all kind of data as its structured type, not as RawString in ODataUntypedValue.

For There's no scenario to use 'EnableUntypedCollection'.

This PR is to remove it and its related reading codes.

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
