### PR TITLE
Fix value was either too large or too small for Uint16 error when loading solution

### DIFF
--- a/tools/CustomMSBuild/Versioning.props
+++ b/tools/CustomMSBuild/Versioning.props
@@ -13,7 +13,7 @@
       overflows the Int16. The system convert below will throw errors when this happens.
     -->
   <PropertyGroup>
-    <VersionStartYear Condition="'$(VersionStartYear)' == ''">2020</VersionStartYear>
+    <VersionStartYear Condition="'$(VersionStartYear)' == ''">2022</VersionStartYear>
     <VersionDateCode>$([System.Convert]::ToUInt16('$([MSBuild]::Add(1, $([MSBuild]::Subtract($([System.DateTime]::Now.Year), $(VersionStartYear)))))$([System.DateTime]::Now.ToString("MMdd"))'))</VersionDateCode>
     <VersionRevision Condition="'$(VersionRevision)' == '' OR '$(VersionRevision)' == '0'">$([System.Convert]::ToString($(VersionDateCode)))</VersionRevision>
   </PropertyGroup>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Fixes the following error that is observed when trying to load the solution:

> The expression "[System.Convert]::ToUInt16(70106)" cannot be evaluated. Value was either too large or too small for a UInt16.  C:\odata.net\tools\CustomMSBuild\Versioning.props

Issue responsible for the pipeline failure. When the `VersionStartYear` falls too far behind, the following calculation starts to fail:
 ```
<VersionDateCode>$([System.Convert]::ToUInt16('$([MSBuild]::Add(1, $([MSBuild]::Subtract($([System.DateTime]::Now.Year), $(VersionStartYear)))))$([System.DateTime]::Now.ToString("MMdd"))'))</VersionDateCode>
```

We usually resolve the issue by moving the date but we should investigate whether `VersionDateCode` is used anywhere