### PR TITLE
Enable collection node for parameter alias

### DIFF
--- a/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1563,7 +1563,8 @@ Microsoft.OData.UriParser.ODataQueryOptionParser.ODataQueryOptionParser(Microsof
 Microsoft.OData.UriParser.ODataQueryOptionParser.ODataQueryOptionParser(Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmType targetEdmType, Microsoft.OData.Edm.IEdmNavigationSource targetNavigationSource, System.Collections.Generic.IDictionary<string, string> queryOptions, System.IServiceProvider container) -> void
 Microsoft.OData.UriParser.ODataQueryOptionParser.ODataQueryOptionParser(Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.UriParser.ODataPath odataPath, System.Collections.Generic.IDictionary<string, string> queryOptions) -> void
 Microsoft.OData.UriParser.ODataQueryOptionParser.ODataQueryOptionParser(Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.UriParser.ODataPath odataPath, System.Collections.Generic.IDictionary<string, string> queryOptions, System.IServiceProvider container) -> void
-Microsoft.OData.UriParser.ODataQueryOptionParser.ParameterAliasNodes.get -> System.Collections.Generic.IDictionary<string, Microsoft.OData.UriParser.QueryNode>
+Microsoft.OData.UriParser.ODataQueryOptionParser.ParameterAliasAllNodes.get -> System.Collections.Generic.IDictionary<string, Microsoft.OData.UriParser.QueryNode>
+Microsoft.OData.UriParser.ODataQueryOptionParser.ParameterAliasNodes.get -> System.Collections.Generic.IDictionary<string, Microsoft.OData.UriParser.SingleValueNode>
 Microsoft.OData.UriParser.ODataQueryOptionParser.ParseApply() -> Microsoft.OData.UriParser.Aggregation.ApplyClause
 Microsoft.OData.UriParser.ODataQueryOptionParser.ParseCompute() -> Microsoft.OData.UriParser.ComputeClause
 Microsoft.OData.UriParser.ODataQueryOptionParser.ParseCount() -> bool?

--- a/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1086,7 +1086,7 @@ Microsoft.OData.ODataUri.Index.set -> void
 Microsoft.OData.ODataUri.ODataUri() -> void
 Microsoft.OData.ODataUri.OrderBy.get -> Microsoft.OData.UriParser.OrderByClause
 Microsoft.OData.ODataUri.OrderBy.set -> void
-Microsoft.OData.ODataUri.ParameterAliasNodes.get -> System.Collections.Generic.IDictionary<string, Microsoft.OData.UriParser.SingleValueNode>
+Microsoft.OData.ODataUri.ParameterAliasNodes.get -> System.Collections.Generic.IDictionary<string, Microsoft.OData.UriParser.QueryNode>
 Microsoft.OData.ODataUri.Path.get -> Microsoft.OData.UriParser.ODataPath
 Microsoft.OData.ODataUri.Path.set -> void
 Microsoft.OData.ODataUri.QueryCount.get -> bool?
@@ -1563,7 +1563,7 @@ Microsoft.OData.UriParser.ODataQueryOptionParser.ODataQueryOptionParser(Microsof
 Microsoft.OData.UriParser.ODataQueryOptionParser.ODataQueryOptionParser(Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmType targetEdmType, Microsoft.OData.Edm.IEdmNavigationSource targetNavigationSource, System.Collections.Generic.IDictionary<string, string> queryOptions, System.IServiceProvider container) -> void
 Microsoft.OData.UriParser.ODataQueryOptionParser.ODataQueryOptionParser(Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.UriParser.ODataPath odataPath, System.Collections.Generic.IDictionary<string, string> queryOptions) -> void
 Microsoft.OData.UriParser.ODataQueryOptionParser.ODataQueryOptionParser(Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.UriParser.ODataPath odataPath, System.Collections.Generic.IDictionary<string, string> queryOptions, System.IServiceProvider container) -> void
-Microsoft.OData.UriParser.ODataQueryOptionParser.ParameterAliasNodes.get -> System.Collections.Generic.IDictionary<string, Microsoft.OData.UriParser.SingleValueNode>
+Microsoft.OData.UriParser.ODataQueryOptionParser.ParameterAliasNodes.get -> System.Collections.Generic.IDictionary<string, Microsoft.OData.UriParser.QueryNode>
 Microsoft.OData.UriParser.ODataQueryOptionParser.ParseApply() -> Microsoft.OData.UriParser.Aggregation.ApplyClause
 Microsoft.OData.UriParser.ODataQueryOptionParser.ParseCompute() -> Microsoft.OData.UriParser.ComputeClause
 Microsoft.OData.UriParser.ODataQueryOptionParser.ParseCount() -> bool?
@@ -1610,7 +1610,7 @@ Microsoft.OData.UriParser.ODataUriParser.ODataUriParser(Microsoft.OData.Edm.IEdm
 Microsoft.OData.UriParser.ODataUriParser.ODataUriParser(Microsoft.OData.Edm.IEdmModel model, System.Uri relativeUri, System.IServiceProvider container) -> void
 Microsoft.OData.UriParser.ODataUriParser.ODataUriParser(Microsoft.OData.Edm.IEdmModel model, System.Uri serviceRoot, System.Uri uri) -> void
 Microsoft.OData.UriParser.ODataUriParser.ODataUriParser(Microsoft.OData.Edm.IEdmModel model, System.Uri serviceRoot, System.Uri uri, System.IServiceProvider container) -> void
-Microsoft.OData.UriParser.ODataUriParser.ParameterAliasNodes.get -> System.Collections.Generic.IDictionary<string, Microsoft.OData.UriParser.SingleValueNode>
+Microsoft.OData.UriParser.ODataUriParser.ParameterAliasNodes.get -> System.Collections.Generic.IDictionary<string, Microsoft.OData.UriParser.QueryNode>
 Microsoft.OData.UriParser.ODataUriParser.ParseApply() -> Microsoft.OData.UriParser.Aggregation.ApplyClause
 Microsoft.OData.UriParser.ODataUriParser.ParseCompute() -> Microsoft.OData.UriParser.ComputeClause
 Microsoft.OData.UriParser.ODataUriParser.ParseCount() -> bool?

--- a/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -6,3 +6,10 @@ override Microsoft.OData.UriParser.IndexSegment.HandleWith(Microsoft.OData.UriPa
 override Microsoft.OData.UriParser.IndexSegment.TranslateWith<T>(Microsoft.OData.UriParser.PathSegmentTranslator<T> translator) -> T
 virtual Microsoft.OData.UriParser.PathSegmentHandler.Handle(Microsoft.OData.UriParser.IndexSegment segment) -> void
 virtual Microsoft.OData.UriParser.PathSegmentTranslator<T>.Translate(Microsoft.OData.UriParser.IndexSegment segment) -> T
+Microsoft.OData.UriParser.ParameterAliasCollectionNode
+Microsoft.OData.UriParser.ParameterAliasCollectionNode.Alias.get -> string
+Microsoft.OData.UriParser.ParameterAliasCollectionNode.ParameterAliasCollectionNode(string alias, Microsoft.OData.Edm.IEdmCollectionTypeReference collectionType) -> void
+override Microsoft.OData.UriParser.ParameterAliasCollectionNode.Accept<T>(Microsoft.OData.UriParser.QueryNodeVisitor<T> visitor) -> T
+override Microsoft.OData.UriParser.ParameterAliasCollectionNode.CollectionType.get -> Microsoft.OData.Edm.IEdmCollectionTypeReference
+override Microsoft.OData.UriParser.ParameterAliasCollectionNode.ItemType.get -> Microsoft.OData.Edm.IEdmTypeReference
+virtual Microsoft.OData.UriParser.QueryNodeVisitor<T>.Visit(Microsoft.OData.UriParser.ParameterAliasCollectionNode nodeIn) -> T

--- a/src/Microsoft.OData.Core/Uri/NodeToStringBuilder.cs
+++ b/src/Microsoft.OData.Core/Uri/NodeToStringBuilder.cs
@@ -398,6 +398,17 @@ namespace Microsoft.OData
         }
 
         /// <summary>
+        /// Translates a <see cref="ParameterAliasCollectionNode"/> into a corresponding <see cref="String"/>.
+        /// </summary>
+        /// <param name="node">The node to translate.</param>
+        /// <returns>The translated String.</returns>
+        public override String Visit(ParameterAliasCollectionNode node)
+        {
+            ExceptionUtils.CheckArgumentNotNull(node, "node");
+            return node.Alias;
+        }
+
+        /// <summary>
         /// Translates a <see cref="NamedFunctionParameterNode"/> into a corresponding <see cref="String"/>.
         /// </summary>
         /// <param name="node">The node to translate.</param>
@@ -570,12 +581,12 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="dictionary">Dictionary</param>
         /// <returns>The url query string of dictionary's key value pairs (URL encoded)</returns>
-        internal String TranslateParameterAliasNodes(IDictionary<string, SingleValueNode> dictionary)
+        internal String TranslateParameterAliasNodes(IDictionary<string, QueryNode> dictionary)
         {
             String result = null;
             if (dictionary != null)
             {
-                foreach (KeyValuePair<string, SingleValueNode> keyValuePair in dictionary)
+                foreach (KeyValuePair<string, QueryNode> keyValuePair in dictionary)
                 {
                     if (keyValuePair.Value != null)
                     {

--- a/src/Microsoft.OData.Core/Uri/ODataUri.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUri.cs
@@ -124,7 +124,7 @@ namespace Microsoft.OData
         /// <summary>
         /// Get the parameter alias nodes info.
         /// </summary>
-        public IDictionary<string, SingleValueNode> ParameterAliasNodes
+        public IDictionary<string, QueryNode> ParameterAliasNodes
         {
             get
             {

--- a/src/Microsoft.OData.Core/Uri/ODataUriSlim.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriSlim.cs
@@ -69,7 +69,7 @@ namespace Microsoft.OData
         /// <summary>
         /// Get the parameter alias nodes info.
         /// </summary>
-        public IDictionary<string, SingleValueNode> ParameterAliasNodes => this.odataUri.ParameterAliasNodes;
+        public IDictionary<string, QueryNode> ParameterAliasNodes => this.odataUri.ParameterAliasNodes;
 
         /// <summary>
         /// Gets any custom query options for this uri.

--- a/src/Microsoft.OData.Core/UriParser/Binders/MetadataBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/MetadataBinder.cs
@@ -224,7 +224,7 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         /// <param name="functionParameterAliasToken">The alias syntactics token.</param>
         /// <returns>The semantics node for parameter alias.</returns>
-        protected virtual SingleValueNode BindParameterAlias(FunctionParameterAliasToken functionParameterAliasToken)
+        protected virtual QueryNode BindParameterAlias(FunctionParameterAliasToken functionParameterAliasToken)
         {
             ParameterAliasBinder binder = new ParameterAliasBinder(this.Bind);
             return binder.BindParameterAlias(this.BindingState, functionParameterAliasToken);

--- a/src/Microsoft.OData.Core/UriParser/Binders/ParameterAliasBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/ParameterAliasBinder.cs
@@ -6,7 +6,6 @@
 
 using Microsoft.OData.Metadata;
 using Microsoft.OData.Edm;
-using Microsoft.OData.Core;
 
 namespace Microsoft.OData.UriParser
 {
@@ -38,7 +37,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="bindingState">The alias name which is inside another alias value.</param>
         /// <param name="aliasToken">The cache of alias value nodes</param>
         /// <returns>The semantics node tree for alias (the @p1 in "@p1=...", not alias value expression)</returns>
-        internal ParameterAliasNode BindParameterAlias(BindingState bindingState, FunctionParameterAliasToken aliasToken)
+        internal QueryNode BindParameterAlias(BindingState bindingState, FunctionParameterAliasToken aliasToken)
         {
             ExceptionUtils.CheckArgumentNotNull(bindingState, "bindingState");
             ExceptionUtils.CheckArgumentNotNull(aliasToken, "aliasToken");
@@ -51,7 +50,7 @@ namespace Microsoft.OData.UriParser
             }
 
             // in cache?
-            SingleValueNode aliasValueNode = null;
+            QueryNode aliasValueNode = null;
             if (!aliasValueAccessor.ParameterAliasValueNodesCached.TryGetValue(alias, out aliasValueNode))
             {
                 // has value expression?
@@ -67,6 +66,11 @@ namespace Microsoft.OData.UriParser
                 }
             }
 
+            if (aliasValueNode is CollectionNode collectionNode)
+            {
+                return new ParameterAliasCollectionNode(alias, collectionNode.CollectionType);
+            }
+
             return new ParameterAliasNode(alias, aliasValueNode.GetEdmTypeReference());
         }
 
@@ -77,7 +81,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="aliasValueExpression">The alias value's expression text.</param>
         /// <param name="parameterType">The edm type of the parameter.</param>
         /// <returns>The semantics node of the expression text.</returns>
-        private SingleValueNode ParseAndBindParameterAliasValueExpression(BindingState bindingState, string aliasValueExpression, IEdmTypeReference parameterType)
+        private QueryNode ParseAndBindParameterAliasValueExpression(BindingState bindingState, string aliasValueExpression, IEdmTypeReference parameterType)
         {
             // Get the syntactic representation of the filter expression
             // TODO: change Settings.FilterLimit to ParameterAliasValueLimit
@@ -87,16 +91,8 @@ namespace Microsoft.OData.UriParser
             // Special logic to handle parameter alias token.
             aliasValueToken = ParseComplexOrCollectionAlias(aliasValueToken, parameterType, bindingState.Model);
 
-            // Get the semantic node, and check for SingleValueNode
-            QueryNode aliasValueNode = this.bindMethod(aliasValueToken);
-            SingleValueNode result = aliasValueNode as SingleValueNode;
-            if (result == null)
-            {
-                // TODO: add string resource
-                throw new ODataException(SRResources.MetadataBinder_ParameterAliasValueExpressionNotSingleValue);
-            }
-
-            return result;
+            // Get the semantic node, it should support single and collection value node.
+            return this.bindMethod(aliasValueToken);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -137,10 +137,16 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// Get the parameter alias nodes info.
         /// </summary>
-        public IDictionary<string, QueryNode> ParameterAliasNodes
+        public IDictionary<string, QueryNode> ParameterAliasAllNodes
         {
             get { return this.Configuration.ParameterAliasValueAccessor.ParameterAliasValueNodesCached; }
         }
+
+        /// <summary>
+        /// Gets the parameter alias nodes as SingleValueNode.
+        /// </summary>
+        [Obsolete("This property is deprecated. Please use ParameterAliasAllNodes instead. When updates the ASP.NET Core OData dependency, this property will be changed later.")]
+        public IDictionary<string, SingleValueNode> ParameterAliasNodes => ParameterAliasAllNodes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value as SingleValueNode);
 
         /// <summary>
         /// Gets or sets the <see cref="ODataUriResolver"/> for <see cref="ODataUriParser"/>.

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -137,7 +137,7 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// Get the parameter alias nodes info.
         /// </summary>
-        public IDictionary<string, SingleValueNode> ParameterAliasNodes
+        public IDictionary<string, QueryNode> ParameterAliasNodes
         {
             get { return this.Configuration.ParameterAliasValueAccessor.ParameterAliasValueNodesCached; }
         }

--- a/src/Microsoft.OData.Core/UriParser/ODataUriParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataUriParser.cs
@@ -214,7 +214,7 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// Get the parameter alias nodes info.
         /// </summary>
-        public IDictionary<string, SingleValueNode> ParameterAliasNodes
+        public IDictionary<string, QueryNode> ParameterAliasNodes
         {
             get
             {

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/ParameterAliasCollectionNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/ParameterAliasCollectionNode.cs
@@ -1,0 +1,62 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ParameterAliasCollectionNode.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.UriParser
+{
+    using Microsoft.OData.Edm;
+
+    /// <summary>
+    /// Represents a parameter alias that refers to a collection value.
+    /// </summary>
+    public class ParameterAliasCollectionNode : CollectionNode
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="alias">The parameter alias.</param>
+        /// <param name="collectionType">The alias' type which is inferred from the type of alias value's CollectionNode.</param>
+        public ParameterAliasCollectionNode(string alias, IEdmCollectionTypeReference collectionType)
+        {
+            ExceptionUtils.CheckArgumentNotNull(collectionType, "collectionType");
+
+            Alias = alias;
+            CollectionType = collectionType;
+        }
+
+        /// <summary>
+        /// The parameter alias.
+        /// </summary>
+        public string Alias { get; }
+
+        /// <summary>
+        /// Gets the type of a single item from the collection represented by this node.
+        /// </summary>
+        public override IEdmTypeReference ItemType => CollectionType.ElementType();
+
+        /// <summary>
+        /// The type of the collection represented by this node.
+        /// </summary>
+        public override IEdmCollectionTypeReference CollectionType { get; }
+
+        /// <summary>
+        /// Is InternalQueryNodeKind.ParameterAliasCollection.
+        /// </summary>
+        internal override InternalQueryNodeKind InternalKind => InternalQueryNodeKind.ParameterAliasCollection;
+
+        /// <summary>
+        /// Accept a <see cref="QueryNodeVisitor{T}"/> to walk a tree of <see cref="QueryNode"/>s.
+        /// </summary>
+        /// <typeparam name="T">Type that the visitor will return after visiting this token.</typeparam>
+        /// <param name="visitor">An implementation of the visitor interface.</param>
+        /// <returns>An object whose type is determined by the type parameter of the visitor.</returns>
+        /// <exception cref="System.ArgumentNullException">Throws if the input visitor is null.</exception>
+        public override T Accept<T>(QueryNodeVisitor<T> visitor)
+        {
+            ExceptionUtils.CheckArgumentNotNull(visitor, "visitor");
+            return visitor.Visit(this);
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/ParameterAliasValueAccessor.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/ParameterAliasValueAccessor.cs
@@ -22,14 +22,14 @@ namespace Microsoft.OData.UriParser
         {
             ExceptionUtils.CheckArgumentNotNull(parameterAliasValueExpressions, "parameterAliasValueExpressions");
             this.ParameterAliasValueExpressions = new Dictionary<string, string>(parameterAliasValueExpressions, StringComparer.Ordinal);
-            this.ParameterAliasValueNodesCached = new Dictionary<string, SingleValueNode>(StringComparer.Ordinal);
+            this.ParameterAliasValueNodesCached = new Dictionary<string, QueryNode>(StringComparer.Ordinal);
         }
 
         /// <summary>
         /// Gets the up-to-now cached semantics nodes of parameter alias value expressions (StringComparer.Ordinal)
         /// Only referenced parameter alias will have their value nodes cached.
         /// </summary>
-        public IDictionary<string, SingleValueNode> ParameterAliasValueNodesCached { get; private set; }
+        public IDictionary<string, QueryNode> ParameterAliasValueNodesCached { get; private set; }
 
         /// <summary>
         /// Gets the parameter alias's value expressions like @p1=... (StringComparer.Ordinal)

--- a/src/Microsoft.OData.Core/UriParser/TreeNodeKinds/QueryNodeKind.cs
+++ b/src/Microsoft.OData.Core/UriParser/TreeNodeKinds/QueryNodeKind.cs
@@ -379,5 +379,10 @@ namespace Microsoft.OData.UriParser
         /// Node that represents a custom query option
         /// </summary>
         CustomQueryOption = 35,
+
+        /// <summary>
+        /// The parameter alias node to collection.
+        /// </summary>
+        ParameterAliasCollection = 36,
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Visitors/QueryNodeVisitor.cs
+++ b/src/Microsoft.OData.Core/UriParser/Visitors/QueryNodeVisitor.cs
@@ -255,6 +255,16 @@ namespace Microsoft.OData.UriParser
         }
 
         /// <summary>
+        /// Visit a ParameterAliasCollectionNode
+        /// </summary>
+        /// <param name="nodeIn">The node to visit</param>
+        /// <returns>The translated expression</returns>
+        public virtual T Visit(ParameterAliasCollectionNode nodeIn)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Visit a SearchTermNode
         /// </summary>
         /// <param name="nodeIn">The node to visit</param>

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/UrlBuilderWithParameterAliasTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/UrlBuilderWithParameterAliasTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
 
             odataUri.Path.LastSegment.ShouldBeOperationImportSegment(HardCodedTestModel.GetFunctionImportForGetPet4()).Parameters.First().ShouldHaveParameterAliasNode("id", "@p1", EdmCoreModel.Instance.GetDecimal(false));
             aliasNodes["@p1"].ShouldBeConstantQueryNode(1.01M);
@@ -49,7 +49,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             SetODataUriParserSettingsTo(this.settings, odataUriParser.Settings);
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
 
             OperationSegmentParameter p = odataUri.Path.LastSegment.ShouldBeOperationImportSegment(HardCodedTestModel.GetFunctionImportForGetPetCount()).Parameters.First();
             Assert.Equal("colorPattern", p.Name);
@@ -58,10 +58,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             Assert.True(node.TypeReference.IsEnum());
             Assert.Equal("Fully.Qualified.Namespace.ColorPattern", node.TypeReference.Definition.FullTypeName());
 
-            var enumValue = Assert.IsType<ODataEnumValue>(Assert.IsType<ConstantNode>(aliasNodes["@p1"]).Value);
+            ConstantNode constNode = Assert.IsType<ConstantNode>(aliasNodes["@p1"]);
+            var enumValue = Assert.IsType<ODataEnumValue>(constNode.Value);
             Assert.Equal("Fully.Qualified.Namespace.ColorPattern", enumValue.TypeName);
             Assert.Equal("22", enumValue.Value);
-            Assert.True(aliasNodes["@p1"].TypeReference.IsEnum());
+            Assert.True(constNode.TypeReference.IsEnum());
 
             Uri actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
             Assert.Equal(fullUri, actualUri, new UriComparer<Uri>());
@@ -79,7 +80,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
 
             odataUri.Path.LastSegment.ShouldBeOperationImportSegment(HardCodedTestModel.GetFunctionImportForGetPet4()).Parameters.First().ShouldHaveParameterAliasNode("id", "@p1", EdmCoreModel.Instance.GetDecimal(false));
             odataUri.Filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal).Right.ShouldBeParameterAliasNode("@p1", EdmCoreModel.Instance.GetDecimal(false));
@@ -101,7 +102,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
             odataUri.Path.LastSegment.ShouldBeOperationImportSegment(HardCodedTestModel.GetFunctionImportForGetPet4()).Parameters.First().ShouldHaveParameterAliasNode("id", "@p1", null);
             aliasNodes["@p1"].ShouldBeConstantQueryNode((object)null);
 
@@ -121,7 +122,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
 
             var operation = HardCodedTestModel.TestModel.FindOperations("Fully.Qualified.Namespace.HasHat").Single(s => (s as IEdmFunction).Parameters.Count() == 2);
             odataUri.Path.LastSegment.ShouldBeOperationSegment(operation);
@@ -145,7 +146,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
             var functionCallNode = odataUri.Filter.Expression.ShouldBeSingleValueFunctionCallQueryNode(HardCodedTestModel.GetFunctionForAllHaveDogWithTwoParameters());
 
             var queryNode = Assert.IsType<NamedFunctionParameterNode>(functionCallNode.Parameters.Last()).Value;
@@ -176,12 +177,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             Assert.True(aliasNode.TypeReference.IsEnum());
             Assert.Equal("Fully.Qualified.Namespace.ColorPattern", aliasNode.TypeReference.Definition.FullTypeName());
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
             var node = Assert.IsType<ConstantNode>(aliasNodes["@p1"]);
             var enumValue = Assert.IsType<ODataEnumValue>(node.Value);
             Assert.Equal("Fully.Qualified.Namespace.ColorPattern", enumValue.TypeName);
             Assert.Equal("22", enumValue.Value);
-            Assert.True(aliasNodes["@p1"].TypeReference.IsEnum());
+            Assert.True(node.TypeReference.IsEnum());
 
             Uri actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
             Assert.Equal(fullUri, actualUri, new UriComparer<Uri>());
@@ -206,12 +207,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             Assert.True(aliasNode.TypeReference.IsEnum());
             Assert.Equal("Fully.Qualified.Namespace.ColorPattern", aliasNode.TypeReference.Definition.FullTypeName());
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
             var node = Assert.IsType<ConstantNode>(aliasNodes["@p1"]);
             var enumValue = Assert.IsType<ODataEnumValue>(node.Value);
             Assert.Equal("Fully.Qualified.Namespace.ColorPattern", enumValue.TypeName);
             Assert.Equal("238563", enumValue.Value);
-            Assert.True(aliasNodes["@p1"].TypeReference.IsEnum());
+            Assert.True(node.TypeReference.IsEnum());
 
             Uri actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
             Assert.Equal(fullUri, actualUri, new UriComparer<Uri>());
@@ -229,7 +230,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
 
             var function = HardCodedTestModel.GetHasDogOverloadForPeopleWithThreeParameters() as IEdmFunction;
             Assert.NotNull(function);
@@ -253,7 +254,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
             var function = HardCodedTestModel.GetHasDogOverloadForPeopleWithThreeParameters() as IEdmFunction;
             Assert.NotNull(function);
             var functionCallNode = odataUri.Filter.Expression.ShouldBeSingleValueFunctionCallQueryNode(function);
@@ -269,6 +270,38 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         }
 
         [Fact]
+        public void BuildFilter_AliasFilter_Recursive_CollectionPropertyAsValue()
+        {
+            Uri fullUri = new Uri("http://gobbledygook/People?$filter=ID in @p1&@p1=@p2&@p2=RelatedIDs");
+            ODataUriParser odataUriParser = new ODataUriParser(HardCodedTestModel.TestModel, serviceRoot, fullUri);
+            SetODataUriParserSettingsTo(this.settings, odataUriParser.Settings);
+            odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
+            ODataUri odataUri = odataUriParser.ParseUri();
+
+            var inNode = odataUri.Filter.Expression.ShouldBeInNode();
+
+            SingleValuePropertyAccessNode singleValuePropAccessNode = Assert.IsType<SingleValuePropertyAccessNode>(inNode.Left);
+            Assert.Equal("ID", singleValuePropAccessNode.Property.Name);
+
+            inNode.Right.ShouldBeParameterAliasCollectionNode("@p1", EdmCoreModel.Instance.GetInt32(false));
+
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
+
+            ParameterAliasCollectionNode p1ParameterNode = Assert.IsType<ParameterAliasCollectionNode>(aliasNodes["@p1"]);
+            Assert.Equal("@p2", p1ParameterNode.Alias);
+
+            CollectionPropertyAccessNode colValuePropAccessNode = Assert.IsType<CollectionPropertyAccessNode>(aliasNodes["@p2"]);
+            Assert.Equal("RelatedIDs", colValuePropAccessNode.Property.Name);
+
+            Uri expected = new Uri("http://gobbledygook/People?$filter=ID in %40p1&@p2=RelatedIDs&@p1=%40p2");
+            Uri actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
+            Assert.Equal(expected, actualUri, new UriComparer<Uri>());
+
+            actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Slash);
+            Assert.Equal(expected, actualUri, new UriComparer<Uri>());
+        }
+
+        [Fact]
         public void BuildFilter_AliasInFunction_PropertyAsValue_TypeMismatch()
         {
             Uri fullUri = new Uri("http://gobbledygook/People?$filter=Fully.Qualified.Namespace.HasDog(inOffice%3D%40p1%2Cname%3D%40p1)&@p2=Name&@p1=%40p2");
@@ -277,7 +310,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
             IEdmFunction function = HardCodedTestModel.GetHasDogOverloadForPeopleWithThreeParameters() as IEdmFunction;
             Assert.NotNull(function);
             var functionCallNode = odataUri.Filter.Expression.ShouldBeSingleValueFunctionCallQueryNode(function);
@@ -302,7 +335,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
             var function = HardCodedTestModel.GetHasDogOverloadForPeopleWithThreeParameters() as IEdmFunction;
             Assert.NotNull(function);
             var functionCallNode = odataUri.Filter.Expression.ShouldBeSingleValueFunctionCallQueryNode(function);
@@ -326,7 +359,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
             odataUri.Filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal).Right.ShouldBeParameterAliasNode("@p1", EdmCoreModel.Instance.GetInt32(false));
             aliasNodes["@p1"].ShouldBeBinaryOperatorNode(BinaryOperatorKind.Add).Right.ShouldBeConstantQueryNode(2);
 
@@ -346,7 +379,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
             Assert.IsType<SingleValueFunctionCallNode>(odataUri.Filter.Expression).Parameters.First().ShouldBeParameterAliasNode("@p1", EdmCoreModel.Instance.GetString(true));
             aliasNodes["@p1"].ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPeopleSet().EntityType.FindProperty("Name"));
 
@@ -430,7 +463,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
             var expectedFunc = HardCodedTestModel.GetAllHasDogFunctionOverloadsForPeople().Single(s => s.Parameters.Count() == 2);
             var funciontCallNode = odataUri.OrderBy.Expression.ShouldBeSingleValueFunctionCallQueryNode(expectedFunc);
             Assert.IsType<NamedFunctionParameterNode>(funciontCallNode.Parameters.Last()).Value.ShouldBeParameterAliasNode("@p1", EdmCoreModel.Instance.GetBoolean(false));
@@ -452,7 +485,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
             odataUri.OrderBy.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Multiply).Right.ShouldBeParameterAliasNode("@p1", EdmCoreModel.Instance.GetInt32(false));
             aliasNodes["@p1"].ShouldBeBinaryOperatorNode(BinaryOperatorKind.Divide).Right.ShouldBeConstantQueryNode(2);
 
@@ -474,7 +507,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
 
-            IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
+            IDictionary<string, QueryNode> aliasNodes = odataUri.ParameterAliasNodes;
             SingleValueFunctionCallNode node = (odataUri.SelectAndExpand.SelectedItems.First() as ExpandedNavigationSelectItem).OrderByOption.Expression as SingleValueFunctionCallNode;
             node.Parameters.Last().ShouldBeParameterAliasNode("@p1", EdmCoreModel.Instance.GetString(true));
             aliasNodes["@p1"].ShouldBeConstantQueryNode("abc");

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FullUriFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FullUriFunctionalTests.cs
@@ -201,7 +201,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             startsWithArgs[1].ShouldBeParameterAliasNode("@p2", EdmCoreModel.Instance.GetString(true));
 
             // @p1
-            Assert.True(parser.ParameterAliasNodes["@p1"].TypeReference.IsInt32());
+            ConstantNode p1 = Assert.IsType<ConstantNode>(parser.ParameterAliasNodes["@p1"]);
+            Assert.True(p1.TypeReference.IsInt32());
 
             // @p2
             List<QueryNode> p2Node = parser.ParameterAliasNodes["@p2"].ShouldBeSingleValueFunctionCallQueryNode("concat").Parameters.ToList();

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ParameterAliasFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ParameterAliasFunctionalTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
                    var enumValue = Assert.IsType<ODataEnumValue>(constNode.Value);
                    Assert.Equal("Fully.Qualified.Namespace.ColorPattern", enumValue.TypeName);
                    Assert.Equal("22", enumValue.Value);
-                   Assert.True(aliasNodes["@p1"].TypeReference.IsEnum());
+                   Assert.True(constNode.TypeReference.IsEnum());
                });
         }
 
@@ -288,7 +288,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
                     var enumValue = Assert.IsType<ODataEnumValue>(constNode.Value);
                     Assert.Equal("Fully.Qualified.Namespace.ColorPattern", enumValue.TypeName);
                     Assert.Equal("22", enumValue.Value);
-                    Assert.True(aliasNodes["@p1"].TypeReference.IsEnum());
+                    Assert.True(constNode.TypeReference.IsEnum());
                 });
         }
 
@@ -312,7 +312,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
                     var enumValue = Assert.IsType<ODataEnumValue>(constNode.Value);
                     Assert.Equal("Fully.Qualified.Namespace.ColorPattern", enumValue.TypeName);
                     Assert.Equal("238563", enumValue.Value);
-                    Assert.True(aliasNodes["@p1"].TypeReference.IsEnum());
+                    Assert.True(constNode.TypeReference.IsEnum());
                 });
         }
 
@@ -425,6 +425,47 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
                     var singlePropAccessNode = Assert.IsType<SingleValuePropertyAccessNode>(aliasNodes["@p1"]);
                     Assert.Equal("ID", singlePropAccessNode.Property.Name);
+                });
+        }
+
+        [Fact]
+        public void ParseFilter_AliasBothInsideInOperator_OperandsAsExpressions()
+        {
+            ParseUriAndVerify(
+                new Uri("http://gobbledygook/People?$filter=@p1 in @p2&@p1=ID&@p2=RelatedIDs"),
+                (oDataPath, filterClause, orderByClause, selectExpandClause, aliasNodes) =>
+                {
+                    var inNode = Assert.IsType<InNode>(filterClause.Expression);
+                    inNode.Left.ShouldBeParameterAliasNode("@p1", EdmCoreModel.Instance.GetInt32(false));
+                    inNode.Right.ShouldBeParameterAliasCollectionNode("@p2", EdmCoreModel.Instance.GetInt32(false));
+
+                    SingleValuePropertyAccessNode singleValuePropAccessNode = Assert.IsType<SingleValuePropertyAccessNode>(aliasNodes["@p1"]);
+                    Assert.Equal("ID", singleValuePropAccessNode.Property.Name);
+
+                    CollectionPropertyAccessNode colValuePropAccessNode = Assert.IsType<CollectionPropertyAccessNode>(aliasNodes["@p2"]);
+                    Assert.Equal("RelatedIDs", colValuePropAccessNode.Property.Name);
+                });
+        }
+
+        [Fact]
+        public void ParseFilter_AliasBothInsideInOperator_MultipleParameterAliasAsExpressions()
+        {
+            ParseUriAndVerify(
+                new Uri("http://gobbledygook/People?$filter=@p1 in @p2&@p1=ID&@p2=@p3&@p3=RelatedIDs"),
+                (oDataPath, filterClause, orderByClause, selectExpandClause, aliasNodes) =>
+                {
+                    var inNode = Assert.IsType<InNode>(filterClause.Expression);
+                    inNode.Left.ShouldBeParameterAliasNode("@p1", EdmCoreModel.Instance.GetInt32(false));
+                    inNode.Right.ShouldBeParameterAliasCollectionNode("@p2", EdmCoreModel.Instance.GetInt32(false));
+
+                    SingleValuePropertyAccessNode singleValuePropAccessNode = Assert.IsType<SingleValuePropertyAccessNode>(aliasNodes["@p1"]);
+                    Assert.Equal("ID", singleValuePropAccessNode.Property.Name);
+
+                    ParameterAliasCollectionNode parameterP2Alias = Assert.IsType<ParameterAliasCollectionNode>(aliasNodes["@p2"]);
+                    Assert.Equal("@p3", parameterP2Alias.Alias);
+
+                    CollectionPropertyAccessNode colValuePropAccessNode = Assert.IsType<CollectionPropertyAccessNode>(aliasNodes["@p3"]);
+                    Assert.Equal("RelatedIDs", colValuePropAccessNode.Property.Name);
                 });
         }
 
@@ -1033,7 +1074,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         #region private methods
         private void ParseUriAndVerify(
             Uri uri,
-            Action<ODataPath, FilterClause, OrderByClause, SelectExpandClause, IDictionary<string, SingleValueNode>> verifyAction)
+            Action<ODataPath, FilterClause, OrderByClause, SelectExpandClause, IDictionary<string, QueryNode>> verifyAction)
         {
             // run 2 test passes:
             // 1. low level api - ODataUriParser instance methods

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ParameterAliasFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ParameterAliasFunctionalTests.cs
@@ -1098,7 +1098,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
                 // Two parser should share same ParameterAliasNodes
                 verifyAction(path, filterClause, orderByClause, selectExpandClause, parser.ParameterAliasNodes);
-                verifyAction(path, filterClause, orderByClause, selectExpandClause, queryOptionParser.ParameterAliasNodes);
+                verifyAction(path, filterClause, orderByClause, selectExpandClause, queryOptionParser.ParameterAliasAllNodes);
             }
 
             //2. high level api - ParseUri

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SetBasedOperationTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SetBasedOperationTests.cs
@@ -441,7 +441,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
                 // Two parser should share same ParameterAliasNodes
                 verifyAction(path, filterClause, parser.ParameterAliasNodes);
-                verifyAction(path, filterClause, queryOptionParser.ParameterAliasNodes);
+                verifyAction(path, filterClause, queryOptionParser.ParameterAliasAllNodes);
             }
 
             //2. high level api - ParseUri

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SetBasedOperationTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SetBasedOperationTests.cs
@@ -419,7 +419,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         #region private methods
         private void ParseUriAndVerify(
             Uri uri,
-            Action<ODataPath, FilterClause, IDictionary<string, SingleValueNode>> verifyAction)
+            Action<ODataPath, FilterClause, IDictionary<string, QueryNode>> verifyAction)
         {
             // run 2 test passes:
             // 1. low level api - ODataUriParser instance methods

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/NodeAssertions.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/NodeAssertions.cs
@@ -418,6 +418,15 @@ namespace Microsoft.OData.Tests.UriParser
             return paramAliasNode;
         }
 
+        public static ParameterAliasCollectionNode ShouldBeParameterAliasCollectionNode(this QueryNode node, string alias, IEdmTypeReference itemType)
+        {
+            Assert.NotNull(node);
+            var paramAliasNode = Assert.IsType<ParameterAliasCollectionNode>(node);
+            Assert.Equal(alias, paramAliasNode.Alias);
+            Assert.True(paramAliasNode.ItemType.IsEquivalentTo(itemType));
+            return paramAliasNode;
+        }
+
         public static UriTemplateExpression ShouldBeUriTemplateExpression(this object node, string literalText, IEdmTypeReference expectedType)
         {
             Assert.NotNull(node);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #1161.*

### Description

* So far, the parameter alias is designed as SingleValueNode.
* No matter what the real value is. 
* For example:
* ~/people?$filter=Id in @p1&@p1=RelatedIds
* Where 'RelatedIds' is a collection property.

This PR is to support this. In this PR:

1) Introduce a new class as "ParameterAliasCollectionNode", which is a parameter alias node but point to a collection value.
2) Keep "ParameterAliasNode" unchanged for single value node
3) Add Test codes to verify the changes.

The reason to change it is that it's time to introduce this breaking change for a public property from
 "IDictionary<string, SingleValueNode>" to
 "IDictionary<string, QueryNode>".


### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
