### PR TITLE
Enable instance annotations for null value nested resource or without value nested resource

### DIFF
--- a/src/Microsoft.OData.Core/Json/ODataJsonPropertyAndValueDeserializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonPropertyAndValueDeserializer.cs
@@ -524,11 +524,13 @@ namespace Microsoft.OData.Json
                 ValidateExpandedNestedResourceInfoPropertyValue(this.JsonReader, isCollection, propertyName, payloadTypeReference);
                 if (isCollection)
                 {
+                    // Sam: Unclear that since it's an undeclared property, why call 'ReadExpandedResourceSetNestedResourceInfo' to tread it as navigation property, not call 'ReadNonExpandedResourceSetNestedResourceInfo'?
                     readerNestedResourceInfo =
-                        ReadExpandedResourceSetNestedResourceInfo(resourceState, null, payloadTypeReference.ToStructuredType(), propertyName, /*isDeltaResourceSet*/ false);
+                        ReadExpandedResourceSetNestedResourceInfo(resourceState, null, payloadTypeReference.ToStructuredType(), propertyName, isDeltaResourceSet: false, this.MessageReaderSettings);
                 }
                 else
                 {
+                    // Sam: Unclear that since it's an undeclared property, why call 'ReadExpandedResourceNestedResourceInfo' to tread it as navigation property, not call 'ReadNonExpandedResourceNestedResourceInfo'?
                     readerNestedResourceInfo = ReadExpandedResourceNestedResourceInfo(resourceState, null, propertyName, payloadTypeReference.ToStructuredType(), this.MessageReaderSettings);
                 }
 
@@ -606,7 +608,7 @@ namespace Microsoft.OData.Json
         }
 
         /// <summary>
-        /// Reads non-expanded nested resource set.
+        /// Reads non-expanded (complex) nested resource set.
         /// </summary>
         /// <param name="resourceState">The state of the reader for resource to read.</param>
         /// <param name="collectionProperty">The collection of complex property for which to read the nested resource info. null for undeclared property.</param>
@@ -628,6 +630,8 @@ namespace Microsoft.OData.Json
                 IsCollection = true,
                 IsComplex = true
             };
+
+            AttachPropertyAnnotationsToNestedResourceInfo(resourceState, nestedResourceInfo);
 
             ODataResourceSet expandedResourceSet = CreateCollectionResourceSet(resourceState, propertyName);
             return ODataJsonReaderNestedResourceInfo.CreateResourceSetReaderNestedResourceInfo(nestedResourceInfo, collectionProperty, nestedResourceType, expandedResourceSet);
@@ -656,13 +660,36 @@ namespace Microsoft.OData.Json
                 IsComplex = true
             };
 
-            // Check the odata.type annotation for the complex property, it should show inside the complex object.
-            if (ValidateDataPropertyTypeNameAnnotation(resourceState.PropertyAndAnnotationCollector, nestedResourceInfo.Name) != null)
-            {
-                throw new ODataException(Error.Format(SRResources.ODataJsonPropertyAndValueDeserializer_ComplexValueWithPropertyTypeAnnotation, ODataAnnotationNames.ODataType));
-            }
+            // Here's old logic: If a complex nested resource has `odata.type` property annotation, then throw exception, it says the annotation should be inside complex object.
+            // It doesn't make sense now since the complex nested resoruce value could be null , in that case the `odata.type` annotation has to be outside the complex object.
+            AttachPropertyAnnotationsToNestedResourceInfo(resourceState, nestedResourceInfo);
 
             return ODataJsonReaderNestedResourceInfo.CreateResourceReaderNestedResourceInfo(nestedResourceInfo, complexProperty, nestedResourceType);
+        }
+
+        protected static void AttachPropertyAnnotationsToNestedResourceInfo(IODataJsonReaderResourceState resourceState, ODataNestedResourceInfo nestedResourceInfo)
+        {
+            Debug.Assert(resourceState != null, "resourceState != null");
+            Debug.Assert(nestedResourceInfo != null, "nestedResourceInfo != null");
+
+            foreach (KeyValuePair<string, object> odataAnnotation
+                    in resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations(nestedResourceInfo.Name))
+            {
+                if (string.Equals(odataAnnotation.Key, "odata.type", StringComparison.Ordinal)
+                    || string.Equals(odataAnnotation.Key, "type", StringComparison.Ordinal))
+                {
+                    nestedResourceInfo.TypeAnnotation = new ODataTypeAnnotation((string)odataAnnotation.Value);
+                }
+                else
+                {
+                    nestedResourceInfo.InstanceAnnotations.Add(new ODataInstanceAnnotation(odataAnnotation.Key, odataAnnotation.Value.ToODataValue(), true));
+                }
+            }
+
+            foreach (KeyValuePair<string, object> instanceAnnotation in resourceState.PropertyAndAnnotationCollector.GetCustomPropertyAnnotations(nestedResourceInfo.Name))
+            {
+                nestedResourceInfo.InstanceAnnotations.Add(new ODataInstanceAnnotation(instanceAnnotation.Key, instanceAnnotation.Value.ToODataValue()));
+            }
         }
 
         /// <summary>
@@ -714,13 +741,25 @@ namespace Microsoft.OData.Json
                         break;
 
                     default:
-                        if (messageReaderSettings.ThrowOnUndeclaredPropertyForNonOpenType)
+                        if (messageReaderSettings.ThrowOnUnexpectedODataPropertyAnnotationOnNavigationProperty)
                         {
                             throw new ODataException(Error.Format(SRResources.ODataJsonResourceDeserializer_UnexpectedExpandedSingletonNavigationLinkPropertyAnnotation, nestedResourceInfo.Name, propertyAnnotation.Key));
                         }
 
+                        // Let's save the property annotations into the nested resource info, therefore we can support the 'null' value nested resource as:
+                        // {
+                        //     "NestedResource@NS.InstanceAnnotation" : "anyvalue",
+                        //     "NestedResource": null
+                        // }
+                        nestedResourceInfo.InstanceAnnotations.Add(new ODataInstanceAnnotation(propertyAnnotation.Key, propertyAnnotation.Value.ToODataValue(), true));
+
                         break;
                 }
+            }
+
+            foreach (KeyValuePair<string, object> instanceAnnotation in resourceState.PropertyAndAnnotationCollector.GetCustomPropertyAnnotations(nestedResourceInfo.Name))
+            {
+                nestedResourceInfo.InstanceAnnotations.Add(new ODataInstanceAnnotation(instanceAnnotation.Key, instanceAnnotation.Value.ToODataValue()));
             }
 
             return ODataJsonReaderNestedResourceInfo.CreateResourceReaderNestedResourceInfo(nestedResourceInfo, navigationProperty, propertyType);
@@ -734,11 +773,13 @@ namespace Microsoft.OData.Json
         /// <param name="propertyType">The type of the collection.</param>
         /// <param name="propertyName">The property name.</param>
         /// <param name="isDeltaResourceSet">The property being read represents a nested delta resource set.</param>
+        /// <param name="messageReaderSettings">The ODataMessageReaderSettings.</param>
         /// <returns>The nested resource info for the expanded link read.</returns>
         /// <remarks>
         /// This method doesn't move the reader.
         /// </remarks>
-        protected static ODataJsonReaderNestedResourceInfo ReadExpandedResourceSetNestedResourceInfo(IODataJsonReaderResourceState resourceState, IEdmNavigationProperty navigationProperty, IEdmStructuredType propertyType, string propertyName, bool isDeltaResourceSet)
+        protected static ODataJsonReaderNestedResourceInfo ReadExpandedResourceSetNestedResourceInfo(IODataJsonReaderResourceState resourceState, 
+            IEdmNavigationProperty navigationProperty, IEdmStructuredType propertyType, string propertyName, bool isDeltaResourceSet, ODataMessageReaderSettings messageReaderSettings)
         {
             Debug.Assert(resourceState != null, "resourceState != null");
             Debug.Assert(navigationProperty != null || propertyName != null, "navigationProperty != null || propertyName != null");
@@ -796,8 +837,19 @@ namespace Microsoft.OData.Json
 
                     case ODataAnnotationNames.ODataDeltaLink:   // Delta links are not supported on expanded resource sets.
                     default:
-                        throw new ODataException(Error.Format(SRResources.ODataJsonResourceDeserializer_UnexpectedExpandedCollectionNavigationLinkPropertyAnnotation, nestedResourceInfo.Name, propertyAnnotation.Key));
+                        if (messageReaderSettings.ThrowOnUnexpectedODataPropertyAnnotationOnNavigationProperty)
+                        {
+                            throw new ODataException(Error.Format(SRResources.ODataJsonResourceDeserializer_UnexpectedExpandedCollectionNavigationLinkPropertyAnnotation, nestedResourceInfo.Name, propertyAnnotation.Key));
+                        }
+
+                        nestedResourceInfo.InstanceAnnotations.Add(new ODataInstanceAnnotation(propertyAnnotation.Key, propertyAnnotation.Value.ToODataValue(), true));
+                        break;
                 }
+            }
+
+            foreach (KeyValuePair<string, object> instanceAnnotation in resourceState.PropertyAndAnnotationCollector.GetCustomPropertyAnnotations(nestedResourceInfo.Name))
+            {
+                nestedResourceInfo.InstanceAnnotations.Add(new ODataInstanceAnnotation(instanceAnnotation.Key, instanceAnnotation.Value.ToODataValue()));
             }
 
             return ODataJsonReaderNestedResourceInfo.CreateResourceSetReaderNestedResourceInfo(nestedResourceInfo, navigationProperty, propertyType, expandedResourceSet);
@@ -2338,7 +2390,7 @@ namespace Microsoft.OData.Json
                 if (isCollection)
                 {
                     readerNestedResourceInfo =
-                        ReadExpandedResourceSetNestedResourceInfo(resourceState, null, payloadTypeReference.ToStructuredType(), propertyName, isDeltaResourceSet: false);
+                        ReadExpandedResourceSetNestedResourceInfo(resourceState, null, payloadTypeReference.ToStructuredType(), propertyName, isDeltaResourceSet: false, this.MessageReaderSettings);
                 }
                 else
                 {

--- a/src/Microsoft.OData.Core/Json/ODataJsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonReader.cs
@@ -1826,16 +1826,30 @@ namespace Microsoft.OData.Json
 
                 // Expanded null resource
                 // The expected type and expected navigation source for an expanded resource are the same as for the nested resource info around it.
-                this.EnterScope(new JsonResourceScope(ODataReaderState.ResourceStart, /*resource*/ null,
-                    this.CurrentNavigationSource, this.CurrentResourceTypeReference, /*propertyAndAnnotationCollector*/null,
-                    /*projectedProperties*/null, this.CurrentScope.ODataUri));
+                this.EnterScope(new JsonResourceScope(ODataReaderState.ResourceStart, resource: null,
+                    navigationSource: this.CurrentNavigationSource, expectedResourceTypeReference: this.CurrentResourceTypeReference, propertyAndAnnotationCollector: null,
+                    selectedProperties: null, odataUri: this.CurrentScope.ODataUri));
             }
             else
             {
-                // Expanded resource
+                // Expanded resource, a JSON object
                 // The expected type for an expanded resource is the same as for the nested resource info around it.
                 JsonResourceBaseScope parentScope = (JsonResourceBaseScope)this.ParentScope;
                 SelectedPropertiesNode parentSelectedProperties = parentScope.SelectedProperties;
+
+                // OData spec says: When annotating a name/value pair for which the value is represented as a JSON object, each annotation is placed within the object and represented as a single name/value pair.
+                // So, do we need to verify that the property annotation should be specified as an instance annotation in the nested resource value?
+                // Or, just let it go and let the upper reader to handle it?
+                // Sam descided to comment out the verification for now. 12/2025, reasons:
+                // 1) This would be a breaking change for existing clients.
+                // 2) The upper reader will handle invalid annotations anyway.
+
+                //if (parentScope.PropertyAndAnnotationCollector.GetCustomPropertyAnnotations(nestedResourceInfo.Name).Any() ||
+                //    parentScope.PropertyAndAnnotationCollector.GetODataPropertyAnnotations(nestedResourceInfo.Name).Count > 0)
+                //{
+                //    throw new ODataException(Error.Format(SRResources.ODataJsonPropertyAndValueDeserializer_NestedResourceValueWithPropertyTypeAnnotation, nestedResourceInfo.Name));
+                //}
+
                 Debug.Assert(parentSelectedProperties != null, "parentProjectedProperties != null");
                 this.ReadResourceSetItemStart(/*propertyAndAnnotationCollector*/ null, parentSelectedProperties.GetSelectedPropertiesForNavigationProperty(parentScope.ResourceType, nestedResourceInfo.Name));
             }

--- a/src/Microsoft.OData.Core/Json/ODataJsonResourceDeserializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonResourceDeserializer.cs
@@ -989,7 +989,7 @@ namespace Microsoft.OData.Json
             if (edmProperty == null || edmProperty.Type.IsUntyped())
             {
                 // Undeclared property - we need to run detection algorithm here.
-                readerNestedInfo = this.ReadUndeclaredProperty(resourceState, propertyName, propertyWithValue: false);
+                 readerNestedInfo = this.ReadUndeclaredProperty(resourceState, propertyName, propertyWithValue: false);
 
                 this.AssertJsonCondition(JsonNodeType.Property, JsonNodeType.EndObject);
                 return readerNestedInfo;
@@ -1274,7 +1274,7 @@ namespace Microsoft.OData.Json
                     if (isCollection)
                     {
                         readerNestedResourceInfo = this.ReadingResponse || isDeltaResourceSet
-                            ? ReadExpandedResourceSetNestedResourceInfo(resourceState, navigationProperty, navigationProperty.Type.ToStructuredType(), propertyName, /*isDeltaResourceSet*/ isDeltaResourceSet)
+                            ? ReadExpandedResourceSetNestedResourceInfo(resourceState, navigationProperty, navigationProperty.Type.ToStructuredType(), propertyName, isDeltaResourceSet: isDeltaResourceSet, this.MessageReaderSettings)
                             : ReadEntityReferenceLinksForCollectionNavigationLinkInRequest(resourceState, navigationProperty, propertyName, /*isExpanded*/ true);
                     }
                     else
@@ -3502,7 +3502,7 @@ namespace Microsoft.OData.Json
                     if (isCollection)
                     {
                         readerNestedResourceInfo = this.ReadingResponse || isDeltaResourceSet
-                            ? ReadExpandedResourceSetNestedResourceInfo(resourceState, navigationProperty, navigationProperty.Type.ToStructuredType(), propertyName, isDeltaResourceSet: isDeltaResourceSet)
+                            ? ReadExpandedResourceSetNestedResourceInfo(resourceState, navigationProperty, navigationProperty.Type.ToStructuredType(), propertyName, isDeltaResourceSet: isDeltaResourceSet, this.MessageReaderSettings)
                             : ReadEntityReferenceLinksForCollectionNavigationLinkInRequest(resourceState, navigationProperty, propertyName, isExpanded: true);
                     }
                     else

--- a/src/Microsoft.OData.Core/Json/ODataJsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonWriter.cs
@@ -364,22 +364,22 @@ namespace Microsoft.OData.Json
         /// <param name="resource">The resource to write.</param>
         protected override void StartResource(ODataResource resource)
         {
-            ODataNestedResourceInfo parentNavLink = this.ParentNestedResourceInfo;
-            if (parentNavLink != null)
+            ODataNestedResourceInfo nestedResourceInfo = this.ParentNestedResourceInfo;
+            if (nestedResourceInfo != null)
             {
                 // For a null value, write the type as a property annotation
                 if (resource == null)
                 {
-                    if (parentNavLink.TypeAnnotation != null && parentNavLink.TypeAnnotation.TypeName != null)
+                    if (nestedResourceInfo.TypeAnnotation != null && nestedResourceInfo.TypeAnnotation.TypeName != null)
                     {
-                        this.odataAnnotationWriter.WriteODataTypePropertyAnnotation(parentNavLink.Name, parentNavLink.TypeAnnotation.TypeName);
+                        this.odataAnnotationWriter.WriteODataTypePropertyAnnotation(nestedResourceInfo.Name, nestedResourceInfo.TypeAnnotation.TypeName);
                     }
 
-                    this.instanceAnnotationWriter.WriteInstanceAnnotations(parentNavLink.GetInstanceAnnotations(), parentNavLink.Name);
+                    this.instanceAnnotationWriter.WriteInstanceAnnotations(nestedResourceInfo.GetInstanceAnnotations(), nestedResourceInfo.Name);
                 }
 
                 // Write the property name of an expanded navigation property to start the value.
-                this.jsonWriter.WriteName(parentNavLink.Name);
+                this.jsonWriter.WriteName(nestedResourceInfo.Name);
             }
 
             if (resource == null)

--- a/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
@@ -94,6 +94,7 @@ namespace Microsoft.OData
                 ThrowOnDuplicatePropertyNames = (validations & ValidationKinds.ThrowOnDuplicatePropertyNames) != 0;
                 ThrowIfTypeConflictsWithMetadata = (validations & ValidationKinds.ThrowIfTypeConflictsWithMetadata) != 0;
                 ThrowOnUndeclaredPropertyForNonOpenType = (validations & ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType) != 0;
+                ThrowOnUnexpectedODataPropertyAnnotationOnNavigationProperty = (validations & ValidationKinds.ThrowOnUnexpectedODataPropertyAnnotationOnNavigationProperty) != 0;
             }
         }
 
@@ -225,6 +226,11 @@ namespace Microsoft.OData
         internal bool ThrowOnUndeclaredPropertyForNonOpenType { get; private set; }
 
         /// <summary>
+        /// Returns whether ThwoOnUnexpectedODataPropertyAnnotationsOnNavigationProperty validation setting is enabled.
+        /// </summary>
+        internal bool ThrowOnUnexpectedODataPropertyAnnotationOnNavigationProperty { get; private set; }
+
+        /// <summary>
         /// Gets or sets a value that indicates whether the reader should put key values in their own URI segment when automatically building URIs.
         /// If this value is false, automatically-generated URLs will take the form "../EntitySet('KeyValue')/..".
         /// If this value is true, automatically-generated URLs will take the form "../EntitySet/KeyValue/..".
@@ -299,6 +305,7 @@ namespace Microsoft.OData
             this.ThrowOnDuplicatePropertyNames = other.ThrowOnDuplicatePropertyNames;
             this.ThrowIfTypeConflictsWithMetadata = other.ThrowIfTypeConflictsWithMetadata;
             this.ThrowOnUndeclaredPropertyForNonOpenType = other.ThrowOnUndeclaredPropertyForNonOpenType;
+            this.ThrowOnUnexpectedODataPropertyAnnotationOnNavigationProperty = other.ThrowOnUnexpectedODataPropertyAnnotationOnNavigationProperty;
             this.LibraryCompatibility = other.LibraryCompatibility;
             this.Version = other.Version;
             this.ReadAsStreamFunc = other.ReadAsStreamFunc;

--- a/src/Microsoft.OData.Core/ODataNestedResourceInfo.cs
+++ b/src/Microsoft.OData.Core/ODataNestedResourceInfo.cs
@@ -7,9 +7,11 @@
 namespace Microsoft.OData
 {
     #region Namespaces
-    using System;
-    using System.Diagnostics;
     using Microsoft.OData.Evaluation;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     #endregion Namespaces
 
     /// <summary>
@@ -137,5 +139,50 @@ namespace Microsoft.OData
         /// Whether this is a complex property.
         /// </summary>
         internal bool IsComplex { get; set; }
+
+        /// <summary>
+        /// Collection of custom instance annotations.
+        /// Reading process:
+        /// A single-valued nested resource could be one of the following three scenarios: Be noted:
+        ///  # 1. a resource with a valid json object
+        ///  {
+        ///      "MyNavProp@ns.annotation": "value",
+        ///      "MyNavProp": {...}
+        ///  }
+        ///  
+        ///  In this case, the instance annotations within resource are attached to the ODataResource represented by "MyNavProp".
+        ///  meanwhile, the instance annotations as property annotations are attached to the ODataNestedResourceInfo representing "MyNavProp"?
+        ///  # 2. a resource with 'null' value
+        ///  {
+        ///      "MyNavProp@ns.annotation": "value",
+        ///      "MyNavProp": null
+        ///  }
+        ///  In this case, the instance annotations as property annotations are attached to the ODataNestedResourceInfo representing "MyNavProp".
+        ///  
+        ///  # 3. a resource without value
+        ///  {
+        ///      "MyNavProp@ns.annotation": "value",
+        ///  }
+        ///  In this case, the instance annotations as property annotations are attached to the ODataPropertyInfo representing "MyNavProp".
+        ///  In reading process, ODataReaderState.NestedProperty is popup.
+        ///  
+        /// For collection-valued nested resource, the instance annotations are always property annotations, for example:
+        /// {
+        ///       "MyCollectionNavProp@ns.annotation": "value",
+        /// }
+        /// The value of collection-valued could be: Empty collection "[]", or collection with items "[{...}, x, {...}]", or without content.
+        /// 
+        /// Writing process:
+        /// Following up OData spec, When annotating a name/value pair for which the value is represented as a JSON object, each annotation is placed within the object and represented as a single name/value pair.
+        /// So,dDuring writing process, the instance annotations attached to ODataNestedResourceInfo will be written as property annotations only if the associated nested resource value is null.
+        /// That means the instance annotations attached to ODataNestedResourceInfo will be ignored if the associated nested resource value is a JSON object.
+        /// </summary>
+        [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly",
+            Justification = "We want to allow the same instance annotation collection instance to be shared across ODataLib OM instances.")]
+        public ICollection<ODataInstanceAnnotation> InstanceAnnotations
+        {
+            get { return this.GetInstanceAnnotations(); }
+            set { this.SetInstanceAnnotations(value); }
+        }
     }
 }

--- a/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.OData.ODataNestedResourceInfo.InstanceAnnotations.get -> System.Collections.Generic.ICollection<Microsoft.OData.ODataInstanceAnnotation>
+Microsoft.OData.ODataNestedResourceInfo.InstanceAnnotations.set -> void
+Microsoft.OData.ValidationKinds.ThrowOnUnexpectedODataPropertyAnnotationOnNavigationProperty = 8 -> Microsoft.OData.ValidationKinds

--- a/src/Microsoft.OData.Core/SRResources.Designer.cs
+++ b/src/Microsoft.OData.Core/SRResources.Designer.cs
@@ -3452,15 +3452,6 @@ namespace Microsoft.OData.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A complex property with an &apos;{0}&apos; property annotation was found. Complex properties must not have the &apos;{0}&apos; property annotation, instead the &apos;{0}&apos; should be specified as an instance annotation in the complex value..
-        /// </summary>
-        internal static string ODataJsonPropertyAndValueDeserializer_ComplexValueWithPropertyTypeAnnotation {
-            get {
-                return ResourceManager.GetString("ODataJsonPropertyAndValueDeserializer_ComplexValueWithPropertyTypeAnnotation", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to A top-level property with name &apos;{0}&apos; was found in the payload; however, property and collection payloads must always have a top-level property with name &apos;{1}&apos;..
         /// </summary>
         internal static string ODataJsonPropertyAndValueDeserializer_InvalidTopLevelPropertyName {
@@ -3484,6 +3475,16 @@ namespace Microsoft.OData.Core {
         internal static string ODataJsonPropertyAndValueDeserializer_InvalidTypeName {
             get {
                 return ResourceManager.GetString("ODataJsonPropertyAndValueDeserializer_InvalidTypeName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A non-null nested resource property with an &apos;{0}&apos; property annotation was found. Non-null nested properties must not have the &apos;{0}&apos; property annotation, instead the &apos;{0}&apos; should be specified as an instance annotation in the nested resource value..
+        /// </summary>
+        internal static string ODataJsonPropertyAndValueDeserializer_NestedResourceValueWithPropertyTypeAnnotation {
+            get {
+                return ResourceManager.GetString("ODataJsonPropertyAndValueDeserializer_NestedResourceValueWithPropertyTypeAnnotati" +
+                        "on", resourceCulture);
             }
         }
         

--- a/src/Microsoft.OData.Core/SRResources.resx
+++ b/src/Microsoft.OData.Core/SRResources.resx
@@ -1436,8 +1436,8 @@
   <data name="ODataJsonPropertyAndValueDeserializer_ResourceValuePropertyAnnotationWithoutProperty" xml:space="preserve">
     <value>One or more property annotations for property '{0}' were found in the resource value without the property to annotate. Resource values must only contain property annotations for existing properties.</value>
   </data>
-  <data name="ODataJsonPropertyAndValueDeserializer_ComplexValueWithPropertyTypeAnnotation" xml:space="preserve">
-    <value>A complex property with an '{0}' property annotation was found. Complex properties must not have the '{0}' property annotation, instead the '{0}' should be specified as an instance annotation in the complex value.</value>
+  <data name="ODataJsonPropertyAndValueDeserializer_NestedResourceValueWithPropertyTypeAnnotation" xml:space="preserve">
+    <value>A non-null nested resource property with an '{0}' property annotation was found. Non-null nested properties must not have the '{0}' property annotation, instead the '{0}' should be specified as an instance annotation in the nested resource value.</value>
   </data>
   <data name="ODataJsonPropertyAndValueDeserializer_ResourceTypeAnnotationNotFirst" xml:space="preserve">
     <value>The 'odata.type' instance annotation in a resource object is not the first property of the object. In OData, the 'odata.type' instance annotation must be the first property of the resource object.</value>

--- a/src/Microsoft.OData.Core/ValidationKinds.cs
+++ b/src/Microsoft.OData.Core/ValidationKinds.cs
@@ -37,6 +37,11 @@ namespace Microsoft.OData
         ThrowIfTypeConflictsWithMetadata = 4,
 
         /// <summary>
+        /// Indicates that an exception is thrown when an unexpected OData property annotation (@odata.xxx) is found on a navigation property.
+        /// </summary>
+        ThrowOnUnexpectedODataPropertyAnnotationOnNavigationProperty = 8,
+
+        /// <summary>
         /// Enable all validations.
         /// </summary>
         All = ~0

--- a/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Reader/Json/UriParameterReaderIntegrationTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Reader/Json/UriParameterReaderIntegrationTests.cs
@@ -621,19 +621,16 @@ namespace Microsoft.OData.Tests.IntegrationTests.Reader.Json
                 "\"OtherAddresses\":null" +
             "}";
 
-            // Not supported.
-            Exception ex = Assert.Throws<ODataException>(() =>
-                ReadAndValidate(payload, personT, true, (resources, nestedResourceInfos, resourceSets) =>
-                {
-                    Assert.Equal(4, resources.Count);
-                    Assert.Equal(3, nestedResourceInfos.Count);
+            ReadAndValidate(payload, personT, true, (resources, nestedResourceInfos, resourceSets) =>
+            {
+                Assert.Equal(4, resources.Count);
+                Assert.Equal(3, nestedResourceInfos.Count);
 
-                    Assert.Equal("OtherAddresses", nestedResourceInfos.ElementAt(2).Name);
-                    Assert.False(nestedResourceInfos.ElementAt(2).IsCollection);
+                Assert.Equal("OtherAddresses", nestedResourceInfos.ElementAt(2).Name);
+                Assert.False(nestedResourceInfos.ElementAt(2).IsCollection);
 
-                    Assert.Null(resources.ElementAt(2));
-                }));
-            Assert.Contains("A complex property with an 'odata.type' property annotation was found", ex.Message);
+                Assert.Null(resources.ElementAt(2));
+            });
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
@@ -456,9 +456,10 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.Json
         }
 
         [Fact]
-        public void ReadNonOpenNestedResourceWithoutContentTest()
+        public void ReadOpenNestedResourceWithoutContentTest()
         {
-            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",
+            // Be noted: If the type is non-open, so far, reading the dynamic properties without value/content will throw exception.
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",
   ""Id"":61880128,
   ""UndeclaredAddress@odata.type"":""#NS1.unknownTypeName123"",
   ""UndeclaredAddress@odata.unknownName1"":""unknown odata.xxx"",
@@ -469,7 +470,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.Json
             ODataNestedResourceInfo nestedInfo = null;
             ODataPropertyInfo propertyInfo = null;
             bool undeclaredAddressRead = false;
-            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
             {
                 if (reader.State == ODataReaderState.ResourceStart)
                 {
@@ -510,7 +511,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.Json
             Assert.Equal("unknown abcdefghijk", (propertyInfo.InstanceAnnotations.Last().Value as ODataPrimitiveValue).Value);
 
             entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
-            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
             {
                 writer.WriteStart(entry);
                 writer.WriteStart(propertyInfo);
@@ -518,7 +519,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.Json
                 writer.WriteEnd();
             });
 
-            Assert.Equal("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredAddress@odata.type\":\"#NS1.unknownTypeName123\",\"UndeclaredAddress@odata.unknownName1\":\"unknown odata.xxx\",\"UndeclaredAddress@NS1.abcdefg\":\"unknown abcdefghijk\"}", result);
+            Assert.Equal("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity\",\"Id\":61880128,\"UndeclaredAddress@odata.type\":\"#NS1.unknownTypeName123\",\"UndeclaredAddress@odata.unknownName1\":\"unknown odata.xxx\",\"UndeclaredAddress@NS1.abcdefg\":\"unknown abcdefghijk\"}", result);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.Json
         private ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings
         {
             ShouldIncludeAnnotation = (annotationName) => true,
-            Validations = ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType
+            Validations = ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType & ~ValidationKinds.ThrowOnUnexpectedODataPropertyAnnotationOnNavigationProperty
         };
 
         private ODataMessageWriterSettings writerSettings = new ODataMessageWriterSettings
@@ -188,14 +188,17 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.Json
         #endregion
 
         #region non-open entity's property unknown name + known value type
-
         [Fact]
-        public void ReadNonOpenNullTest()
+        public void ReadNonOpenDeclaredNestedResourceWithContentTest()
         {
-            // non-open entity's unknown property type including string & numeric values
-            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1@odata.type"":""#NS1.unknownTypeName123"",""UndeclaredAddress1@odata.unknownName1"":""uknown odata.xxx value1"",""UndeclaredAddress1@NS1.abcdefg"":""uknown abcdefghijk value2"",""UndeclaredAddress1"":null}";
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",
+  ""Id"":61880128,
+  ""Address@odata.unknownName1"":""unknown odata.xxx"",
+  ""Address@NS1.abcdefg"":""unknown abcdefg"",
+  ""Address"": {}
+}";
             ODataResource entry = null;
-            ODataResource complex1 = null;
+            ODataResource address = null;
             ODataNestedResourceInfo nestedInfo = null;
             this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
             {
@@ -208,40 +211,314 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.Json
                     else
                     {
                         Assert.NotNull(nestedInfo);
-                        Assert.Equal("UndeclaredAddress1", nestedInfo.Name);
-                        complex1 = (reader.Item as ODataResource);
+                        Assert.Equal("Address", nestedInfo.Name);
+                        address = (reader.Item as ODataResource);
                     }
                 }
                 else if (reader.State == ODataReaderState.NestedResourceInfoStart)
                 {
                     nestedInfo = (ODataNestedResourceInfo)(reader.Item);
-                    // to ensure read to the end of entry
                 }
             });
 
             Assert.Single(entry.Properties);
 
             Assert.NotNull(nestedInfo);
-            Assert.Null(complex1);
+            Assert.Equal(2, nestedInfo.InstanceAnnotations.Count());
+            Assert.Equal("unknown odata.xxx", (nestedInfo.InstanceAnnotations.First().Value as ODataPrimitiveValue).Value);
+            Assert.Equal("unknown abcdefg", (nestedInfo.InstanceAnnotations.Last().Value as ODataPrimitiveValue).Value);
 
-            // So far, the ODL doesn't popout the annotation for the null nested resource. As expected, we should get the annotation from the nested resource info, but no such logic yet,
-            // See details at: https://github.com/OData/odata.net/issues/3440
-            // Assert.Equal(2, nestedInfo.InstanceAnnotations.Count());
-            // Assert.Equal("unknown odata.xxx value1", (nestedInfo.InstanceAnnotations.First().Value as ODataPrimitiveValue).Value);
-            // Assert.Equal("unknown abcdefghijk value2", (nestedInfo.InstanceAnnotations.Last().Value as ODataPrimitiveValue).Value);
+            Assert.NotNull(address);
+            Assert.Empty(address.Properties);
+            Assert.Empty(address.InstanceAnnotations);
 
             entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
             string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
             {
                 writer.WriteStart(entry);
                 writer.WriteStart(nestedInfo);
-                writer.WriteStart(complex1);
+                writer.WriteStart(address);
                 writer.WriteEnd();
                 writer.WriteEnd();
                 writer.WriteEnd();
             });
 
-            Assert.Equal("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredAddress1@odata.type\":\"#NS1.unknownTypeName123\",\"UndeclaredAddress1\":null}", result);
+            Assert.Equal("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"Address\":{}}", result);
+        }
+
+        [Fact]
+        public void ReadNonOpenNestedResourceWithContentWithPropertyAnnotationAndResourceAnnotationTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",
+  ""Id"":61880128,
+  ""UndeclaredAddress@odata.type"":""#NS1.unknownTypeName123"",
+  ""UndeclaredAddress@odata.unknownName1"":""unknown value"",
+  ""UndeclaredAddress@NS1.abcdefg"":""unknown abcdefg"",
+  ""UndeclaredAddress"": {
+    ""@NS2.Annotation"": 42,
+    ""City"": ""abc""}
+}";
+            ODataResource entry = null;
+            ODataResource undeclaredAddress = null;
+            ODataNestedResourceInfo nestedInfo = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                if (reader.State == ODataReaderState.ResourceStart)
+                {
+                    if (entry == null)
+                    {
+                        entry = (reader.Item as ODataResource);
+                    }
+                    else
+                    {
+                        Assert.NotNull(nestedInfo);
+                        Assert.Equal("UndeclaredAddress", nestedInfo.Name);
+                        undeclaredAddress = (reader.Item as ODataResource);
+                    }
+                }
+                else if (reader.State == ODataReaderState.NestedResourceInfoStart)
+                {
+                    nestedInfo = (ODataNestedResourceInfo)(reader.Item);
+                }
+            });
+
+            Assert.Single(entry.Properties);
+
+            Assert.NotNull(nestedInfo);
+            Assert.Equal("NS1.unknownTypeName123", nestedInfo.TypeAnnotation.TypeName);
+
+            Assert.Equal(2, nestedInfo.InstanceAnnotations.Count());
+            Assert.Equal("unknown value", (nestedInfo.InstanceAnnotations.First().Value as ODataPrimitiveValue).Value);
+            Assert.Equal("unknown abcdefg", (nestedInfo.InstanceAnnotations.Last().Value as ODataPrimitiveValue).Value);
+
+            Assert.NotNull(undeclaredAddress);
+            ODataInstanceAnnotation annotation = Assert.Single(undeclaredAddress.InstanceAnnotations);
+            Assert.Equal("NS2.Annotation", annotation.Name);
+            Assert.Equal(42, (annotation.Value as ODataPrimitiveValue).Value);
+
+            entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteStart(nestedInfo);
+                writer.WriteStart(undeclaredAddress);
+                writer.WriteEnd();
+                writer.WriteEnd();
+                writer.WriteEnd();
+            });
+
+            // Make sure the annotation on ODataNestedResourceInfo is not written if the nested resource has content.
+            Assert.Equal("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredAddress\":{\"@NS2.Annotation\":42,\"City\":\"abc\"}}", result);
+        }
+
+        [Fact]
+        public void ReadNonOpenTypeNestedResourceWithNullValueTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",
+  ""Id"":61880128,
+  ""UndeclaredAddress@odata.type"":""#NS1.unknownTypeName123"",
+  ""UndeclaredAddress@odata.unknownName1"":""unknown value"",
+  ""UndeclaredAddress@NS1.abcdefg"":""unknown abcdefg value"",
+  ""UndeclaredAddress"": null
+}";
+            ODataResource entry = null;
+            ODataResource undeclaredAddress = null;
+            bool undeclaredAddressRead = false;
+            ODataNestedResourceInfo nestedInfo = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                if (reader.State == ODataReaderState.ResourceStart)
+                {
+                    if (entry == null)
+                    {
+                        entry = (reader.Item as ODataResource);
+                    }
+                    else
+                    {
+                        Assert.NotNull(nestedInfo);
+                        Assert.Equal("UndeclaredAddress", nestedInfo.Name);
+                        Assert.False(undeclaredAddressRead);
+                        undeclaredAddressRead = true;
+                        undeclaredAddress = (reader.Item as ODataResource);
+                    }
+                }
+                else if (reader.State == ODataReaderState.NestedResourceInfoStart)
+                {
+                    nestedInfo = (ODataNestedResourceInfo)(reader.Item);
+                }
+            });
+
+            Assert.Single(entry.Properties);
+
+            Assert.Null(undeclaredAddress);
+            Assert.True(undeclaredAddressRead); // make sure we hit the "nested resource reading cycle"
+
+            Assert.NotNull(nestedInfo);
+
+            // @odata.type read into 'TypeAnnotation'.
+            Assert.Equal("NS1.unknownTypeName123", nestedInfo.TypeAnnotation.TypeName);
+
+            Assert.Equal(2, nestedInfo.InstanceAnnotations.Count());
+            Assert.Equal("unknown value", (nestedInfo.InstanceAnnotations.First().Value as ODataPrimitiveValue).Value);
+            Assert.Equal("unknown abcdefg value", (nestedInfo.InstanceAnnotations.Last().Value as ODataPrimitiveValue).Value);
+
+            entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteStart(nestedInfo);
+                writer.WriteStart(undeclaredAddress);
+                writer.WriteEnd();
+                writer.WriteEnd();
+                writer.WriteEnd();
+            });
+
+            Assert.Equal("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredAddress@odata.type\":\"#NS1.unknownTypeName123\",\"UndeclaredAddress@odata.unknownName1\":\"unknown value\",\"UndeclaredAddress@NS1.abcdefg\":\"unknown abcdefg value\",\"UndeclaredAddress\":null}", result);
+        }
+
+        [Fact]
+        public void ReadNonOpenDeclaredAndUndeclaredMixedNestedResourceWithOrWithoutContentTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",
+  ""Address@odata.unknownName1"":""address unknown name"",
+  ""Address@NS1.abcdefg"":""address abcdefg"",
+  ""MyEdmUntypedProp1@NS2.Untyped"": { ""UntypedProp1"":123 },
+  ""MyEdmUntypedProp1"": null,
+  ""UndeclaredAddress@odata.unknownName1"":""unknown value"",
+  ""UndeclaredAddress@NS1.abcdefg"":""unknown abcdefg"",
+  ""UndeclaredAddress"": []
+}";
+            ODataResource entry = null;
+            ODataNestedResourceInfo nestedInfo = null;
+            ODataResourceSet undeclaredAddress = null;
+            ODataPropertyInfo nestedPropertyInfo = null;
+            int hit = 0;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                if (reader.State == ODataReaderState.ResourceStart)
+                {
+                    entry = (reader.Item as ODataResource);
+                }
+                else if (reader.State == ODataReaderState.ResourceSetStart)
+                {
+                    undeclaredAddress = (ODataResourceSet)(reader.Item);
+                }
+                else if (reader.State == ODataReaderState.NestedResourceInfoStart)
+                {
+                    hit++;
+                    nestedInfo = (ODataNestedResourceInfo)(reader.Item);
+                }
+                else if (reader.State == ODataReaderState.NestedProperty)
+                {
+                    nestedPropertyInfo = (ODataPropertyInfo)(reader.Item);
+                }
+            });
+
+            ODataProperty property = Assert.IsType<ODataProperty>(Assert.Single(entry.Properties));
+            Assert.Equal("MyEdmUntypedProp1", property.Name);
+            Assert.Null(property.Value);
+            ODataInstanceAnnotation myEdmUntypedProp1Annotation = Assert.Single(property.InstanceAnnotations);
+            Assert.Equal("NS2.Untyped", myEdmUntypedProp1Annotation.Name);
+            ODataResourceValue resourceValue = Assert.IsType<ODataResourceValue>(myEdmUntypedProp1Annotation.Value);
+
+            Assert.Equal(1, hit); // only hit once for nested resource info
+            Assert.NotNull(nestedInfo);
+            Assert.Equal("UndeclaredAddress", nestedInfo.Name);
+            Assert.Equal(2, nestedInfo.InstanceAnnotations.Count());
+            Assert.Equal("unknown value", (nestedInfo.InstanceAnnotations.First().Value as ODataPrimitiveValue).Value);
+            Assert.Equal("unknown abcdefg", (nestedInfo.InstanceAnnotations.Last().Value as ODataPrimitiveValue).Value);
+
+            Assert.NotNull(nestedPropertyInfo);
+            Assert.Equal("Address", nestedPropertyInfo.Name);
+            Assert.Equal(2, nestedPropertyInfo.InstanceAnnotations.Count());
+            Assert.Equal("address unknown name", (nestedPropertyInfo.InstanceAnnotations.First().Value as ODataPrimitiveValue).Value);
+            Assert.Equal("address abcdefg", (nestedPropertyInfo.InstanceAnnotations.Last().Value as ODataPrimitiveValue).Value);
+
+            Assert.NotNull(undeclaredAddress);
+
+            // We have to specify a type name for ODataResourceValue to write it.
+            // it seems a feature gap that it should not be required..
+            resourceValue.TypeName = "Server.NS.Address";
+
+            entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteStart(nestedInfo);
+                writer.WriteStart(undeclaredAddress);
+                writer.WriteEnd();
+                writer.WriteEnd();
+                writer.WriteEnd();
+            });
+
+            // It seems a feature gap to write the instance annotations for 'Edm.Untyped' declared property.
+            Assert.Equal("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"MyEdmUntypedProp1@NS2.Untyped\":{\"@odata.type\":\"#Server.NS.Address\",\"UntypedProp1\":123},\"MyEdmUntypedProp1\":null,\"UndeclaredAddress\":[]}", result);
+        }
+
+        [Fact]
+        public void ReadNonOpenNestedResourceWithoutContentTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",
+  ""Id"":61880128,
+  ""UndeclaredAddress@odata.type"":""#NS1.unknownTypeName123"",
+  ""UndeclaredAddress@odata.unknownName1"":""unknown odata.xxx"",
+  ""UndeclaredAddress@NS1.abcdefg"":""unknown abcdefghijk""
+}";
+            ODataResource entry = null;
+            ODataResource undeclaredAddress = null;
+            ODataNestedResourceInfo nestedInfo = null;
+            ODataPropertyInfo propertyInfo = null;
+            bool undeclaredAddressRead = false;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                if (reader.State == ODataReaderState.ResourceStart)
+                {
+                    if (entry == null)
+                    {
+                        entry = (reader.Item as ODataResource);
+                    }
+                    else
+                    {
+                        Assert.NotNull(nestedInfo);
+                        Assert.Equal("UndeclaredAddress", nestedInfo.Name);
+                        undeclaredAddressRead = true;
+                        undeclaredAddress = (reader.Item as ODataResource);
+                    }
+                }
+                else if (reader.State == ODataReaderState.NestedResourceInfoStart)
+                {
+                    nestedInfo = (ODataNestedResourceInfo)(reader.Item);
+                }
+                else if (reader.State == ODataReaderState.NestedProperty)
+                {
+                    propertyInfo = (ODataPropertyInfo)(reader.Item);
+                }
+            });
+
+            Assert.Single(entry.Properties);
+
+            Assert.False(undeclaredAddressRead); // make sure we did not hit the "nested resource reading cycle"
+            Assert.Null(undeclaredAddress);
+
+            Assert.Null(nestedInfo);
+
+            Assert.NotNull(propertyInfo);
+            Assert.Equal("NS1.unknownTypeName123", propertyInfo.TypeAnnotation.TypeName);
+
+            Assert.Equal(2, propertyInfo.InstanceAnnotations.Count());
+            Assert.Equal("unknown odata.xxx", (propertyInfo.InstanceAnnotations.First().Value as ODataPrimitiveValue).Value);
+            Assert.Equal("unknown abcdefghijk", (propertyInfo.InstanceAnnotations.Last().Value as ODataPrimitiveValue).Value);
+
+            entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteStart(propertyInfo);
+                writer.WriteEnd();
+                writer.WriteEnd();
+            });
+
+            Assert.Equal("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredAddress@odata.type\":\"#NS1.unknownTypeName123\",\"UndeclaredAddress@odata.unknownName1\":\"unknown odata.xxx\",\"UndeclaredAddress@NS1.abcdefg\":\"unknown abcdefghijk\"}", result);
         }
 
         [Fact]
@@ -537,9 +814,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.Json
                 writer.WriteEnd();
             });
 
-            // It should contain the following annotations but we don't have such logic yet. Keep the codes for later change once we fix the issue at https://github.com/OData/odata.net/issues/3440
-            // Assert.Equal("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredAddress1@odata.type\":\"#Server.NS.UndefComplex1\",\"UndeclaredAddress1@odata.unknownName1\":\"unknown odata.xxx value1\",\"UndeclaredAddress1@NS1.abcdefg\":\"unknown abcdefghijk value2\",\"UndeclaredAddress1\":null}", result);
-            Assert.Equal("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredAddress1@odata.type\":\"#Server.NS.UndefComplex1\",\"UndeclaredAddress1\":null}", result);
+            Assert.Equal("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredAddress1@odata.type\":\"#Server.NS.UndefComplex1\",\"UndeclaredAddress1@odata.unknownName1\":\"unknown odata.xxx value1\",\"UndeclaredAddress1@NS1.abcdefg\":\"unknown abcdefghijk value2\",\"UndeclaredAddress1\":null}", result);
         }
 
         [Fact]
@@ -1334,11 +1609,12 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.Json
             EdmEntitySet entitySet, 
             EdmEntityType entityType, 
             Action<ODataReader> action, 
-            ODataMessageReaderSettings settings = null)
+            ODataMessageReaderSettings settings = null,
+            IEdmModel model = null)
         {
             var message = new InMemoryMessage() { Stream = new MemoryStream(Encoding.UTF8.GetBytes(payload)) };
             message.SetHeader("Content-Type", "application/json");
-            using (var msgReader = new ODataMessageReader((IODataResponseMessage)message, settings ?? readerSettings, this.serverModel))
+            using (var msgReader = new ODataMessageReader((IODataResponseMessage)message, settings ?? readerSettings, model ?? this.serverModel))
             {
                 var reader = msgReader.CreateODataResourceReader(entitySet, entityType);
                 while (reader.Read())

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerUndeclaredTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerUndeclaredTests.cs
@@ -2981,7 +2981,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.Json
 
             Assert.Single(entry.Properties);
             Assert.Equal("UndeclaredProperty", nestedInfo.Name);
-            Assert.Null(nestedInfo.TypeAnnotation);
+            Assert.Equal("Collection(Server.NS.Undeclared)", nestedInfo.TypeAnnotation.TypeName);
             Assert.Null(undeclaredProperty.TypeName);
             Assert.Single(undeclaredProperty.Properties);
             Assert.Equal("123", Assert.IsType<ODataProperty>(undeclaredProperty.Properties.Single(p => p.Name == "Id")).Value);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Resources/SRResourcesTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Resources/SRResourcesTests.cs
@@ -387,7 +387,7 @@ public class SRResourcesTests
     [InlineData("ODataJsonParameterDeserializer_UnsupportedPrimitiveParameterType", new object[] { "Value1", "Value2" })]
     [InlineData("ODataJsonPropertyAndValueDeserializer_CollectionTypeExpected", new object[] { "Value" })]
     [InlineData("ODataJsonPropertyAndValueDeserializer_CollectionTypeNotExpected", new object[] { "Value" })]
-    [InlineData("ODataJsonPropertyAndValueDeserializer_ComplexValueWithPropertyTypeAnnotation", new object[] { "Value" })]
+    [InlineData("ODataJsonPropertyAndValueDeserializer_NestedResourceValueWithPropertyTypeAnnotation", new object[] { "Value" })]
     [InlineData("ODataJsonPropertyAndValueDeserializer_InvalidTopLevelPropertyName", new object[] { "Value1", "Value2" })]
     [InlineData("ODataJsonPropertyAndValueDeserializer_InvalidTopLevelPropertyPayload", new object[] { })]
     [InlineData("ODataJsonPropertyAndValueDeserializer_InvalidTypeName", new object[] { "Value" })]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3440: Missing annotations for null value nested resource or without value nested resource.*

### Description

When writing the nested resource, we can see the ODL retrieves the instance annotations from `ODataNestedResourceInfo` and write them as property annotation if the nested resource value is `null`.

So, this design makes sense but there's no way for developer to specify the instance annotations for `ODataNestedResourceInfo` since the 'SetInstanceAnnotation()` is internal API. This also blocks to read the instance annotations for `null` value nested resource.

This PR is to expose the instance annotations on the `ODataNestedResourceInfo`. Then 
## in reading, upper layer can retrieve the instance annotations.
## in writing, upper layer can set the instance annotations.

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
