### PR TITLE
Fixes the test project building warnings

### DIFF
--- a/src/CodeGen/ODataT4CodeGenerator.ttinclude
+++ b/src/CodeGen/ODataT4CodeGenerator.ttinclude
@@ -3242,7 +3242,7 @@ namespace <#= fullNamespace #>
         /// server schema, use type-mappers to map between the two.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
-        protected global::System.Type ResolveTypeFromName(string typeName)
+        protected new global::System.Type ResolveTypeFromName(string typeName)
         {
 <#+
     }

--- a/src/Microsoft.OData.Core/Json/IJsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/IJsonWriter.cs
@@ -7,7 +7,6 @@
 namespace Microsoft.OData.Json
 {
     using System;
-    using Microsoft.OData.Edm;
     using System.Threading.Tasks;
     using System.IO;
     using System.Text.Json;
@@ -18,18 +17,6 @@ namespace Microsoft.OData.Json
     [CLSCompliant(false)]
     public interface IJsonWriter
     {
-        /// <summary>
-        /// Start the padding function scope.
-        /// </summary>
-        [Obsolete("This will be dropped in the 9.x release.")]
-        void StartPaddingFunctionScope();
-
-        /// <summary>
-        /// End the padding function scope.
-        /// </summary>
-        [Obsolete("This will be dropped in the 9.x release.")]
-        void EndPaddingFunctionScope();
-
         /// <summary>
         /// Start the object scope.
         /// </summary>
@@ -55,13 +42,6 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="name">Name of the object property.</param>
         void WriteName(string name);
-
-        /// <summary>
-        /// Writes a function name for JSON padding.
-        /// </summary>
-        /// <param name="functionName">Name of the padding function to write.</param>
-        [Obsolete("This will be dropped in the 9.x release.")]
-        void WritePaddingFunctionName(string functionName);
 
         /// <summary>
         /// Write a boolean value.
@@ -204,20 +184,6 @@ namespace Microsoft.OData.Json
         void EndTextWriterValueScope();
 
         /// <summary>
-        /// Asynchronously starts the padding function scope.
-        /// </summary>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        [Obsolete("This will be dropped in the 9.x release.")]
-        Task StartPaddingFunctionScopeAsync();
-
-        /// <summary>
-        /// Asynchronously ends the padding function scope.
-        /// </summary>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        [Obsolete("This will be dropped in the 9.x release.")]
-        Task EndPaddingFunctionScopeAsync();
-
-        /// <summary>
         /// Asynchronously starts the object scope.
         /// </summary>
         /// <returns>A task that represents the asynchronous operation.</returns>
@@ -247,14 +213,6 @@ namespace Microsoft.OData.Json
         /// <param name="name">Name of the object property.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
         Task WriteNameAsync(string name);
-
-        /// <summary>
-        /// Asynchronously writes a function name for JSON padding.
-        /// </summary>
-        /// <param name="functionName">Name of the padding function to write.</param>
-        /// <returns>A task that represents the asynchronous write operation.</returns>
-        [Obsolete("This will be dropped in the 9.x release.")]
-        Task WritePaddingFunctionNameAsync(string functionName);
 
         /// <summary>
         /// Asynchronously writes a boolean value.

--- a/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -30,7 +30,6 @@ Microsoft.OData.IServiceCollectionProvider
 Microsoft.OData.IServiceCollectionProvider.ServiceProvider.get -> System.IServiceProvider
 Microsoft.OData.Json.IJsonWriter.EndArrayScopeAsync() -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.EndObjectScopeAsync() -> System.Threading.Tasks.Task
-Microsoft.OData.Json.IJsonWriter.EndPaddingFunctionScopeAsync() -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.EndStreamValueScope() -> void
 Microsoft.OData.Json.IJsonWriter.EndStreamValueScopeAsync() -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.EndTextWriterValueScope() -> void
@@ -38,13 +37,11 @@ Microsoft.OData.Json.IJsonWriter.EndTextWriterValueScopeAsync() -> System.Thread
 Microsoft.OData.Json.IJsonWriter.FlushAsync() -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.StartArrayScopeAsync() -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.StartObjectScopeAsync() -> System.Threading.Tasks.Task
-Microsoft.OData.Json.IJsonWriter.StartPaddingFunctionScopeAsync() -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.StartStreamValueScope() -> System.IO.Stream
 Microsoft.OData.Json.IJsonWriter.StartStreamValueScopeAsync() -> System.Threading.Tasks.Task<System.IO.Stream>
 Microsoft.OData.Json.IJsonWriter.StartTextWriterValueScope(string contentType) -> System.IO.TextWriter
 Microsoft.OData.Json.IJsonWriter.StartTextWriterValueScopeAsync(string contentType) -> System.Threading.Tasks.Task<System.IO.TextWriter>
 Microsoft.OData.Json.IJsonWriter.WriteNameAsync(string name) -> System.Threading.Tasks.Task
-Microsoft.OData.Json.IJsonWriter.WritePaddingFunctionNameAsync(string functionName) -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.WriteRawValueAsync(string rawValue) -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.WriteValueAsync(bool value) -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.WriteValueAsync(byte value) -> System.Threading.Tasks.Task
@@ -301,13 +298,10 @@ Microsoft.OData.Json.IJsonReaderFactory.CreateJsonReader(System.IO.TextReader te
 Microsoft.OData.Json.IJsonWriter
 Microsoft.OData.Json.IJsonWriter.EndArrayScope() -> void
 Microsoft.OData.Json.IJsonWriter.EndObjectScope() -> void
-Microsoft.OData.Json.IJsonWriter.EndPaddingFunctionScope() -> void
 Microsoft.OData.Json.IJsonWriter.Flush() -> void
 Microsoft.OData.Json.IJsonWriter.StartArrayScope() -> void
 Microsoft.OData.Json.IJsonWriter.StartObjectScope() -> void
-Microsoft.OData.Json.IJsonWriter.StartPaddingFunctionScope() -> void
 Microsoft.OData.Json.IJsonWriter.WriteName(string name) -> void
-Microsoft.OData.Json.IJsonWriter.WritePaddingFunctionName(string functionName) -> void
 Microsoft.OData.Json.IJsonWriter.WriteRawValue(string rawValue) -> void
 Microsoft.OData.Json.IJsonWriter.WriteValue(bool value) -> void
 Microsoft.OData.Json.IJsonWriter.WriteValue(byte value) -> void

--- a/test/EndToEndTests/Common/Microsoft.OData.E2E.TestCommon/Common/Server/Default/DefaultDataModel.cs
+++ b/test/EndToEndTests/Common/Microsoft.OData.E2E.TestCommon/Common/Server/Default/DefaultDataModel.cs
@@ -70,7 +70,7 @@ namespace Microsoft.OData.E2E.TestCommon.Common.Server.Default
         public string? LastName { get; set; }
         public string? MiddleName { get; set; }
         public Collection<string>? Numbers { get; set; }
-        public Collection<string>? Emails { get; set; }
+        public Collection<string?>? Emails { get; set; }
         public Collection<Address>? Addresses { get; set; }
         public Address? HomeAddress { get; set; }
         public GeographyPoint? Home { get; set; }

--- a/test/EndToEndTests/Common/Microsoft.OData.E2E.TestCommon/Common/Server/Default/DefaultDataSource.cs
+++ b/test/EndToEndTests/Common/Microsoft.OData.E2E.TestCommon/Common/Server/Default/DefaultDataSource.cs
@@ -7,6 +7,7 @@
 
 using Microsoft.OData.Edm;
 using Microsoft.Spatial;
+using Xunit;
 
 namespace Microsoft.OData.E2E.TestCommon.Common.Server.Default
 {
@@ -541,11 +542,17 @@ namespace Microsoft.OData.E2E.TestCommon.Common.Server.Default
             Orders[0].OrderDetails = [OrderDetails[1]];
             Orders[1].OrderDetails = [OrderDetails[2]];
 
-            (People[2] as Employee).CompanyID = Company.CompanyID;
-            (People[3] as Employee).CompanyID = Company.CompanyID;
-            (People[2] as Employee).Company = Company;
-            (People[3] as Employee).Company = Company;
-            Company.Employees = [(People[2] as Employee), (People[3] as Employee)];
+            Employee? p2 = People[2] as Employee;
+            Assert.NotNull(p2);
+            p2.CompanyID = Company.CompanyID;
+            p2.Company = Company;
+
+            Employee? p3 = People[3] as Employee;
+            Assert.NotNull(p3);
+            p3.CompanyID = Company.CompanyID;
+            p3.Company = Company;
+
+            Company.Employees = [p2, p3];
             Company.VipCustomer = VipCustomer;
             VipCustomer.Company = Company;
 
@@ -908,9 +915,9 @@ namespace Microsoft.OData.E2E.TestCommon.Common.Server.Default
                 }
             ];
 
-            Accounts[0].AccountInfo.DynamicProperties["MiddleName"] = "Hood";
-            Accounts[0].AccountInfo.DynamicProperties["FavoriteColor"] = Color.Red;
-            Accounts[0].AccountInfo.DynamicProperties["Address"] = new Address
+            Accounts[0].AccountInfo?.DynamicProperties?["MiddleName"] = "Hood";
+            Accounts[0].AccountInfo?.DynamicProperties?["FavoriteColor"] = Color.Red;
+            Accounts[0].AccountInfo?.DynamicProperties?["Address"] = new Address
             {
                 City = "a",
                 Street = "b",

--- a/test/EndToEndTests/Common/Microsoft.OData.E2E.TestCommon/Common/Server/EndToEnd/CommonEndToEndDataSource.cs
+++ b/test/EndToEndTests/Common/Microsoft.OData.E2E.TestCommon/Common/Server/EndToEnd/CommonEndToEndDataSource.cs
@@ -8279,23 +8279,35 @@ namespace Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd
         private void PopulateLogin_ReceivedMessages()
         {
             var loginDictionary = new Dictionary<string, Login>();
-            foreach (var login in Logins)
+            if (Logins != null)
             {
-                loginDictionary[login.Username] = login;
+                foreach (var login in Logins)
+                {
+                    if (login.Username != null)
+                    {
+                        loginDictionary[login.Username] = login;
+                    }
+                }
             }
 
-            foreach (var message in Messages)
+            if (Messages != null)
             {
-                if (loginDictionary.TryGetValue(message.FromUsername, out var recipientLogin))
+                foreach (var message in Messages)
                 {
-                    message.Recipient = recipientLogin;
-
-                    if (recipientLogin.ReceivedMessages == null)
+                    if (message.FromUsername != null)
                     {
-                        recipientLogin.ReceivedMessages = new List<Message>();
-                    }
+                        if (loginDictionary.TryGetValue(message.FromUsername, out var recipientLogin))
+                        {
+                            message.Recipient = recipientLogin;
 
-                    recipientLogin.ReceivedMessages.Add(message);
+                            if (recipientLogin.ReceivedMessages == null)
+                            {
+                                recipientLogin.ReceivedMessages = new List<Message>();
+                            }
+
+                            recipientLogin.ReceivedMessages.Add(message);
+                        }
+                    }
                 }
             }
         }
@@ -8303,16 +8315,22 @@ namespace Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd
         private void PopulateCustomer_CustomerInfo()
         {
             var customerDictionary = new Dictionary<int, Customer>();
-            foreach (var customer in Customers)
+            if (Customers != null)
             {
-                customerDictionary[customer.CustomerId] = customer;
+                foreach (var customer in Customers)
+                {
+                    customerDictionary[customer.CustomerId] = customer;
+                }
             }
 
-            foreach (var customerInfo in CustomerInfos)
+            if (CustomerInfos != null)
             {
-                if (customerDictionary.TryGetValue(customerInfo.CustomerInfoId, out var customer))
+                foreach (var customerInfo in CustomerInfos)
                 {
-                    customer.Info = customerInfo;
+                    if (customerDictionary.TryGetValue(customerInfo.CustomerInfoId, out var customer))
+                    {
+                        customer.Info = customerInfo;
+                    }
                 }
             }
         }

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ActionOverloadingTests/Server/ActionOverloadingTestsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ActionOverloadingTests/Server/ActionOverloadingTestsController.cs
@@ -10,18 +10,19 @@ using Microsoft.AspNetCore.OData.Formatter;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.AspNetCore.OData.Routing.Controllers;
 using Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd;
+using Xunit;
 
 namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
 {
     public class ActionOverloadingTestsController : ODataController
     {
-        private static CommonEndToEndDataSource _dataSource;
+        private static CommonEndToEndDataSource? _dataSource;
 
         [EnableQuery]
         [HttpGet("odata/People")]
         public IActionResult Get()
         {
-            var people = _dataSource.People;
+            var people = _dataSource?.People;
 
             return Ok(people);
         }
@@ -30,7 +31,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpGet("odata/People({key})")]
         public IActionResult Get(int key)
         {
-            var person = _dataSource.People.FirstOrDefault(a => a.PersonId == key);
+            var person = _dataSource?.People?.FirstOrDefault(a => a.PersonId == key);
 
             if (person == null)
             {
@@ -43,7 +44,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/Default.UpdatePersonInfo")]
         public IActionResult UpdatePersonInfo()
         {
-            var person = _dataSource.People.SingleOrDefault(a => a.PersonId == -10);
+            var person = _dataSource?.People?.SingleOrDefault(a => a.PersonId == -10);
 
             if (person == null)
             {
@@ -58,7 +59,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People({key})/Default.UpdatePersonInfo")]
         public IActionResult UpdatePersonInfo([FromODataUri] int key)
         {
-            var person = _dataSource.People.SingleOrDefault(x => x.PersonId == key);
+            var person = _dataSource?.People?.SingleOrDefault(x => x.PersonId == key);
 
             if (person == null)
             {
@@ -73,7 +74,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People({key})/Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd.Person/Default.UpdatePersonInfo")]
         public IActionResult UpdateInfo([FromODataUri] int key)
         {
-            var person = _dataSource.People.SingleOrDefault(a => a.PersonId == key);
+            var person = _dataSource?.People?.SingleOrDefault(a => a.PersonId == key);
 
             if (person == null)
             {
@@ -88,7 +89,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People({key})/Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd.Employee/Default.UpdatePersonInfo")]
         public IActionResult UpdateEmployeeeInfo([FromODataUri] int key)
         {
-            var person = _dataSource.People.SingleOrDefault(a => a.PersonId == key);
+            var person = _dataSource?.People?.SingleOrDefault(a => a.PersonId == key);
 
             if (person == null)
             {
@@ -103,7 +104,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People({key})/Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd.SpecialEmployee/Default.UpdatePersonInfo")]
         public IActionResult UpdateSpecialEmployeeeInfo([FromODataUri] int key)
         {
-            var person = _dataSource.People.SingleOrDefault(a => a.PersonId == key);
+            var person = _dataSource?.People?.SingleOrDefault(a => a.PersonId == key);
 
             if (person == null)
             {
@@ -118,7 +119,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People({key})/Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd.Contractor/Default.UpdatePersonInfo")]
         public IActionResult UpdateContractorInfo([FromODataUri] int key)
         {
-            var person = _dataSource.People.SingleOrDefault(a => a.PersonId == key);
+            var person = _dataSource?.People?.SingleOrDefault(a => a.PersonId == key);
 
             if (person == null)
             {
@@ -133,7 +134,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People({key})/Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd.SpecialEmployee/Default.IncreaseEmployeeSalary")]
         public IActionResult IncreaseSpecialEmployeeSalary([FromODataUri] int key, ODataActionParameters parameters)
         {
-            var person = _dataSource.People.First(a => a.PersonId == key);
+            var person = _dataSource?.People?.First(a => a.PersonId == key);
 
             if (person is SpecialEmployee specialEmployee && parameters == null)
             {
@@ -142,7 +143,8 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
             }
             else
             {
-                var employee = (Employee)_dataSource.People.First(a => a.PersonId == key);
+                var employee = _dataSource?.People?.First(a => a.PersonId == key) as Employee;
+                Assert.NotNull(employee);
                 employee.Salary += (int)parameters["n"];
 
                 return Ok(true);
@@ -152,7 +154,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People({key})/Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd.Employee/Default.IncreaseEmployeeSalary")]
         public IActionResult IncreaseEmployeeSalary([FromODataUri] int key, ODataActionParameters parameters)
         {
-            var person = _dataSource.People.First(a => a.PersonId == key);
+            var person = _dataSource?.People?.First(a => a.PersonId == key);
 
             if (person is SpecialEmployee specialEmployee && parameters == null)
             {
@@ -161,7 +163,8 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
             }
             else
             {
-                var employee = (Employee)_dataSource.People.First(a => a.PersonId == key);
+                var employee = _dataSource?.People?.First(a => a.PersonId == key) as Employee;
+                Assert.NotNull(employee);
                 employee.Salary += (int)parameters["n"];
 
                 return Ok(true);
@@ -171,11 +174,13 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People/Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd.Employee/Default.IncreaseSalaries")]
         public IActionResult IncreaseSalaries(ODataActionParameters parameters)
         {
-            var employees = _dataSource.People.OfType<Employee>();
-
-            foreach (var employee in employees)
+            var employees = _dataSource?.People?.OfType<Employee>();
+            if (employees != null)
             {
-                employee.Salary += (int)parameters["n"];
+                foreach (var employee in employees)
+                {
+                    employee.Salary += (int)parameters["n"];
+                }
             }
 
             return Ok();
@@ -184,11 +189,13 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People/Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd.SpecialEmployee/Default.IncreaseSalaries")]
         public IActionResult IncreaseSpecialEmployeesSalaries(ODataActionParameters parameters)
         {
-            var employees = _dataSource.People.OfType<SpecialEmployee>();
-
-            foreach (var employee in employees)
+            var employees = _dataSource?.People?.OfType<SpecialEmployee>();
+            if (employees != null)
             {
-                employee.Salary += (int)parameters["n"];
+                foreach (var employee in employees)
+                {
+                    employee.Salary += (int)parameters["n"];
+                }
             }
 
             return Ok();
@@ -204,7 +211,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpGet("odata/OrderLines")]
         public IActionResult GetOrderLines()
         {
-            var orderLines = _dataSource.OrderLines;
+            var orderLines = _dataSource?.OrderLines;
 
             return Ok(orderLines);
         }
@@ -213,7 +220,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpGet("odata/OrderLines(OrderId={keyOrderId},ProductId={keyProductId})")]
         public IActionResult Get([FromRoute] int keyOrderId, [FromRoute] int keyProductId)
         {
-            var orderLine = _dataSource.OrderLines?.FirstOrDefault(a => a.OrderId == keyOrderId && a.ProductId == keyProductId);
+            var orderLine = _dataSource?.OrderLines?.FirstOrDefault(a => a.OrderId == keyOrderId && a.ProductId == keyProductId);
 
             if (orderLine == null)
             {
@@ -226,7 +233,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/OrderLines(OrderId={keyOrderId},ProductId={keyProductId})/Default.RetrieveProduct")]
         public IActionResult RetrieveProduct([FromODataUri] int keyOrderId, [FromODataUri] int keyProductId)
         {
-            var orderLine = _dataSource.OrderLines?.FirstOrDefault(a => a.OrderId == keyOrderId && a.ProductId == keyProductId);
+            var orderLine = _dataSource?.OrderLines?.FirstOrDefault(a => a.OrderId == keyOrderId && a.ProductId == keyProductId);
 
             if (orderLine == null)
             {
@@ -242,7 +249,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpGet("odata/Products")]
         public IActionResult GetProducts()
         {
-            var products = _dataSource.Products;
+            var products = _dataSource?.Products;
             return Ok(products);
         }
 
@@ -250,7 +257,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpGet("odata/Products({key})")]
         public IActionResult GetProduct(int key)
         {
-            var product = _dataSource.Products.FirstOrDefault(a => a.ProductId == key);
+            var product = _dataSource?.Products?.FirstOrDefault(a => a.ProductId == key);
 
             if (product == null)
             {
@@ -263,7 +270,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/RetrieveProduct")]
         public IActionResult RetrieveProduct()
         {
-            var product = _dataSource.Products.FirstOrDefault(a => a.ProductId == -9);
+            var product = _dataSource?.Products?.FirstOrDefault(a => a.ProductId == -9);
 
             if (product == null)
             {
@@ -278,7 +285,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/Products({key})/Default.RetrieveProduct")]
         public IActionResult RetrieveProduct([FromODataUri] int key)
         {
-            var product = _dataSource.Products.FirstOrDefault(a => a.ProductId == key);
+            var product = _dataSource?.Products?.FirstOrDefault(a => a.ProductId == key);
 
             if (product == null)
             {

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Client/AnnotationSerializationProxy.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Client/AnnotationSerializationProxy.cs
@@ -840,7 +840,7 @@ namespace Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.D
         /// server schema, use type-mappers to map between the two.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        protected global::System.Type ResolveTypeFromName(string typeName)
+        protected new global::System.Type ResolveTypeFromName(string typeName)
         {
             global::System.Type resolvedType = this.DefaultResolveType(typeName, "Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models", "Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models");
             if ((resolvedType != null))

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Server/ClientTestsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Server/ClientTestsController.cs
@@ -15,13 +15,13 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Server
 {
     public class ClientTestsController : ODataController
     {
-        private static DefaultDataSource _dataSource;
+        private static DefaultDataSource? _dataSource;
 
         [EnableQuery]
         [HttpGet("odata/People")]
         public IActionResult Get()
         {
-            var people = _dataSource.People;
+            var people = _dataSource?.People;
 
             return Ok(people);
         }
@@ -30,7 +30,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Server
         [HttpGet("odata/People({key})")]
         public IActionResult Get([FromRoute] int key)
         {
-            var person = _dataSource.People?.FirstOrDefault(a => a.PersonID == key);
+            var person = _dataSource?.People?.FirstOrDefault(a => a.PersonID == key);
 
             if (person == null)
             {
@@ -43,14 +43,14 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Server
         [HttpDelete("odata/People({key})")]
         public IActionResult DeletePerson(int key)
         {
-            var person = _dataSource.People.SingleOrDefault(a => a.PersonID == key);
+            var person = _dataSource?.People?.SingleOrDefault(a => a.PersonID == key);
 
             if (person == null)
             {
                 return NotFound();
             }
 
-            _dataSource.People.Remove(person);
+            _dataSource?.People?.Remove(person);
 
             return NoContent();
         }
@@ -58,14 +58,14 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Server
         [HttpDelete("odata/People({key})/Parent")]
         public IActionResult DeleteParent(int key)
         {
-            var person = _dataSource.People.SingleOrDefault(a => a.PersonID == key);
+            var person = _dataSource?.People?.SingleOrDefault(a => a.PersonID == key);
 
             if (person == null)
             {
                 return NotFound();
             }
 
-            _dataSource.People.Remove(person);
+            _dataSource?.People?.Remove(person);
 
             return NoContent();
         }
@@ -74,7 +74,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Server
         [HttpGet("odata/Products")]
         public IActionResult GetProducts()
         {
-            var products = _dataSource.Products;
+            var products = _dataSource?.Products;
 
             return Ok(products);
         }
@@ -83,7 +83,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Server
         [HttpGet("odata/Orders")]
         public IActionResult GetOrders()
         {
-            var orders = _dataSource.Orders;
+            var orders = _dataSource?.Orders;
 
             return Ok(orders);
         }
@@ -92,7 +92,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Server
         [HttpGet("odata/Customers")]
         public IActionResult GetCustomers()
         {
-            var customers = _dataSource.Customers;
+            var customers = _dataSource?.Customers;
 
             return Ok(customers);
         }
@@ -101,7 +101,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Server
         [HttpGet("odata/Customers({key})")]
         public IActionResult GetCustomer(int key)
         {
-            var customer = _dataSource.Customers.SingleOrDefault(a => a.PersonID == key);
+            var customer = _dataSource?.Customers?.SingleOrDefault(a => a.PersonID == key);
 
             if (customer == null)
             {
@@ -115,7 +115,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Server
         [HttpGet("odata/ProductDetails")]
         public IActionResult GetProductDetails()
         {
-            var productDetails = _dataSource.ProductDetails;
+            var productDetails = _dataSource?.ProductDetails;
 
             return Ok(productDetails);
         }
@@ -124,7 +124,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Server
         [HttpGet("odata/OrderDetails")]
         public IActionResult GetOrderDetails()
         {
-            var orderDetails = _dataSource.OrderDetails;
+            var orderDetails = _dataSource?.OrderDetails;
 
             return Ok(orderDetails);
         }
@@ -133,7 +133,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Server
         [HttpGet("odata/OrderDetails(orderId={orderId},productId={productId})")]
         public IActionResult GetOrderDetail([FromODataUri] int orderId, [FromODataUri] int productId)
         {
-            var orderDetail = _dataSource.OrderDetails.SingleOrDefault(a => a.OrderID == orderId && a.ProductID == productId);
+            var orderDetail = _dataSource?.OrderDetails?.SingleOrDefault(a => a.OrderID == orderId && a.ProductID == productId);
 
             if (orderDetail == null)
             {

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientEntityDescriptorTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientEntityDescriptorTests.cs
@@ -64,7 +64,8 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Tests
         [MemberData(nameof(GetEntitySetData))]
         public void EntityDescriptor_LinksAndIdentity_AreNotNull_ForAllEntities(string entitySetKey)
         {
-            IQueryable iqueryableProperty = typeof(Container).GetProperty(entitySetKey).GetValue(_context, null) as IQueryable;
+            IQueryable? iqueryableProperty = typeof(Container).GetProperty(entitySetKey)?.GetValue(_context, null) as IQueryable;
+            Assert.NotNull(iqueryableProperty);
             foreach (var entity in iqueryableProperty)
             {
                 EntityDescriptor eDescriptor = _context.GetEntityDescriptor(entity);

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientQueryTests.cs
@@ -220,13 +220,13 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Tests
             // Arrange
             int expectedCount = _context.Customers.Count();
             bool checkNextLink = false;
-            Uri nextPageLink = null;
+            Uri? nextPageLink = null;
 
             EventHandler<SendingRequest2EventArgs> sendRequestEvent = (sender, args) =>
             {
                 if (checkNextLink)
                 {
-                    Assert.Equal(nextPageLink.AbsoluteUri, args.RequestMessage.Url.AbsoluteUri);
+                    Assert.Equal(nextPageLink?.AbsoluteUri, args.RequestMessage.Url.AbsoluteUri);
                 }
 
                 checkNextLink = true;
@@ -322,13 +322,13 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Tests
             // Arrange
             int expectedCount = _context.Customers.Count();
             bool checkNextLink = false;
-            Uri nextPageLink = null;
+            Uri? nextPageLink = null;
 
             EventHandler<SendingRequest2EventArgs> sendRequestEvent = (sender, args) =>
             {
                 if (checkNextLink)
                 {
-                    Assert.Equal(nextPageLink.AbsoluteUri, args.RequestMessage.Url.AbsoluteUri);
+                    Assert.Equal(nextPageLink?.AbsoluteUri, args.RequestMessage.Url.AbsoluteUri);
                 }
 
                 checkNextLink = true;

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientWithoutTypeResolverTests/Clients/MismatchedClientModel/MismatchedClientModelWithoutTypeResolverContainer.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientWithoutTypeResolverTests/Clients/MismatchedClientModel/MismatchedClientModelWithoutTypeResolverContainer.cs
@@ -8667,7 +8667,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientWithoutTypeResolverTests.Client
         /// server schema, use type-mappers to map between the two.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        protected global::System.Type ResolveTypeFromName(string typeName)
+        protected new global::System.Type ResolveTypeFromName(string typeName)
         {
             global::System.Type resolvedType = this.DefaultResolveType(typeName, "Microsoft.OData.Client.E2E.Tests.Common.Server.EndToEnd", "Microsoft.OData.Client.E2E.Tests.ClientWithoutTypeResolverTests.Clients");
             if ((resolvedType != null))

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientWithoutTypeResolverTests/Server/OpenTypesWithoutTypeResolverTestsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientWithoutTypeResolverTests/Server/OpenTypesWithoutTypeResolverTestsController.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientWithoutTypeResolverTests.Server
 {
     public class OpenTypesWithoutTypeResolverTestsController : ODataController
     {
-        private static OpenTypesDataSource _dataSource;
+        private static OpenTypesDataSource? _dataSource;
 
         [EnableQuery]
         [HttpGet("odata/RowIndices")]

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ComplexTypeTests/ComplexTypeTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ComplexTypeTests/ComplexTypeTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests
 
             Assert.NotNull(personResult);
 
-            ClientDefaultModel.HomeAddress homeAddress = personResult.HomeAddress as ClientDefaultModel.HomeAddress;
+            ClientDefaultModel.HomeAddress? homeAddress = personResult.HomeAddress as ClientDefaultModel.HomeAddress;
 
             Assert.NotNull(homeAddress);
             Assert.Equal(1, personResult.PersonID);
@@ -283,6 +283,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests
                         Value = new ODataUntypedValue() { RawValue = "{ \"sender\": \"RSS\", \"senderImage\": \"https://exchangelabs.live-int.com/connectors/content/images/feed-icon-128px.png?upn=admin%40tenant-EXHR-3837dom.EXTEST.MICROSOFT.COM\", \"summary\": \"RSS is now connected to your mailbox\", \"title\": null }" }
                     };
                     var accountInfoComplexValueProperties = ea.Entry.Properties as List<ODataProperty>;
+                    Assert.NotNull(accountInfoComplexValueProperties);
                     accountInfoComplexValueProperties.Add(undeclaredOdataProperty);
                 }
             });
@@ -297,12 +298,13 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests
                 rsa.Settings.Validations ^= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
             });
 
-            ODataUntypedValue undeclaredOdataPropertyValue = null;
+            ODataUntypedValue? undeclaredOdataPropertyValue = null;
             _context.Configurations.ResponsePipeline.OnEntityMaterialized(rea =>
             {
                 if (rea.Entity.GetType() == typeof(ClientDefaultModel.AccountInfo))
                 {
                     var undeclaredOdataProperty = rea.Entry.Properties.OfType<ODataProperty>().FirstOrDefault(s => s.Name == "UndecalredOpenProperty1");
+                    Assert.NotNull(undeclaredOdataProperty);
                     undeclaredOdataPropertyValue = (ODataUntypedValue)undeclaredOdataProperty.Value;
                 }
             });
@@ -320,6 +322,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests
             if (ea.Entity.GetType() == typeof(ClientDefaultModel.AccountInfo))
             {
                 var properties = ea.Entry.Properties as List<ODataProperty>;
+                Assert.NotNull(properties);
                 var undeclaredOdataProperty = new ODataProperty() { Name = "dynamicPropertyKey", Value = "dynamicPropertyValue" };
                 properties.Add(undeclaredOdataProperty);
                 ea.Entry.Properties = properties;

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/PayloadValueConverterTests/Client/PayloadValueConverterContainer.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/PayloadValueConverterTests/Client/PayloadValueConverterContainer.cs
@@ -659,7 +659,7 @@ namespace Microsoft.OData.Client.E2E.Tests.PayloadValueConverterTests.Client.Def
         /// server schema, use type-mappers to map between the two.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        protected global::System.Type ResolveTypeFromName(string typeName)
+        protected new global::System.Type ResolveTypeFromName(string typeName)
         {
             global::System.Type resolvedType = this.DefaultResolveType(typeName, "Microsoft.OData.Client.E2E.Tests.PayloadValueConverterTests.Server", "Microsoft.OData.Client.E2E.Tests.PayloadValueConverterTests.Client");
             if ((resolvedType != null))

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/SingletonTests/Server/SingletonClientTestsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/SingletonTests/Server/SingletonClientTestsController.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OData.Client.E2E.Tests.SingletonTests.Server;
 
 public class SingletonClientTestsController : ODataController
 {
-    private static DefaultDataSource _dataSource;
+    private static DefaultDataSource? _dataSource;
 
 
     #region odata/VipCustomer

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/HttpClientTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/HttpClientTests.cs
@@ -176,8 +176,9 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests
         {
             _context.AddObject("Products", new ClientEndToEndModel.Product { ProductId = 55443, Description = "My new product", });
 
-            ClientEndToEndModel.Customer customerWithCustomerInfo = null;
+            ClientEndToEndModel.Customer? customerWithCustomerInfo = null;
             var query = _context.Customers.Expand(c => c.Info).Where(c => c.Info != null) as DataServiceQuery<ClientEndToEndModel.Customer>;
+            Assert.NotNull(query);
             var queryResult = await query.ExecuteAsync();
             customerWithCustomerInfo = queryResult.First();
 

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/Server/HttpClientController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/Server/HttpClientController.cs
@@ -15,13 +15,13 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
 {
     public class HttpClientController : ODataController
     {
-        private static CommonEndToEndDataSource _dataSource;
+        private static CommonEndToEndDataSource? _dataSource;
 
         [EnableQuery]
         [HttpGet("odata/Products")]
         public IActionResult Get()
         {
-            var products = _dataSource.Products;
+            var products = _dataSource?.Products;
 
             return Ok(products);
         }
@@ -30,7 +30,7 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
         [HttpGet("odata/Orders")]
         public IActionResult GetOrders()
         {
-            var orders = _dataSource.Orders;
+            var orders = _dataSource?.Orders;
 
             return Ok(orders);
         }
@@ -39,7 +39,7 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
         [HttpGet("odata/Customers")]
         public IActionResult GetCustomers()
         {
-            var customers = _dataSource.Customers;
+            var customers = _dataSource?.Customers;
 
             return Ok(customers);
         }
@@ -48,7 +48,7 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
         [HttpGet("odata/Computers")]
         public IActionResult GetComputer()
         {
-            var computers = _dataSource.Computers;
+            var computers = _dataSource?.Computers;
 
             return Ok(computers);
         }
@@ -57,7 +57,7 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
         [HttpGet("odata/Login")]
         public IActionResult GetLogins()
         {
-            var logins = _dataSource.Logins;
+            var logins = _dataSource?.Logins;
 
             return Ok(logins);
         }
@@ -65,21 +65,21 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
         [HttpPost("odata/Orders")]
         public IActionResult PostOrder([FromBody] Order order)
         {
-            _dataSource.Orders.Add(order);
+            _dataSource?.Orders?.Add(order);
             return Created(order);
         }
 
         [HttpPost("odata/Products")]
         public IActionResult PostProducts([FromBody] Product product)
         {
-            _dataSource.Products.Add(product);
+            _dataSource?.Products?.Add(product);
             return Created(product);
         }
 
         [HttpPatch("odata/Computers({key})")]
         public IActionResult GetComputer([FromRoute] int key)
         {
-            var computer = _dataSource.Computers.SingleOrDefault(a => a.ComputerId == key);
+            var computer = _dataSource?.Computers?.SingleOrDefault(a => a.ComputerId == key);
 
             if (computer == null)
             {
@@ -92,7 +92,7 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
         [HttpGet("odata/Products({key})/Description")]
         public IActionResult GetProductDescription([FromRoute] int key)
         {
-            var product = _dataSource.Products.SingleOrDefault(a => a.ProductId == key);
+            var product = _dataSource?.Products?.SingleOrDefault(a => a.ProductId == key);
 
             if (product == null)
             {
@@ -105,7 +105,7 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
         [HttpGet("odata/Orders({key})")]
         public IActionResult GetOrder([FromRoute] int key)
         {
-            var order = _dataSource.Orders.SingleOrDefault(a => a.OrderId == key);
+            var order = _dataSource?.Orders?.SingleOrDefault(a => a.OrderId == key);
 
             if (order == null)
             {
@@ -118,7 +118,7 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
         [HttpGet("odata/Products({key})/RelatedProducts")]
         public IActionResult GetRelatedProducts([FromRoute] int key)
         {
-            var product = _dataSource.Products.SingleOrDefault(a => a.ProductId == key);
+            var product = _dataSource?.Products?.SingleOrDefault(a => a.ProductId == key);
 
             if (product == null)
             {
@@ -131,7 +131,7 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
         [HttpPatch("odata/Products({key})")]
         public IActionResult PatchProducts([FromRoute] int key, [FromBody] Delta<Product> delta)
         {
-            var product = _dataSource.Products.SingleOrDefault(a => a.ProductId == key);
+            var product = _dataSource?.Products?.SingleOrDefault(a => a.ProductId == key);
 
             if (product == null)
             {
@@ -146,7 +146,7 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
         [HttpPatch("odata/CustomerInfos({key})")]
         public IActionResult PatchCustomerInfos([FromRoute] int key, [FromBody] Delta<CustomerInfo> delta)
         {
-            var customerInfo = _dataSource.CustomerInfos.SingleOrDefault(a => a.CustomerInfoId == key);
+            var customerInfo = _dataSource?.CustomerInfos?.SingleOrDefault(a => a.CustomerInfoId == key);
 
             if (customerInfo == null)
             {
@@ -161,7 +161,7 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
         [HttpPatch("odata/Customers({key})")]
         public IActionResult PatchCustomers([FromRoute] int key, [FromBody] Delta<Customer> delta)
         {
-            var customer = _dataSource.Customers.SingleOrDefault(a => a.CustomerId == key);
+            var customer = _dataSource?.Customers?.SingleOrDefault(a => a.CustomerId == key);
 
             if (customer == null)
             {
@@ -176,14 +176,14 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
         [HttpDelete("odata/Customers({key})")]
         public IActionResult DeleteCustomer([FromRoute] int key)
         {
-            var customer = _dataSource.Customers?.SingleOrDefault(o => o.CustomerId == key);
+            var customer = _dataSource?.Customers?.SingleOrDefault(o => o.CustomerId == key);
 
             if (customer == null)
             {
                 return NotFound();
             }
 
-            _dataSource.Customers.Remove(customer);
+            _dataSource?.Customers?.Remove(customer);
 
             return NoContent();
         }
@@ -191,17 +191,17 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
         [HttpPut("odata/Products({key})")]
         public IActionResult PutProduct([FromRoute] int key, [FromBody] Product product)
         {
-            var existProduct = _dataSource.Products?.SingleOrDefault(o => o.ProductId == key);
+            var existProduct = _dataSource?.Products?.SingleOrDefault(o => o.ProductId == key);
 
             if (existProduct == null)
             {
                 return NotFound();
             }
 
-            _dataSource.Products.Remove(existProduct);
+            _dataSource?.Products?.Remove(existProduct);
             existProduct.Description = product.Description;
 
-            _dataSource.Products.Add(existProduct);
+            _dataSource?.Products?.Add(existProduct);
 
             return Ok(existProduct);
         }
@@ -209,14 +209,14 @@ namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
         [HttpDelete("odata/Computers({key})")]
         public IActionResult DeleteComputer([FromRoute] int key)
         {
-            var computer = _dataSource.Computers?.SingleOrDefault(o => o.ComputerId == key);
+            var computer = _dataSource?.Computers?.SingleOrDefault(o => o.ComputerId == key);
 
             if (computer == null)
             {
                 return NotFound();
             }
 
-            _dataSource.Computers.Remove(computer);
+            _dataSource?.Computers?.Remove(computer);
 
             return NoContent();
         }

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/ActionOverloadingTests/Server/ActionOverloadingQueryTestsController.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/ActionOverloadingTests/Server/ActionOverloadingQueryTestsController.cs
@@ -15,13 +15,13 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
 {
     internal class ActionOverloadingQueryTestsController : ODataController
     {
-        private static CommonEndToEndDataSource _dataSource;
+        private static CommonEndToEndDataSource? _dataSource;
 
         [EnableQuery]
         [HttpGet("odata/People")]
         public IActionResult Get()
         {
-            var people = _dataSource.People;
+            var people = _dataSource?.People;
 
             return Ok(people);
         }
@@ -30,7 +30,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpGet("odata/People({key})")]
         public IActionResult Get(int key)
         {
-            var person = _dataSource.People.FirstOrDefault(a => a.PersonId == key);
+            var person = _dataSource?.People?.FirstOrDefault(a => a.PersonId == key);
 
             if (person == null)
             {
@@ -43,7 +43,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/Default.UpdatePersonInfo")]
         public IActionResult UpdatePersonInfo()
         {
-            var person = _dataSource.People.SingleOrDefault(a => a.PersonId == -10);
+            var person = _dataSource?.People?.SingleOrDefault(a => a.PersonId == -10);
 
             if (person == null)
             {
@@ -58,7 +58,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People({key})/Default.UpdatePersonInfo")]
         public IActionResult UpdatePersonInfo([FromODataUri] int key)
         {
-            var person = _dataSource.People.SingleOrDefault(x => x.PersonId == key);
+            var person = _dataSource?.People?.SingleOrDefault(x => x.PersonId == key);
 
             if (person == null)
             {
@@ -73,7 +73,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People({key})/Microsoft.OData.Client.E2E.TestCommon.Common.Server.EndToEnd.Person/Default.UpdatePersonInfo")]
         public IActionResult UpdateInfo([FromODataUri] int key)
         {
-            var person = _dataSource.People.SingleOrDefault(a => a.PersonId == key);
+            var person = _dataSource?.People?.SingleOrDefault(a => a.PersonId == key);
 
             if (person == null)
             {
@@ -88,7 +88,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People({key})/Microsoft.OData.Client.E2E.TestCommon.Common.Server.EndToEnd.Employee/Default.UpdatePersonInfo")]
         public IActionResult UpdateEmployeeeInfo([FromODataUri] int key)
         {
-            var person = _dataSource.People.SingleOrDefault(a => a.PersonId == key);
+            var person = _dataSource?.People?.SingleOrDefault(a => a.PersonId == key);
 
             if (person == null)
             {
@@ -103,7 +103,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People({key})/Microsoft.OData.Client.E2E.TestCommon.Common.Server.EndToEnd.SpecialEmployee/Default.UpdatePersonInfo")]
         public IActionResult UpdateSpecialEmployeeeInfo([FromODataUri] int key)
         {
-            var person = _dataSource.People.SingleOrDefault(a => a.PersonId == key);
+            var person = _dataSource?.People?.SingleOrDefault(a => a.PersonId == key);
 
             if (person == null)
             {
@@ -118,7 +118,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People({key})/Microsoft.OData.Client.E2E.TestCommon.Common.Server.EndToEnd.Contractor/Default.UpdatePersonInfo")]
         public IActionResult UpdateContractorInfo([FromODataUri] int key)
         {
-            var person = _dataSource.People.SingleOrDefault(a => a.PersonId == key);
+            var person = _dataSource?.People?.SingleOrDefault(a => a.PersonId == key);
 
             if (person == null)
             {
@@ -133,7 +133,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People({key})/Microsoft.OData.Client.E2E.TestCommon.Common.Server.EndToEnd.SpecialEmployee/Default.IncreaseEmployeeSalary")]
         public IActionResult IncreaseSpecialEmployeeSalary([FromODataUri] int key, ODataActionParameters parameters)
         {
-            var person = _dataSource.People.First(a => a.PersonId == key);
+            var person = _dataSource?.People?.First(a => a.PersonId == key);
 
             if (person is SpecialEmployee specialEmployee && parameters == null)
             {
@@ -142,7 +142,8 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
             }
             else
             {
-                var employee = (Employee)_dataSource.People.First(a => a.PersonId == key);
+                var employee = _dataSource?.People?.First(a => a.PersonId == key) as Employee;
+                Assert.NotNull(employee);
                 employee.Salary += (int)parameters["n"];
 
                 return Ok(true);
@@ -152,7 +153,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People({key})/Microsoft.OData.Client.E2E.TestCommon.Common.Server.EndToEnd.Employee/Default.IncreaseEmployeeSalary")]
         public IActionResult IncreaseEmployeeSalary([FromODataUri] int key, ODataActionParameters parameters)
         {
-            var person = _dataSource.People.First(a => a.PersonId == key);
+            var person = _dataSource?.People?.First(a => a.PersonId == key);
 
             if (person is SpecialEmployee specialEmployee && parameters == null)
             {
@@ -161,7 +162,8 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
             }
             else
             {
-                var employee = (Employee)_dataSource.People.First(a => a.PersonId == key);
+                var employee = _dataSource?.People?.First(a => a.PersonId == key) as Employee;
+                Assert.NotNull(employee);
                 employee.Salary += (int)parameters["n"];
 
                 return Ok(true);
@@ -171,7 +173,8 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People/Microsoft.OData.Client.E2E.TestCommon.Common.Server.EndToEnd.Employee/Default.IncreaseSalaries")]
         public IActionResult IncreaseSalaries(ODataActionParameters parameters)
         {
-            var employees = _dataSource.People.OfType<Employee>();
+            var employees = _dataSource?.People?.OfType<Employee>();
+            Assert.NotNull(employees);
 
             foreach (var employee in employees)
             {
@@ -184,8 +187,8 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/People/Microsoft.OData.Client.E2E.TestCommon.Common.Server.EndToEnd.SpecialEmployee/Default.IncreaseSalaries")]
         public IActionResult IncreaseSpecialEmployeesSalaries(ODataActionParameters parameters)
         {
-            var employees = _dataSource.People.OfType<SpecialEmployee>();
-
+            var employees = _dataSource?.People?.OfType<SpecialEmployee>();
+            Assert.NotNull(employees);
             foreach (var employee in employees)
             {
                 employee.Salary += (int)parameters["n"];
@@ -204,7 +207,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpGet("odata/OrderLines")]
         public IActionResult GetOrderLines()
         {
-            var orderLines = _dataSource.OrderLines;
+            var orderLines = _dataSource?.OrderLines;
 
             return Ok(orderLines);
         }
@@ -213,7 +216,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpGet("odata/OrderLines(OrderId={keyOrderId},ProductId={keyProductId})")]
         public IActionResult Get([FromRoute] int keyOrderId, [FromRoute] int keyProductId)
         {
-            var orderLine = _dataSource.OrderLines?.FirstOrDefault(a => a.OrderId == keyOrderId && a.ProductId == keyProductId);
+            var orderLine = _dataSource?.OrderLines?.FirstOrDefault(a => a.OrderId == keyOrderId && a.ProductId == keyProductId);
 
             if (orderLine == null)
             {
@@ -226,7 +229,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/OrderLines(OrderId={keyOrderId},ProductId={keyProductId})/Default.RetrieveProduct")]
         public IActionResult RetrieveProduct([FromODataUri] int keyOrderId, [FromODataUri] int keyProductId)
         {
-            var orderLine = _dataSource.OrderLines?.FirstOrDefault(a => a.OrderId == keyOrderId && a.ProductId == keyProductId);
+            var orderLine = _dataSource?.OrderLines?.FirstOrDefault(a => a.OrderId == keyOrderId && a.ProductId == keyProductId);
 
             if (orderLine == null)
             {
@@ -242,7 +245,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpGet("odata/Products")]
         public IActionResult GetProducts()
         {
-            var products = _dataSource.Products;
+            var products = _dataSource?.Products;
             return Ok(products);
         }
 
@@ -250,7 +253,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpGet("odata/Products({key})")]
         public IActionResult GetProduct(int key)
         {
-            var product = _dataSource.Products.FirstOrDefault(a => a.ProductId == key);
+            var product = _dataSource?.Products?.FirstOrDefault(a => a.ProductId == key);
 
             if (product == null)
             {
@@ -263,7 +266,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/RetrieveProduct")]
         public IActionResult RetrieveProduct()
         {
-            var product = _dataSource.Products.FirstOrDefault(a => a.ProductId == -9);
+            var product = _dataSource?.Products?.FirstOrDefault(a => a.ProductId == -9);
 
             if (product == null)
             {
@@ -278,7 +281,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Server
         [HttpPost("odata/Products({key})/Default.RetrieveProduct")]
         public IActionResult RetrieveProduct([FromODataUri] int key)
         {
-            var product = _dataSource.Products.FirstOrDefault(a => a.ProductId == key);
+            var product = _dataSource?.Products?.FirstOrDefault(a => a.ProductId == key);
 
             if (product == null)
             {

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/ActionOverloadingTests/Tests/ActionOverloadingQueryTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/ActionOverloadingTests/Tests/ActionOverloadingQueryTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Tests
     {
         private readonly Uri _baseUri;
         private readonly Container _context;
-        private IEdmModel _model = null;
+        private IEdmModel? _model = null;
         public const string PersonTypeName = "Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd.Person";
         public const string EmployeeTypeName = "Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd.Employee";
         public const string SpecialEmployeeTypeName = "Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd.SpecialEmployee";
@@ -46,6 +46,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ActionOverloadingTests.Tests
         public ActionOverloadingQueryTests(TestWebApplicationFactory<TestsStartup> fixture)
             : base(fixture)
         {
+            Assert.NotNull(Client.BaseAddress);
             _baseUri = new Uri(Client.BaseAddress, "odata/");
             _context = new Container(_baseUri)
             {

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/CollectionTests/Tests/CollectionNullableFacetTest.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/CollectionTests/Tests/CollectionNullableFacetTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.Core.E2E.Tests.CollectionTests.Tests
     public class CollectionNullableFacetTest : EndToEndTestBase<CollectionNullableFacetTest.TestsStartup>
     {
         private readonly Uri _baseUri;
-        private IEdmModel _model = null;
+        private IEdmModel? _model = null;
         private readonly Container _context;
         private static string NameSpacePrefix = "Microsoft.OData.E2E.TestCommon.Common.Server.Default.";
         protected readonly string[] mimeTypes =
@@ -47,6 +47,7 @@ namespace Microsoft.OData.Core.E2E.Tests.CollectionTests.Tests
         public CollectionNullableFacetTest(TestWebApplicationFactory<TestsStartup> fixture)
             : base(fixture)
         {
+            Assert.NotNull(Client.BaseAddress);
             _baseUri = new Uri(Client.BaseAddress, "odata/");
             _model = DefaultEdmModel.GetEdmModel();
             _context = new Container(_baseUri)
@@ -119,7 +120,7 @@ namespace Microsoft.OData.Core.E2E.Tests.CollectionTests.Tests
             {
                 if (property.Name.Equals(testProperty))
                 {
-                    IEdmCollectionTypeReference typeRef = property.Type as IEdmCollectionTypeReference;
+                    IEdmCollectionTypeReference? typeRef = property.Type as IEdmCollectionTypeReference;
                     Assert.NotNull(typeRef);
                     isNullable = typeRef.IsNullable;
                 }
@@ -152,9 +153,13 @@ namespace Microsoft.OData.Core.E2E.Tests.CollectionTests.Tests
 
                     // verify the update
                     Assert.Equal(204, responseMessage.StatusCode);
-                    ODataResource updatedProduct = await QueryEntityItemAsync("Customers(1)") as ODataResource;
-                    ODataCollectionValue testCollection = updatedProduct.Properties.OfType<ODataProperty>().Single(p => p.Name == testProperty).Value as ODataCollectionValue;
-                    ODataCollectionValue expectValue = personToAdd.Properties.OfType<ODataProperty>().Single(p => p.Name == testProperty).Value as ODataCollectionValue;
+                    ODataResource? updatedProduct = await QueryEntityItemAsync("Customers(1)") as ODataResource;
+                    Assert.NotNull(updatedProduct);
+                    ODataCollectionValue? testCollection = updatedProduct.Properties.OfType<ODataProperty>().Single(p => p.Name == testProperty).Value as ODataCollectionValue;
+                    ODataCollectionValue? expectValue = personToAdd.Properties.OfType<ODataProperty>().Single(p => p.Name == testProperty).Value as ODataCollectionValue;
+
+                    Assert.NotNull(testCollection);
+                    Assert.NotNull(expectValue);
                     var actIter = testCollection.Items.GetEnumerator();
                     var expIter = expectValue.Items.GetEnumerator();
                     while (actIter.MoveNext() && expIter.MoveNext())
@@ -166,7 +171,7 @@ namespace Microsoft.OData.Core.E2E.Tests.CollectionTests.Tests
                 {
                     if (!isNullable)
                     {
-                        Assert.Equal(exception.Message, "A null value was detected in the items of a collection property value; non-nullable instances of collection types do not support null values as items.");
+                        Assert.Equal("A null value was detected in the items of a collection property value; non-nullable instances of collection types do not support null values as items.", exception.Message);
                     }
                     else
                     {
@@ -176,7 +181,7 @@ namespace Microsoft.OData.Core.E2E.Tests.CollectionTests.Tests
             }
         }
 
-        private async Task<ODataItem> QueryEntityItemAsync(string uri, int expectedStatusCode = 200)
+        private async Task<ODataItem?> QueryEntityItemAsync(string uri, int expectedStatusCode = 200)
         {
             ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = _baseUri };
 
@@ -191,7 +196,7 @@ namespace Microsoft.OData.Core.E2E.Tests.CollectionTests.Tests
             var queryResponseMessage = await queryRequestMessage.GetResponseAsync();
             Assert.Equal(expectedStatusCode, queryResponseMessage.StatusCode);
 
-            ODataItem item = null;
+            ODataItem? item = null;
             if (expectedStatusCode == 200)
             {
                 using (var messageReader = new ODataMessageReader(queryResponseMessage, readerSettings, _model))

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/ComplexTypeTests/ComplexTypeTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/ComplexTypeTests/ComplexTypeTests.cs
@@ -255,7 +255,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ComplexTypeTests
         public async Task UpdatingADerivedComplexTypeProperty_UpdatesSuccessfully(string mimeType)
         {
             ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
-            (ODataResource entry, List<ODataResource> complexTypeResources) = await QueryEntryAsync("People(1)");
+            (ODataResource? entry, List<ODataResource> complexTypeResources) = await QueryEntryAsync("People(1)");
 
             var homeAddress = complexTypeResources.Last(a => a.TypeName.EndsWith("HomeAddress"));
 
@@ -445,8 +445,9 @@ namespace Microsoft.OData.Core.E2E.Tests.ComplexTypeTests
             // verify the insert
             Assert.Equal(201, responseMessage.StatusCode);
 
-            (ODataResource entry, List<ODataResource> complexTypeResources) = await QueryEntryAsync("People(101)");
+            (ODataResource? entry, List<ODataResource> complexTypeResources) = await QueryEntryAsync("People(101)");
 
+            Assert.NotNull(entry);
             Assert.Equal(101, entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "PersonID").Value);
 
             var homeAddress = complexTypeResources.Single(r => r.TypeName.EndsWith("Address"));
@@ -466,7 +467,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ComplexTypeTests
             // verify the delete
             Assert.Equal(204, deleteResponseMessage.StatusCode);
 
-            ODataResource deletedEntry = null;
+            ODataResource? deletedEntry = null;
             (deletedEntry, complexTypeResources) = await QueryEntryAsync("People(101)", 404);
 
             Assert.Null(deletedEntry);
@@ -565,9 +566,9 @@ namespace Microsoft.OData.Core.E2E.Tests.ComplexTypeTests
                 using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
                 var reader = await messageReader.CreateODataResourceReaderAsync();
 
-                ODataResource account = null;
-                ODataResource accountInfo = null;
-                ODataResource addressComplex1 = null;
+                ODataResource? account = null;
+                ODataResource? accountInfo = null;
+                ODataResource? addressComplex1 = null;
 
                 while (await reader.ReadAsync())
                 {
@@ -649,9 +650,9 @@ namespace Microsoft.OData.Core.E2E.Tests.ComplexTypeTests
                 using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
                 var reader = await messageReader.CreateODataResourceSetReaderAsync();
 
-                ODataResource account = null;
-                ODataResource accountInfo = null;
-                ODataResource addressComplex1 = null;
+                ODataResource? account = null;
+                ODataResource? accountInfo = null;
+                ODataResource? addressComplex1 = null;
 
                 while (await reader.ReadAsync())
                 {
@@ -700,7 +701,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ComplexTypeTests
             string[] middleNames = { "Hood", "MN1", "MN2", "MN3" };
             for (int i = 0; i < types.Length; i++)
             {
-                (ODataResource entry, List<ODataResource> complexTypeResources) = await QueryEntryAsync("Accounts(101)");
+                (ODataResource? entry, List<ODataResource> complexTypeResources) = await QueryEntryAsync("Accounts(101)");
 
                 var accountInfo = complexTypeResources.Single(a => a.TypeName.EndsWith("AccountInfo"));
                 Assert.Equal(middleNames[i], accountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "MiddleName").Value);
@@ -863,7 +864,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ComplexTypeTests
 
             // verify the delete
             Assert.Equal(204, deleteResponseMessage.StatusCode);
-            (ODataResource deletedEntry, List<ODataResource> complexProperties) = await QueryEntryAsync("Accounts(10086)", 404);
+            (ODataResource? deletedEntry, List<ODataResource> complexProperties) = await QueryEntryAsync("Accounts(10086)", 404);
             Assert.Null(deletedEntry);
         }
 
@@ -889,7 +890,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ComplexTypeTests
             {
                 using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
                 var odataReader = await messageReader.CreateODataResourceReaderAsync();
-                ODataResource accountInfo = null;
+                ODataResource? accountInfo = null;
 
                 while (await odataReader.ReadAsync())
                 {
@@ -1074,7 +1075,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ComplexTypeTests
             Assert.Equal(204, responseMessage.StatusCode);
 
             // verify updated value
-            (ODataResource entry, List<ODataResource> complexProperties) = await QueryEntryAsync("Accounts(101)");
+            (ODataResource? entry, List<ODataResource> complexProperties) = await QueryEntryAsync("Accounts(101)");
             var updatedAccountInfo = complexProperties.Single(r => r.TypeName.EndsWith("AccountInfo"));
 
             Assert.Equal("FN", updatedAccountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "FirstName").Value);
@@ -1097,7 +1098,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ComplexTypeTests
         }
         #endregion
 
-        private async Task<(ODataResource entry, List<ODataResource> complexProperties)> QueryEntryAsync(string uri, int expectedStatusCode = 200)
+        private async Task<(ODataResource? entry, List<ODataResource> complexProperties)> QueryEntryAsync(string uri, int expectedStatusCode = 200)
         {
             ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = _baseUri };
 
@@ -1113,7 +1114,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ComplexTypeTests
 
             Assert.Equal(expectedStatusCode, queryResponseMessage.StatusCode);
 
-            ODataResource entry = null;
+            ODataResource? entry = null;
             List<ODataResource> complexProperties = [];
 
             if (expectedStatusCode == 200)
@@ -1138,7 +1139,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ComplexTypeTests
                                 }
                                 else
                                 {
-                                    complexProperties.Add(reader.Item as ODataResource);
+                                    complexProperties.Add((ODataResource)reader.Item);
                                 }
 
                                 break;

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/ContainmentTests/ContainmentTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/ContainmentTests/ContainmentTests.cs
@@ -85,7 +85,8 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
+                        Assert.NotNull(entry);
                         Assert.Equal(301, entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "GiftCardID").Value);
                     }
                 }
@@ -140,7 +141,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
                         Assert.NotNull(entry);
                         entries.Add(entry);
                     }
@@ -201,7 +202,8 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
+                        Assert.NotNull(entry);
                         entries.Add(entry);
                     }
                 }
@@ -237,7 +239,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
 
                         Assert.NotNull(entry);
                         entries.Add(entry);
@@ -280,7 +282,8 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
+                        Assert.NotNull(entry);
                         Assert.Equal("103 second PI", entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "FriendlyName").Value);
                     }
                 }
@@ -313,7 +316,8 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
+                        Assert.NotNull(entry);
                         Assert.Equal("Digital goods: App", entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "TransactionDescription").Value);
                     }
                 }
@@ -346,7 +350,8 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
+                        Assert.NotNull(entry);
                         Assert.NotNull(entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "StatementID").Value);
                         Assert.NotNull(entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "TransactionType").Value);
                         Assert.NotNull(entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "TransactionDescription").Value);
@@ -385,7 +390,8 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
+                        Assert.NotNull(entry);
                         Assert.Equal(802, entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "StoredPIID").Value);
                         Assert.Equal("AliPay", entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "PIType").Value);
                     }
@@ -419,7 +425,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
                         Assert.NotNull(entry);
                         entries.Add(entry);
                     }
@@ -457,7 +463,8 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
+                        Assert.NotNull(entry);
                         Assert.Equal(101902, entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "PaymentInstrumentID").Value);
                     }
                 }
@@ -489,7 +496,8 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
+                        Assert.NotNull(entry);
                         Assert.NotNull(entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "PaymentInstrumentID").Value);
                     }
                     else if (reader.State == ODataReaderState.ResourceSetEnd)
@@ -556,7 +564,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
             {
                 using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
                 var reader = await messageReader.CreateODataResourceReaderAsync();
-                ODataResource entry = null;
+                ODataResource? entry = null;
 
                 while (await reader.ReadAsync())
                 {
@@ -566,6 +574,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
                     }
                 }
 
+                Assert.NotNull(entry);
                 Assert.Equal(101, entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "AccountID").Value);
                 Assert.Equal(ODataReaderState.Completed, reader.State);
             }
@@ -589,13 +598,13 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
             {
                 using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
                 var reader = await messageReader.CreateODataResourceSetReaderAsync();
-                ODataResourceSet feed = null;
+                ODataResourceSet? feed = null;
 
                 while (await reader.ReadAsync())
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
                         if (entry != null && entry.TypeName.EndsWith("Account"))
                         {
                             Assert.NotNull(entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "AccountID").Value);
@@ -698,7 +707,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
 
                         Assert.NotNull(entry);
                         entries.Add(entry);
@@ -743,11 +752,11 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        entries.Add(reader.Item as ODataResource);
+                        entries.Add((ODataResource)reader.Item);
                     }
                     else if (reader.State == ODataReaderState.NestedResourceInfoEnd)
                     {
-                        navigationLinks.Add(reader.Item as ODataNestedResourceInfo);
+                        navigationLinks.Add((ODataNestedResourceInfo)reader.Item);
                     }
                 }
 
@@ -778,9 +787,10 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
             };
 
             var accountType = _model.FindDeclaredType(TestModelNameSpace + ".Account") as IEdmEntityType;
+            Assert.NotNull(accountType);
             var accountSet = _model.EntityContainer.FindEntitySet("Accounts");
             var paymentInstrumentType = _model.FindDeclaredType(TestModelNameSpace + ".PaymentInstrument") as IEdmEntityType;
-            IEdmNavigationProperty navProp = accountType.FindProperty("MyPaymentInstruments") as IEdmNavigationProperty;
+            IEdmNavigationProperty? navProp = accountType.FindProperty("MyPaymentInstruments") as IEdmNavigationProperty;
             var myPaymentInstrumentSet = accountSet.FindNavigationTarget(navProp);
 
             var requestUrl = new Uri(_baseUri + "Accounts(101)/MyPaymentInstruments");
@@ -805,7 +815,8 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
 
             // verify the create
             Assert.Equal(201, responseMessage.StatusCode);
-            ODataResource entry = await QueryEntityItemAsync("Accounts(101)/MyPaymentInstruments(101904)") as ODataResource;
+            ODataResource? entry = await QueryEntityItemAsync("Accounts(101)/MyPaymentInstruments(101904)") as ODataResource;
+            Assert.NotNull(entry);
             Assert.Equal(101904, entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "PaymentInstrumentID").Value);
 
             // delete the entry
@@ -820,7 +831,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
 
             // verify the delete
             Assert.Equal(204, deleteResponseMessage.StatusCode);
-            ODataResource deletedEntry = await QueryEntityItemAsync("Accounts(101)/MyPaymentInstruments(101904)", 404) as ODataResource;
+            ODataResource? deletedEntry = await QueryEntityItemAsync("Accounts(101)/MyPaymentInstruments(101904)", 404) as ODataResource;
             Assert.Null(deletedEntry);
         }
 
@@ -843,9 +854,10 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
             };
 
             var accountType = _model.FindDeclaredType(TestModelNameSpace + ".Account") as IEdmEntityType;
+            Assert.NotNull(accountType);
             var accountSet = _model.EntityContainer.FindEntitySet("Accounts");
             var giftCardType = _model.FindDeclaredType(TestModelNameSpace + ".GiftCard") as IEdmEntityType;
-            IEdmNavigationProperty navProp = accountType.FindProperty("MyGiftCard") as IEdmNavigationProperty;
+            IEdmNavigationProperty? navProp = accountType.FindProperty("MyGiftCard") as IEdmNavigationProperty;
             var myGiftCardSet = accountSet.FindNavigationTarget(navProp);
 
             var requestUrl = new Uri(_baseUri + "Accounts(104)/MyGiftCard");
@@ -870,7 +882,8 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
             var responseMessage = await requestMessage.GetResponseAsync();
 
             Assert.Equal(204, responseMessage.StatusCode);
-            ODataResource entry = await QueryEntityItemAsync("Accounts(104)/MyGiftCard") as ODataResource;
+            ODataResource? entry = await QueryEntityItemAsync("Accounts(104)/MyGiftCard") as ODataResource;
+            Assert.NotNull(entry);
             Assert.Equal(304, entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "GiftCardID").Value);
         }
 
@@ -886,9 +899,10 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
             };
 
             var accountType = _model.FindDeclaredType(TestModelNameSpace + ".Account") as IEdmEntityType;
+            Assert.NotNull(accountType);
             var accountSet = _model.EntityContainer.FindEntitySet("Accounts");
             var paymentInstrumentType = _model.FindDeclaredType(TestModelNameSpace + ".PaymentInstrument") as IEdmEntityType;
-            IEdmNavigationProperty navProp = accountType.FindProperty("MyPaymentInstruments") as IEdmNavigationProperty;
+            IEdmNavigationProperty? navProp = accountType.FindProperty("MyPaymentInstruments") as IEdmNavigationProperty;
             var myPaymentInstrumentSet = accountSet.FindNavigationTarget(navProp);
 
             var paymentInstrumentEntry = new ODataResource() { TypeName = TestModelNameSpace + ".PaymentInstrument" };
@@ -919,7 +933,8 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
 
             // verify the create
             Assert.Equal(204, responseMessage.StatusCode);
-            ODataResource entry = await QueryEntityItemAsync("Accounts(101)/MyPaymentInstruments(101903)") as ODataResource;
+            ODataResource? entry = await QueryEntityItemAsync("Accounts(101)/MyPaymentInstruments(101903)") as ODataResource;
+            Assert.NotNull(entry);
             Assert.Equal(101903, entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "PaymentInstrumentID").Value);
             Assert.Equal(mimeType, entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "FriendlyName").Value);
         }
@@ -936,7 +951,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
             yield return new object[] { "Accounts(101)/MyPaymentInstruments(101901)?$select=PaymentInstrumentID,FriendlyName,CreatedDate", 3, "application/json;odata.metadata=none" };
         }
 
-        private async Task<ODataItem> QueryEntityItemAsync(string uri, int expectedStatusCode = 200)
+        private async Task<ODataItem?> QueryEntityItemAsync(string uri, int expectedStatusCode = 200)
         {
             ODataMessageReaderSettings readerSettings = new()
             {
@@ -952,7 +967,7 @@ namespace Microsoft.OData.Core.E2E.Tests.ContainmentTests
 
             Assert.Equal(expectedStatusCode, queryResponseMessage.StatusCode);
 
-            ODataItem item = null;
+            ODataItem? item = null;
             if (expectedStatusCode == 200)
             {
                 using var messageReader = new ODataMessageReader(queryResponseMessage, readerSettings, _model);

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/DateOnlyAndTimeOnlyTests/DateOnlyAndTimeOfDayTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/DateOnlyAndTimeOnlyTests/DateOnlyAndTimeOfDayTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.OData.Core.E2E.Tests.DateAndTimeOnlyTests
                 using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model))
                 {
                     var reader = await messageReader.CreateODataResourceReaderAsync();
-                    ODataResource entry = null;
+                    ODataResource? entry = null;
                     while (await reader.ReadAsync())
                     {
                         if (reader.State == ODataReaderState.ResourceEnd)
@@ -88,6 +88,7 @@ namespace Microsoft.OData.Core.E2E.Tests.DateAndTimeOnlyTests
                     }
 
                     // Verify DateOnly Property
+                    Assert.NotNull(entry);
                     Assert.Equal(new DateOnly(2014, 8, 31), entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "ShipDate").Value);
                     Assert.Equal(new TimeOnly(12, 40, 5, 50), entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "ShipTime").Value);
                     Assert.Equal(ODataReaderState.Completed, reader.State);
@@ -194,7 +195,7 @@ namespace Microsoft.OData.Core.E2E.Tests.DateAndTimeOnlyTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
                         if (entry != null && entry.TypeName.EndsWith("Order"))
                         {
                             // Verify DateOnly Property
@@ -231,7 +232,7 @@ namespace Microsoft.OData.Core.E2E.Tests.DateAndTimeOnlyTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
 
                         if (entry != null)
                         {
@@ -344,7 +345,8 @@ namespace Microsoft.OData.Core.E2E.Tests.DateAndTimeOnlyTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
+                        Assert.NotNull(entry);
                         // Verify DateOnly Property
                         Assert.Equal(new DateOnly(2015, 11, 11), entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "Day").Value);
                     }
@@ -405,7 +407,7 @@ namespace Microsoft.OData.Core.E2E.Tests.DateAndTimeOnlyTests
                 {
                     if (reader.State == ODataReaderState.ResourceEnd)
                     {
-                        ODataResource entry = reader.Item as ODataResource;
+                        ODataResource? entry = reader.Item as ODataResource;
 
                         if (entry != null)
                         {

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/DeltaTests/DeltaTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/DeltaTests/DeltaTests.cs
@@ -206,6 +206,7 @@ namespace Microsoft.OData.Core.E2E.Tests.DeltaTests
             // Arrange: Set up OData model, navigation properties, and request URI
             var accountsSet = _model.FindDeclaredEntitySet("Accounts");
             var accountType = _model.FindDeclaredType(NameSpacePrefix + "Account") as IEdmEntityType;
+            Assert.NotNull(accountType);
             var myPisNav = accountType.FindProperty("MyPaymentInstruments") as IEdmNavigationProperty;
             var piSet = accountsSet.FindNavigationTarget(myPisNav) as IEdmEntitySetBase;
             var piType = _model.FindDeclaredType(NameSpacePrefix + "PaymentInstrument") as IEdmEntityType;
@@ -309,15 +310,17 @@ namespace Microsoft.OData.Core.E2E.Tests.DeltaTests
                 {
                     case ODataReaderState.ResourceEnd:
                         var entry = deltaReader.Item as ODataResource;
-
+                        Assert.NotNull(entry);
                         if (entry.Id == new Uri(_baseUri, "Accounts(103)/MyPaymentInstruments(103901)"))
                         {
                             var friendlyNameProp = entry.Properties.OfType<ODataProperty>().SingleOrDefault(p => p.Name == "FriendlyName");
+                            Assert.NotNull(friendlyNameProp);
                             Assert.Equal("GGGG", friendlyNameProp.Value);
                         }
                         else if (entry.Id == new Uri(_baseUri, "Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901005)"))
                         {
                             var transationTypeProp = entry.Properties.OfType<ODataProperty>().SingleOrDefault(p => p.Name == "TransactionType");
+                            Assert.NotNull(transationTypeProp);
                             Assert.Equal("OnlinePurchase", transationTypeProp.Value);
                         }
 
@@ -461,15 +464,18 @@ namespace Microsoft.OData.Core.E2E.Tests.DeltaTests
                 {
                     case ODataReaderState.ResourceEnd:
                         var entry = deltaReader.Item as ODataResource;
+                        Assert.NotNull(entry);
 
                         if (entry.Id == new Uri(_baseUri, "People(1)"))
                         {
                             var cityNameProp = entry.Properties.OfType<ODataProperty>().SingleOrDefault(p => p.Name == "City");
+                            Assert.NotNull(cityNameProp);
                             Assert.Equal("GGGG", cityNameProp.Value);
                         }
                         else if (entry.Id == new Uri(_baseUri, "Orders(100)"))
                         {
                             var orderIdProp = entry.Properties.OfType<ODataProperty>().SingleOrDefault(p => p.Name == "OrderID");
+                            Assert.NotNull(orderIdProp);
                             Assert.Equal(100, orderIdProp.Value);
                         }
 
@@ -802,7 +808,7 @@ namespace Microsoft.OData.Core.E2E.Tests.DeltaTests
                 switch (deltaReader.State)
                 {
                     case ODataReaderState.ResourceEnd:
-                        ODataResource entry = deltaReader.Item as ODataResource;
+                        ODataResource? entry = deltaReader.Item as ODataResource;
                         Assert.NotNull(entry);
 
                         var personIdProp = entry.Properties.OfType<ODataProperty>().SingleOrDefault(p => p.Name == "PersonID");

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/EnumerationTypeTests/EnumerationTypeQueryTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/EnumerationTypeTests/EnumerationTypeQueryTests.cs
@@ -58,8 +58,6 @@ public class EnumerationTypeQueryTests : EndToEndTestBase<EnumerationTypeQueryTe
     private static string NameSpacePrefix = typeof(DefaultEdmModel).Namespace ?? "Microsoft.OData.E2E.TestCommon.Common.Server.Default";
 
     // Constants
-    private const string MimeTypeODataParameterFullMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterFullMetadata;
-    private const string MimeTypeODataParameterMinimalMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterMinimalMetadata;
     private const string MimeTypeApplicationAtomXml = MimeTypes.ApplicationAtomXml;
 
     #region Tests querying entity set and verifies the enumeration type properties

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/EnumerationTypeTests/EnumerationTypeUpdateTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/EnumerationTypeTests/EnumerationTypeUpdateTests.cs
@@ -58,10 +58,6 @@ public class EnumerationTypeUpdateTests : EndToEndTestBase<EnumerationTypeUpdate
 
     private static string NameSpacePrefix = typeof(DefaultEdmModel).Namespace ?? "Microsoft.OData.E2E.TestCommon.Common.Server.Default";
 
-    // Constants
-    private const string MimeTypeODataParameterFullMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterFullMetadata;
-    private const string MimeTypeODataParameterMinimalMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterMinimalMetadata;
-
     #region Tests creating and deleting an entity with enumeration type properties.
 
     [Theory]

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/PrimitiveTypesTests/DurationTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/PrimitiveTypesTests/DurationTests.cs
@@ -52,10 +52,6 @@ public class DurationTests : EndToEndTestBase<DurationTests.TestsStartup>
         ResetDefaultDataSource();
     }
 
-    // Constants
-    private const string MimeTypeODataParameterFullMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterFullMetadata;
-    private const string MimeTypeODataParameterMinimalMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterMinimalMetadata;
-
     #region Entity Set
 
     [Theory]

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/PrimitiveTypesTests/PrimitiveValueFormatTest.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/PrimitiveTypesTests/PrimitiveValueFormatTest.cs
@@ -53,7 +53,6 @@ public class PrimitiveValueFormatTest : EndToEndTestBase<PrimitiveValueFormatTes
     }
 
     public string DataPattern = "(" + @"[\+-]?\d\.?\d*E?[\+-]?\d*" + "|" + @"INF|-INF|NaN" + ")";
-    private const string MimeTypeODataParameterFullMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterFullMetadata;
     private const string MimeTypeODataParameterFullMetadataAndIEEE754Compatible = MimeTypes.ApplicationJson + MimeTypes.ODataParameterFullMetadata + MimeTypes.ODataParameterIEEE754Compatible;
 
     [Theory]

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/QueryCountTests/QueryCountTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/QueryCountTests/QueryCountTests.cs
@@ -55,10 +55,7 @@ public class QueryCountTests : EndToEndTestBase<QueryCountTests.TestsStartup>
 
     // Constants
     private const string MimeTypeApplicationAtomXml = MimeTypes.ApplicationAtomXml;
-    private const string MimeTypeODataParameterFullMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterFullMetadata;
-    private const string MimeTypeODataParameterMinimalMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterMinimalMetadata;
     private const string MimeTypeODataParameterIEEE754Compatible = MimeTypes.ApplicationJson + MimeTypes.ODataParameterIEEE754Compatible;
-    private const string MimeTypeODataParameterNoMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterNoMetadata;
 
     #region Positive tests
 

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/SingletonTests/Tests/SingletonQueryTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/SingletonTests/Tests/SingletonQueryTests.cs
@@ -51,10 +51,6 @@ public class SingletonQueryTests : EndToEndTestBase<SingletonQueryTests.TestsSta
         ResetDefaultDataSource();
     }
 
-    // Constants
-    private const string MimeTypeODataParameterFullMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterFullMetadata;
-    private const string MimeTypeODataParameterMinimalMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterMinimalMetadata;
-
     #region Query singleton entity
 
     [Theory]

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/SingletonTests/Tests/SingletonUpdateTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/SingletonTests/Tests/SingletonUpdateTests.cs
@@ -53,10 +53,6 @@ public class SingletonUpdateTests : EndToEndTestBase<SingletonUpdateTests.TestsS
         ResetDefaultDataSource();
     }
 
-    // Constants
-    private const string MimeTypeODataParameterFullMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterFullMetadata;
-    private const string MimeTypeODataParameterMinimalMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterMinimalMetadata;
-
     [Theory]
     [InlineData(MimeTypeODataParameterFullMetadata)]
     [InlineData(MimeTypeODataParameterMinimalMetadata)]

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/TypeDefinition/TypeDefinitionTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/TypeDefinition/TypeDefinitionTests.cs
@@ -1181,7 +1181,7 @@ public class TypeDefinitionTests : EndToEndTestBase<TypeDefinitionTests.TestsSta
 
         using (var messageWriter = new ODataMessageWriter(requestMessage, writerSettings, _model))
         {
-            var odataWriter = messageWriter.CreateODataParameterWriter((IEdmOperation)null);
+            var odataWriter = messageWriter.CreateODataParameterWriter(null);
             odataWriter.WriteStart();
             odataWriter.WriteValue("seconds", 1000u);
             odataWriter.WriteEnd();

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/WriteJsonPayloadTests/WritePayloadHelper.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/WriteJsonPayloadTests/WritePayloadHelper.cs
@@ -970,8 +970,8 @@ namespace Microsoft.OData.Core.E2E.Tests.WriteJsonPayloadTests
             properties.Add(thumbnailProperty);
             customerEntry.Properties = properties.ToArray();
 
-            expectedCustomerObject.Add("Thumbnail" + JsonLightConstants.ODataMediaEditLinkAnnotationName, (thumbnailProperty.Value as ODataStreamReferenceValue).EditLink.AbsoluteUri);
-            expectedCustomerObject.Add("Thumbnail" + JsonLightConstants.ODataMediaReadLinkAnnotationName, (thumbnailProperty.Value as ODataStreamReferenceValue).ReadLink.AbsoluteUri);
+            expectedCustomerObject.Add("Thumbnail" + JsonLightConstants.ODataMediaEditLinkAnnotationName, ((ODataStreamReferenceValue)thumbnailProperty.Value).EditLink.AbsoluteUri);
+            expectedCustomerObject.Add("Thumbnail" + JsonLightConstants.ODataMediaReadLinkAnnotationName, ((ODataStreamReferenceValue)thumbnailProperty.Value).ReadLink.AbsoluteUri);
 
             return thumbnailProperty;
         }
@@ -1147,9 +1147,9 @@ namespace Microsoft.OData.Core.E2E.Tests.WriteJsonPayloadTests
             TestStreamResponseMessage responseMessage,
             IEdmEntitySet expectedSet,
             IEdmEntityType expectedType,
-            Action<ODataResourceSet> verifyFeed,
-            Action<ODataResource> verifyEntry,
-            Action<ODataNestedResourceInfo> verifyNavigation)
+            Action<ODataResourceSet?> verifyFeed,
+            Action<ODataResource?> verifyEntry,
+            Action<ODataNestedResourceInfo?> verifyNavigation)
         {
             var settings = new ODataMessageReaderSettings() { BaseUri = _baseUri, EnableMessageStreamDisposal = false };
             settings.ShouldIncludeAnnotation = s => true;
@@ -1164,10 +1164,7 @@ namespace Microsoft.OData.Core.E2E.Tests.WriteJsonPayloadTests
                 {
                     case ODataReaderState.ResourceSetEnd:
                         {
-                            if (verifyFeed != null)
-                            {
-                                verifyFeed((ODataResourceSet)reader.Item);
-                            }
+                            verifyFeed?.Invoke((ODataResourceSet?)reader.Item);
 
                             break;
                         }
@@ -1182,10 +1179,7 @@ namespace Microsoft.OData.Core.E2E.Tests.WriteJsonPayloadTests
                         }
                     case ODataReaderState.NestedResourceInfoEnd:
                         {
-                            if (verifyNavigation != null)
-                            {
-                                verifyNavigation((ODataNestedResourceInfo)reader.Item);
-                            }
+                            verifyNavigation?.Invoke((ODataNestedResourceInfo?)reader.Item);
 
                             break;
                         }

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/WriteJsonPayloadTests/WritePayloadTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/WriteJsonPayloadTests/WritePayloadTests.cs
@@ -36,6 +36,7 @@ namespace Microsoft.OData.Core.E2E.Tests.WriteJsonPayloadTests
         public WritePayloadTests(TestWebApplicationFactory<TestsStartup> fixture)
             : base(fixture)
         {
+            Assert.NotNull(Client.BaseAddress);
             _baseUri = new Uri(Client.BaseAddress, "odata/");
             _model = CommonEndToEndEdmModel.GetEdmModel();
         }
@@ -44,7 +45,7 @@ namespace Microsoft.OData.Core.E2E.Tests.WriteJsonPayloadTests
         [InlineData(MimeTypeODataParameterFullMetadata, "\"@odata.associationLink\":", "\"@odata.type\":")]
         [InlineData(MimeTypeODataParameterMinimalMetadata, "", "\"@odata.type\":")]
         [InlineData(MimeTypeODataParameterNoMetadata, "", "")]
-        public async Task WritingAnODataFeed_WithDifferentMimeTypes_ShouldMatchExpectedPayload(string? mimeType, string associationLink, string odataType)
+        public async Task WritingAnODataFeed_WithDifferentMimeTypes_ShouldMatchExpectedPayload(string mimeType, string associationLink, string odataType)
         {
             var settings = new ODataMessageWriterSettings
             {
@@ -99,7 +100,7 @@ namespace Microsoft.OData.Core.E2E.Tests.WriteJsonPayloadTests
         [InlineData(MimeTypeODataParameterMinimalMetadata, "", "\"@odata.type\":")]
         [InlineData(MimeTypeODataParameterNoMetadata, "", "")]
         public async Task WritingAnExpandedEntry_WithDifferentMimeTypes_ShouldMatchExpectedPayload(
-            string? mimeType,
+            string mimeType,
             string associationLink,
             string odataType)
         {
@@ -109,8 +110,8 @@ namespace Microsoft.OData.Core.E2E.Tests.WriteJsonPayloadTests
                 EnableMessageStreamDisposal = false
             };
 
-            string outputWithModel = null;
-            string outputWithoutModel = null;
+            string? outputWithModel = null;
+            string? outputWithoutModel = null;
 
             // Without Model
             var responseMessageWithoutModel = new TestStreamResponseMessage(new MemoryStream());
@@ -261,8 +262,9 @@ namespace Microsoft.OData.Core.E2E.Tests.WriteJsonPayloadTests
                 ODataUri = new ODataUri() { ServiceRoot = _baseUri },
                 EnableMessageStreamDisposal = false
             };
-            string outputWithModel = null;
-            string outputWithoutModel = null;
+
+            string? outputWithModel = null;
+            string? outputWithoutModel = null;
 
             var responseMessageWithModel = new TestStreamResponseMessage(new MemoryStream());
             responseMessageWithModel.SetHeader("Content-Type", mimeType);
@@ -303,8 +305,8 @@ namespace Microsoft.OData.Core.E2E.Tests.WriteJsonPayloadTests
                 ODataUri = new ODataUri() { ServiceRoot = _baseUri },
                 EnableMessageStreamDisposal = false
             };
-            string outputWithModel = null;
-            string outputWithoutModel = null;
+            string? outputWithModel = null;
+            string? outputWithoutModel = null;
 
             var contactDetailType = _model.FindDeclaredType(NameSpacePrefix + "ContactDetails") as IEdmComplexType;
 

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ConstructibleModelTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ConstructibleModelTests.cs
@@ -161,7 +161,7 @@ public class ConstructibleModelTests : EdmLibTestCaseBase
         Assert.True(exception.Message.Contains("Boxed") && exception.Message.Contains("String"));
 
         // Act
-        model.SetAnnotationValue<Boxed<string>>(f11, null);
+        model.SetAnnotationValue<Boxed<string>?>(f11, null);
 
         // Assert
         Assert.Equal(3, model.DirectValueAnnotations(f11).Count());
@@ -172,7 +172,7 @@ public class ConstructibleModelTests : EdmLibTestCaseBase
         Assert.Null(model.GetAnnotationValue<Boxed<bool>>(f11));
 
         // Act
-        model.SetAnnotationValue<Boxed<int>>(f11, null);
+        model.SetAnnotationValue<Boxed<int>?>(f11, null);
         model.SetAnnotationValue(f11, "Grumble", "Stumble", null);
         model.SetAnnotationValue(f11, "Grumble", "Tumble", null);
 

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/EvaluationTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/EvaluationTests.cs
@@ -1601,7 +1601,7 @@ public class EvaluationTests : EdmLibTestCaseBase
 
         // And finally make sure we can handle nulls for bad graph references.
         clrEvaluator.EdmToClrConverter = new EdmToClrConverter(
-            (IEdmStructuredValue edmValue, Type clrType, EdmToClrConverter converter, out object objectInstance, out bool objectInstanceInitialized) =>
+            (IEdmStructuredValue edmValue, Type clrType, EdmToClrConverter converter, out object? objectInstance, out bool objectInstanceInitialized) =>
             {
                 objectInstance = null;
                 objectInstanceInitialized = false;

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/SchemaParsingTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/SchemaParsingTests.cs
@@ -925,7 +925,7 @@ public class SchemaParsingTests : EdmLibTestCaseBase
         Assert.Equal("Address", type2.StructuralProperties().Last().Name);
 
         IEdmStringTypeReference addressType = type2.StructuralProperties().Last().Type.AsPrimitive().AsString();
-        Assert.Equal(addressType.PrimitiveKind(), EdmPrimitiveTypeKind.String);
+        Assert.Equal(EdmPrimitiveTypeKind.String, addressType.PrimitiveKind());
         Assert.Equal(2048, addressType.MaxLength);
         Assert.True(addressType.IsNullable);
 
@@ -955,7 +955,7 @@ public class SchemaParsingTests : EdmLibTestCaseBase
         IEdmPrimitiveTypeReference resolvedIdType = id.Type.AsPrimitive();
         Assert.Equal(EdmPrimitiveTypeKind.Int32, resolvedIdType.PrimitiveKind());
 
-        Assert.Equal(1, smod.DeclaredKey.Count());
+        Assert.Single(smod.DeclaredKey);
         Assert.Equal(id, smod.DeclaredKey.First());
         Assert.Equal(smod.DeclaredKey.First(), clod.Key().First());
     }

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/StubEdm/StubEdmEntityType.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/StubEdm/StubEdmEntityType.cs
@@ -12,7 +12,7 @@ namespace Microsoft.OData.Edm.E2E.Tests.StubEdm;
 public class StubEdmEntityType : StubEdmElement, IEdmEntityType
 {
     private List<IEdmProperty> declaredProperties = new List<IEdmProperty>();
-    private List<IEdmPropertyRef> declaredKeyProperties = null;
+    private List<IEdmPropertyRef>? declaredKeyProperties = null;
 
     /// <summary>
     /// Initializes a new instance of the StubEdmEntityType class.

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/MockUnresponsiveHttpClientHandler.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/MockUnresponsiveHttpClientHandler.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OData.Client.Tests.Serialization
         /// </summary>
         public Action OnRequestStarted { get; set; }
 
-        public HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+        public new HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             NotifyRequestStart();
             Stopwatch stopwatch = new Stopwatch();

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Evaluation/NoOpResourceMetadataBuilderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Evaluation/NoOpResourceMetadataBuilderTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.OData.Tests.Evaluation
 
             ODataResource entry = new ODataResource();
             entry.AddAction(action);
-            Assert.Single(new NoOpResourceMetadataBuilder(entry).GetActions().Where(a => a == action));
+            Assert.Single(new NoOpResourceMetadataBuilder(entry).GetActions(), a => a == action);
 
             // Verify that the action information wasn't removed or changed.
             Assert.Equal(new Uri("http://example.com/$metadata#Action"), action.Metadata);
@@ -115,7 +115,7 @@ namespace Microsoft.OData.Tests.Evaluation
             ODataResource entry = new ODataResource();
             entry.AddFunction(function);
 
-            Assert.Single(new NoOpResourceMetadataBuilder(entry).GetFunctions().Where(f => f == function));
+            Assert.Single(new NoOpResourceMetadataBuilder(entry).GetFunctions(), f => f == function);
 
             // Verify that the Function information wasn't removed or changed.
             Assert.Equal(new Uri("http://example.com/$metadata#Function"), function.Metadata);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Evaluation/NullEntityMetadataBuilderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Evaluation/NullEntityMetadataBuilderTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.OData.Tests.Evaluation
                     new ODataProperty() {Name = "StreamProperty", Value = new ODataStreamReferenceValue()}
                 };
 
-            Assert.Single(this.testSubject.GetProperties(properties).Where(p => p.Name == "IntegerProperty"));
+            Assert.Single(this.testSubject.GetProperties(properties), p => p.Name == "IntegerProperty");
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
@@ -1243,7 +1243,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
             resourceWriter.WriteEnd();
 
             var str = Encoding.UTF8.GetString(stream.ToArray());
-            Assert.Equal(str, "{\"@odata.context\":\"http://svc/$metadata#Customers/$entity\"," +
+            Assert.Equal("{\"@odata.context\":\"http://svc/$metadata#Customers/$entity\"," +
                 "\"Id\":9," +
                 "\"ComplexProperty\":{" +
                     "\"@odata.type\":\"#NS.Address\"," +
@@ -1255,7 +1255,8 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
                 "\"EntityProperty\":{" +
                     "\"@odata.type\":\"#NS.Customer\"," +
                     "\"Id\":42" +
-                "}}");
+                "}}",
+                str);
         }
 
         [Fact]
@@ -3250,7 +3251,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
                 }
                 else
                 {
-                    Assert.True(false, "Top level item to write must be entry or feed.");
+                    Assert.Fail("Top level item to write must be entry or feed.");
                 }
 
                 Assert.Equal(itemsToWrite.Length, currentIdx);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/UriParameterWriterIntegrationTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/UriParameterWriterIntegrationTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
         public void WriteComplexColParameter_WithoutModel()
         {
             WriteResourceSetParameter(false, false,
-                (actual) => Assert.Equal(actual,
+                (actual) => Assert.Equal(
                     "[" +
                         "{" +
                             "\"@odata.type\":\"#NS.Address\"," +
@@ -104,7 +104,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
                             "\"CompanyName\":\"MS\"," +
                             "\"City\":{\"@odata.type\":\"#NS.City\",\"CityName\":\"City1\",\"AreaCode\":\"AreaCode1\"}" +
                         "}" +
-                    "]"));
+                    "]", actual));
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/BufferingJsonReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/BufferingJsonReaderTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OData.Tests.Json
             // Assert
             Assert.True(result);
             Assert.Equal("any target", error.Target);
-            Assert.Equal(1, error.Details.Count);
+            Assert.Single(error.Details);
             var detail = error.Details.Single();
             Assert.Equal("500", detail.Code);
             Assert.Equal("another target", detail.Target);
@@ -380,10 +380,10 @@ namespace Microsoft.OData.Tests.Json
                 var innerError = error.InnerError;
                 Assert.NotNull(innerError);
                 Assert.Equal(3, innerError.Properties.Count);
-                Assert.Single(innerError.Properties.Where(d => d.Key.Equals("message")));
-                Assert.Single(innerError.Properties.Where(d => d.Key.Equals("type")));
-                Assert.Single(innerError.Properties.Where(d => d.Key.Equals("stacktrace")));
-                Assert.Empty(innerError.Properties.Where(d => d.Key.Equals("foo")));
+                Assert.Single(innerError.Properties, d => d.Key.Equals("message"));
+                Assert.Single(innerError.Properties, d => d.Key.Equals("type"));
+                Assert.Single(innerError.Properties, d => d.Key.Equals("stacktrace"));
+                Assert.DoesNotContain(innerError.Properties, d => d.Key.Equals("foo"));
             }
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
@@ -30,28 +30,6 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
-        public async Task StartPaddingFunctionScopeAsyncWritesParenthesis()
-        {
-            await this.writer.StartPaddingFunctionScopeAsync();
-            Assert.Equal("(", this.builder.ToString());
-        }
-
-        [Fact]
-        public async Task EndPaddingFunctionScopeAsyncWritesParenthesis()
-        {
-            await this.writer.StartPaddingFunctionScopeAsync();
-            await this.writer.EndPaddingFunctionScopeAsync();
-            Assert.Equal("()", this.builder.ToString());
-        }
-
-        [Fact]
-        public async Task WritePaddingFunctionNameAsyncWritesName()
-        {
-            await this.writer.WritePaddingFunctionNameAsync("example");
-            Assert.Equal("example", this.builder.ToString());
-        }
-
-        [Fact]
         public async Task StartObjectScopeAsyncWritesCurlyBraces()
         {
             await this.writer.StartObjectScopeAsync();

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
@@ -30,28 +30,6 @@ namespace Microsoft.OData.Tests.Json
             
         }
 
-        [Fact]
-        public void StartPaddingFunctionScopeWritesParenthesis()
-        {
-            this.writer.StartPaddingFunctionScope();
-            Assert.Equal("(", this.builder.ToString());
-        }
-
-        [Fact]
-        public void EndPaddingFunctionScopeWritesParenthesis()
-        {
-            this.writer.StartPaddingFunctionScope();
-            this.writer.EndPaddingFunctionScope();
-            Assert.Equal("()", this.builder.ToString());
-        }
-
-        [Fact]
-        public void WritePaddingFunctionNameWritesName()
-        {
-            this.writer.WritePaddingFunctionName("example");
-            Assert.Equal("example", this.builder.ToString());
-        }
-
         #region WritePrimitiveValue
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonBatchReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonBatchReaderTests.cs
@@ -392,7 +392,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     }
                     catch (NullReferenceException ex)
                     {
-                        Assert.False(true, ex.Message);
+                        Assert.Fail(ex.Message);
                     }
                 },
                 isResponse: false);
@@ -428,7 +428,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     }
                     catch (NullReferenceException ex)
                     {
-                        Assert.False(true, ex.Message);
+                        Assert.Fail(ex.Message);
                     }
                 },
                 isResponse: false);
@@ -459,7 +459,7 @@ namespace Microsoft.OData.Core.Tests.Json
                             jsonBatchReader.CreateOperationRequestMessage();
                         }
                     }
-                    Assert.False(true, "The test failed, because the duplicate header has not thrown an ODataException");
+                    Assert.Fail("The test failed, because the duplicate header has not thrown an ODataException");
                 },
                 isResponse: false));
 
@@ -492,7 +492,7 @@ namespace Microsoft.OData.Core.Tests.Json
                             await jsonBatchReader.CreateOperationRequestMessageAsync();
                         }
                     }
-                    Assert.False(true, "The test failed, because the duplicate header has not thrown an ODataException");
+                    Assert.Fail("The test failed, because the duplicate header has not thrown an ODataException");
                 },
                 isResponse: false));
 
@@ -523,7 +523,7 @@ namespace Microsoft.OData.Core.Tests.Json
                             jsonBatchReader.CreateOperationRequestMessage();
                         }
                     }
-                    Assert.False(true, "The test failed, because the duplicate header has thrown no ODataException");
+                    Assert.Fail("The test failed, because the duplicate header has thrown no ODataException");
                 },
                 isResponse: false));
 
@@ -554,7 +554,7 @@ namespace Microsoft.OData.Core.Tests.Json
                                 await jsonBatchReader.CreateOperationRequestMessageAsync();
                             }
                         }
-                        Assert.False(true, "The test failed, because the duplicate header has thrown no ODataException");
+                        Assert.Fail("The test failed, because the duplicate header has thrown no ODataException");
                 },
                 isResponse: false));
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionDeserializerTests.cs
@@ -149,7 +149,6 @@ namespace Microsoft.OData.Tests.Json
                     await jsonCollectionDeserializer.ReadCollectionEndAsync(
                         isReadingNestedPayload: false);
 
-                    Assert.NotNull(readCollectionStartResult);
                     var collectionStart = Assert.IsType<ODataCollectionStart>(readCollectionStartResult.Item1);
                     var actualItemTypeReference = Assert.IsAssignableFrom<IEdmTypeReference>(readCollectionStartResult.Item2);
                     Assert.NotNull(collectionStart);
@@ -196,7 +195,6 @@ namespace Microsoft.OData.Tests.Json
                     await jsonCollectionDeserializer.ReadCollectionEndAsync(
                         isReadingNestedPayload: false);
 
-                    Assert.NotNull(readCollectionStartResult);
                     Assert.Equal("Tea", collectionItem1);
                     Assert.Equal("Coffee", collectionItem2);
                 });

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionWriterTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.OData.Tests.Json
                             }
                         }))));
             var str = Encoding.UTF8.GetString(stream.ToArray());
-            Assert.Equal(str,
+            Assert.Equal(
                 "{" +
                     "\"@odata.context\":\"http://svc/$metadata#EntitySet/$entity\"," +
                     "\"ID\":1," +
@@ -92,7 +92,7 @@ namespace Microsoft.OData.Tests.Json
                     "\"DynamicPrimitive\":[1,2,null]," +
                     "\"DynamicComplex@odata.type\":\"#Collection(NS.ComplexType)\"," +
                     "\"DynamicComplex\":[null,null,{\"Prop1\":1,\"Prop2\":2}]" +
-                "}");
+                "}", str);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeltaReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeltaReaderTests.cs
@@ -558,7 +558,7 @@ namespace Microsoft.OData.Tests.Json
                         break;
                     case ODataReaderState.Stream:
                     case ODataReaderState.NestedResourceInfoStart:
-                        Assert.True(false, "Should not add stream or navigation properties to delta payload");
+                        Assert.Fail("Should not add stream or navigation properties to delta payload");
                         break;
                 }
             }
@@ -4254,12 +4254,12 @@ namespace Microsoft.OData.Tests.Json
                                 Assert.True(nestedResourceInfo.Name.Equals("Details") || nestedResourceInfo.Name.Equals("Address") || nestedResourceInfo.Name.Equals("City"));
                                 break;
                             default:
-                                Assert.True(false, "Wrong reader sub state.");
+                                Assert.Fail("Wrong reader sub state.");
                                 break;
                         }
                         break;
                     default:
-                        Assert.True(false, "Wrong reader state.");
+                        Assert.Fail("Wrong reader state.");
                         break;
                 }
             }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeltaWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeltaWriterTests.cs
@@ -856,7 +856,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.WriteExpandedFeedWithModelImplementation();
 
-            Assert.Equal(this.TestPayload(),
+            Assert.Equal("{" +
                 "{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
@@ -880,7 +880,7 @@ namespace Microsoft.OData.Tests.Json
                             "]" +
                         "}" +
                     "]" +
-                "}");
+                "}", this.TestPayload());
         }
 
         [Fact]
@@ -890,8 +890,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.WriteExpandedFeedWithModelImplementation();
 
-            Assert.Equal(this.TestPayload(),
-                "{" +
+            Assert.Equal("{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
                     "[" +
@@ -924,7 +923,7 @@ namespace Microsoft.OData.Tests.Json
                             "\"ProductBeingViewed@odata.navigationLink\":\"http://host/service/Customers('BOTTM')/ProductBeingViewed\"" +
                         "}" +
                     "]" +
-                "}");
+                "}", this.TestPayload());
         }
 
         [InlineData(/*isResponse*/true)]
@@ -951,8 +950,7 @@ namespace Microsoft.OData.Tests.Json
             writer.WriteEnd(); // deltaFeedWithInfo
             writer.Flush();
 
-            Assert.Equal(this.TestPayload(),
-                "{" +
+            Assert.Equal("{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
                     "[" +
@@ -975,7 +973,7 @@ namespace Microsoft.OData.Tests.Json
                             "]" +
                         "}" +
                     "]" +
-                "}");
+                "}", this.TestPayload());
         }
 
         [InlineData(/*isResponse*/true)]
@@ -1008,8 +1006,7 @@ namespace Microsoft.OData.Tests.Json
             writer.WriteEnd(); // deltaFeed
             writer.Flush();
 
-            Assert.Equal(this.TestPayload(),
-                "{" +
+            Assert.Equal("{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
                     "[" +
@@ -1040,7 +1037,7 @@ namespace Microsoft.OData.Tests.Json
                             "]" +
                         "}" +
                     "]" +
-                "}");
+                "}", this.TestPayload());
         }
 
         [InlineData(/*isResponse*/true)]
@@ -1069,8 +1066,7 @@ namespace Microsoft.OData.Tests.Json
             writer.WriteEnd(); // deltaFeed
             writer.Flush();
 
-            Assert.Equal(this.TestPayload(),
-                "{" +
+            Assert.Equal("{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
                     "[" +
@@ -1094,7 +1090,7 @@ namespace Microsoft.OData.Tests.Json
                             "]" +
                         "}" +
                     "]" +
-                "}");
+                "}", this.TestPayload());
         }
 
         [InlineData(/*isResponse*/true)]
@@ -1106,8 +1102,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.WriteNestedDeltaFeedImplementation(isResponse);
 
-            Assert.Equal(this.TestPayload(),
-                "{" +
+            Assert.Equal("{" +
                     "\"@context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
                     "[" +
@@ -1137,8 +1132,7 @@ namespace Microsoft.OData.Tests.Json
                             "]" +
                         "}" +
                     "]" +
-                "}"
-                );
+                "}", this.TestPayload());
         }
 
         [InlineData(/*isResponse*/true)]
@@ -1367,8 +1361,7 @@ namespace Microsoft.OData.Tests.Json
             writer.WriteEnd(); // deltaFeed
             writer.Flush();
 
-            Assert.Equal(this.TestPayload(),
-                "{" +
+            Assert.Equal("{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
                     "[" +
@@ -1390,7 +1383,7 @@ namespace Microsoft.OData.Tests.Json
                             "}" +
                         "}" +
                     "]" +
-                "}");
+                "}", this.TestPayload());
         }
 
         #endregion

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeserializerTests.cs
@@ -633,7 +633,7 @@ namespace Microsoft.OData.Tests.Json
                     jsonReader.ShouldBeOn(JsonNodeType.Property, "@odata.unknown");
                     var propertyAnnotation = duplicateChecker.GetODataPropertyAnnotations("NavProp").Keys;
                     Assert.Contains("odata.navigationLink", propertyAnnotation);
-                    Assert.Equal(1, propertyAnnotation.Count);
+                    Assert.Single(propertyAnnotation);
                 },
                 (jsonReader, name) =>
                 {
@@ -827,13 +827,13 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
-        public void ReadPayloadStartAsyncTestForDetla()
+        public async Task ReadPayloadStartAsyncTestForDetla()
         {
             var model = this.CreateEdmModelWithEntity();
             var primitiveTypeRef = ((IEdmEntityType)model.SchemaElements.First()).Properties().First().Type;
             this.messageReaderSettings = new ODataMessageReaderSettings();
             ODataJsonPropertyAndValueDeserializer deserializer = new ODataJsonPropertyAndValueDeserializer(this.CreateJsonInputContext("{\"@odata.context\":\"http://odata.org/test/$metadata#Customers/$delta\",\"value\":\"Joe\"}", model));
-            deserializer.ReadPayloadStartAsync(ODataPayloadKind.Delta, null, false, true);
+            await deserializer.ReadPayloadStartAsync(ODataPayloadKind.Delta, null, false, true);
             Assert.Equal(ODataDeltaKind.ResourceSet, deserializer.ContextUriParseResult.DeltaKind);
         }
 
@@ -965,7 +965,7 @@ namespace Microsoft.OData.Tests.Json
                     if (odataReader.State == ODataReaderState.ResourceEnd)
                     {
                         var resource = odataReader.Item as ODataResource;
-                        Assert.Equal(0, resource.Properties.First().InstanceAnnotations.Count);
+                        Assert.Empty(resource.Properties.First().InstanceAnnotations);
                     }
                 }
             };
@@ -2063,8 +2063,8 @@ namespace Microsoft.OData.Tests.Json
 
                     var resource = Assert.IsType<ODataResourceValue>(property.ODataValue);
                     Assert.Equal(2, resource.Properties.Count());
-                    var streetProperty = Assert.Single(resource.Properties.Where(d => d.Name.Equals("Street")));
-                    var cityProperty = Assert.Single(resource.Properties.Where(d => d.Name.Equals("City")));
+                    var streetProperty = Assert.Single(resource.Properties, d => d.Name.Equals("Street"));
+                    var cityProperty = Assert.Single(resource.Properties, d => d.Name.Equals("City"));
                     Assert.Equal("S1", streetProperty.Value);
                     Assert.Equal("C1", cityProperty.Value);
                 });

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerTests.cs
@@ -327,7 +327,7 @@ namespace Microsoft.OData.Tests.Json
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             ODataResourceSet feed = new ODataResourceSet();
             deserializer.ReadAndApplyResourceSetInstanceAnnotationValue("custom.Int32Annotation", feed, propertyAndAnnotationCollector);
-            Assert.Equal(1, feed.InstanceAnnotations.Count);
+            Assert.Single(feed.InstanceAnnotations);
             TestUtils.AssertODataValueAreEqual(new ODataPrimitiveValue(123), feed.InstanceAnnotations.Single(ia => ia.Name == "custom.Int32Annotation").Value);
         }
 
@@ -374,7 +374,7 @@ namespace Microsoft.OData.Tests.Json
             AdvanceReaderToFirstPropertyValue(deserializer.JsonReader);
             var entryState = new TestJsonReaderEntryState();
             deserializer.ApplyEntryInstanceAnnotation(entryState, "custom.Int32Annotation", 123);
-            Assert.Equal(1, entryState.Resource.InstanceAnnotations.Count);
+            Assert.Single(entryState.Resource.InstanceAnnotations);
             TestUtils.AssertODataValueAreEqual(new ODataPrimitiveValue(123), entryState.Resource.InstanceAnnotations.Single(ia => ia.Name == "custom.Int32Annotation").Value);
         }
 
@@ -403,7 +403,7 @@ namespace Microsoft.OData.Tests.Json
             var feed = new ODataResourceSet();
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             deserializer.ReadTopLevelResourceSetAnnotations(feed, propertyAndAnnotationCollector, true /*forResourceSetStart*/, true /*readAllFeedProperties*/);
-            Assert.Equal(0, feed.InstanceAnnotations.Count);
+            Assert.Empty(feed.InstanceAnnotations);
         }
 
         [Fact]
@@ -414,7 +414,7 @@ namespace Microsoft.OData.Tests.Json
             var feed = new ODataResourceSet();
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             deserializer.ReadTopLevelResourceSetAnnotations(feed, propertyAndAnnotationCollector, true /*forResourceSetStart*/, false /*readAllFeedProperties*/);
-            Assert.Equal(1, feed.InstanceAnnotations.Count);
+            Assert.Single(feed.InstanceAnnotations);
             TestUtils.AssertODataValueAreEqual(new ODataPrimitiveValue(123), feed.InstanceAnnotations.Single(ia => ia.Name == "custom.before").Value);
         }
 
@@ -426,7 +426,7 @@ namespace Microsoft.OData.Tests.Json
             var feed = new ODataResourceSet();
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             deserializer.ReadTopLevelResourceSetAnnotations(feed, propertyAndAnnotationCollector, true /*forResourceSetStart*/, false /*readAllFeedProperties*/);
-            Assert.Equal(0, feed.InstanceAnnotations.Count);
+            Assert.Empty(feed.InstanceAnnotations);
         }
 
         [Fact]
@@ -448,7 +448,7 @@ namespace Microsoft.OData.Tests.Json
             var feed = new ODataResourceSet();
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             deserializer.ReadTopLevelResourceSetAnnotations(feed, propertyAndAnnotationCollector, false /*forResourceSetStart*/, false /*readAllFeedProperties*/);
-            Assert.Equal(1, feed.InstanceAnnotations.Count);
+            Assert.Single(feed.InstanceAnnotations);
             TestUtils.AssertODataValueAreEqual(new ODataPrimitiveValue(456), feed.InstanceAnnotations.Single(ia => ia.Name == "custom.after").Value);
         }
 
@@ -460,7 +460,7 @@ namespace Microsoft.OData.Tests.Json
             var feed = new ODataResourceSet();
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             deserializer.ReadTopLevelResourceSetAnnotations(feed, propertyAndAnnotationCollector, false /*forResourceSetStart*/, false /*readAllFeedProperties*/);
-            Assert.Equal(0, feed.InstanceAnnotations.Count);
+            Assert.Empty(feed.InstanceAnnotations);
         }
 
         #endregion Test ReadTopLevelResourceSetAnnotations
@@ -486,7 +486,7 @@ namespace Microsoft.OData.Tests.Json
             AdvanceReaderToFirstProperty(deserializer.JsonReader);
             var entryState = new TestJsonReaderEntryState();
             deserializer.ReadResourceContent(entryState);
-            Assert.Equal(0, entryState.Resource.InstanceAnnotations.Count);
+            Assert.Empty(entryState.Resource.InstanceAnnotations);
         }
 
         #endregion Test ReadResourceContent

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonErrorDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonErrorDeserializerTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OData.Tests.Json
 
             // Assert
             Assert.Equal("any target", error.Target);
-            Assert.Equal(1, error.Details.Count);
+            Assert.Single(error.Details);
             var detail = error.Details.Single();
             Assert.Equal("500", detail.Code);
             Assert.Equal("another target", detail.Target);
@@ -132,7 +132,7 @@ namespace Microsoft.OData.Tests.Json
 
             // Assert Top Level properties
             Assert.Equal("any target", error.Target);
-            Assert.Equal(1, error.Details.Count);
+            Assert.Single(error.Details);
             var detail = error.Details.Single();
             Assert.Equal("500", detail.Code);
             Assert.Equal("any target", detail.Target);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonPayloadKindDetectionDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonPayloadKindDetectionDeserializerTests.cs
@@ -41,8 +41,8 @@ namespace Microsoft.OData.Tests.Json
                     var payloadKinds = jsonPayloadKindDetectionDeserializer.DetectPayloadKind(this.payloadKindDetectionInfo);
 
                     Assert.Equal(2, payloadKinds.Count());
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Resource)));
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Delta)));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Resource));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Delta));
                 });
         }
 
@@ -59,7 +59,7 @@ namespace Microsoft.OData.Tests.Json
                     var payloadKinds = jsonPayloadKindDetectionDeserializer.DetectPayloadKind(this.payloadKindDetectionInfo);
 
                     Assert.Single(payloadKinds);
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Error)));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Error));
                 });
         }
 
@@ -97,8 +97,8 @@ namespace Microsoft.OData.Tests.Json
                     var payloadKinds = await jsonPayloadKindDetectionDeserializer.DetectPayloadKindAsync(this.payloadKindDetectionInfo);
 
                     Assert.Equal(2, payloadKinds.Count());
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Resource)));
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Delta)));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Resource));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Delta));
                 });
         }
 
@@ -115,7 +115,7 @@ namespace Microsoft.OData.Tests.Json
                     var payloadKinds = await jsonPayloadKindDetectionDeserializer.DetectPayloadKindAsync(this.payloadKindDetectionInfo);
 
                     Assert.Single(payloadKinds);
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Error)));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Error));
                 });
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonResourceDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonResourceDeserializerTests.cs
@@ -682,7 +682,7 @@ namespace Microsoft.OData.Tests.Json
                 this.categoryEntityType,
                 (resourceState) =>
                 {
-                    var mediaProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Media"))));
+                    var mediaProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("Media")));
                     var streamReferenceValue = Assert.IsType<ODataStreamReferenceValue>(mediaProperty.Value);
 
                     Assert.Equal("http://tempuri.org/Categories(1)/Media", streamReferenceValue.EditLink.AbsoluteUri);
@@ -741,7 +741,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var warehousePinProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("WarehousePin"))));
+                    var warehousePinProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("WarehousePin")));
                     var geographyPoint = Assert.IsAssignableFrom<GeographyPoint>(warehousePinProperty.Value);
                     Assert.Equal(22.2, geographyPoint.Latitude);
                     Assert.Equal(22.2, geographyPoint.Longitude);
@@ -765,7 +765,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var piProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Pi"))));
+                    var piProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("Pi")));
                     Assert.Equal(3.1428571429m, piProperty.Value);
                 });
         }
@@ -788,7 +788,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var creditLimitProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("CreditLimit"))));
+                    var creditLimitProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("CreditLimit")));
                     Assert.Equal(1730, creditLimitProperty.Value);
                 });
         }
@@ -812,7 +812,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var creditLimitProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("CreditLimit"))));
+                    var creditLimitProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("CreditLimit")));
                     Assert.Equal(1730M, creditLimitProperty.Value);
                 });
         }
@@ -1054,7 +1054,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var photoProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Photo"))));
+                    var photoProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("Photo")));
                     var streamReferenceValue = Assert.IsType<ODataStreamReferenceValue>(photoProperty.Value);
 
                     Assert.Equal("http://tempuri.org/Products(1)/Photo", streamReferenceValue.EditLink.AbsoluteUri);
@@ -1080,7 +1080,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var photoProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Photo"))));
+                    var photoProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("Photo")));
                     var streamReferenceValue = Assert.IsType<ODataStreamReferenceValue>(photoProperty.Value);
 
                     Assert.Equal("http://tempuri.org/Products(1)/Photo", streamReferenceValue.EditLink.AbsoluteUri);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterTests.cs
@@ -814,7 +814,7 @@ namespace Microsoft.OData.Core.Tests.Json
                 {
                     if (!CsdlReader.TryParse(xmlReader, out model, out var errors))
                     {
-                        Assert.True(false, string.Join(Environment.NewLine, errors));
+                        Assert.Fail(string.Join(Environment.NewLine, errors));
                     }
                 }
             }
@@ -875,7 +875,7 @@ namespace Microsoft.OData.Core.Tests.Json
                 {
                     if (!CsdlReader.TryParse(xmlReader, out model, out var errors))
                     {
-                        Assert.True(false, string.Join(Environment.NewLine, errors));
+                        Assert.Fail(string.Join(Environment.NewLine, errors));
                     }
                 }
             }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -53,28 +53,6 @@ namespace Microsoft.OData.Tests.Json
             await this.stream.DisposeAsync();
         }
 
-        [Fact]
-        public async Task StartPaddingFunctionScopeAsync_WritesParenthesis()
-        {
-            await this.writer.StartPaddingFunctionScopeAsync();
-            Assert.Equal("(", await this.ReadStreamAsync());
-        }
-
-        [Fact]
-        public async Task EndPaddingFunctionScopeAsync_WritesParenthesis()
-        {
-            await this.writer.StartPaddingFunctionScopeAsync();
-            await this.writer.EndPaddingFunctionScopeAsync();
-            Assert.Equal("()", await this.ReadStreamAsync());
-        }
-
-        [Fact]
-        public async Task WritePaddingFunctionNameAsync_WritesName()
-        {
-            await this.writer.WritePaddingFunctionNameAsync("example");
-            Assert.Equal("example", await this.ReadStreamAsync());
-        }
-
         #region WritePrimitiveValue
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
@@ -61,28 +61,6 @@ namespace Microsoft.OData.Tests.Json
             this.disposed = true;
         }
 
-        [Fact]
-        public void StartPaddingFunctionScopeWritesParenthesis()
-        {
-            this.writer.StartPaddingFunctionScope();
-            Assert.Equal("(", this.ReadStream());
-        }
-
-        [Fact]
-        public void EndPaddingFunctionScopeWritesParenthesis()
-        {
-            this.writer.StartPaddingFunctionScope();
-            this.writer.EndPaddingFunctionScope();
-            Assert.Equal("()", this.ReadStream());
-        }
-
-        [Fact]
-        public void WritePaddingFunctionNameWritesName()
-        {
-            this.writer.WritePaddingFunctionName("example");
-            Assert.Equal("example", this.ReadStream());
-        }
-
         #region WritePrimitiveValue
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataBinaryStreamReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataBinaryStreamReaderTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.OData.Tests
 
                 var bytesRead = reader.Read(buffer, 0, maxLength);
 
-                Assert.Equal(bytesRead, maxLength);
+                Assert.Equal(maxLength, bytesRead);
                 Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 }, buffer);
             }
         }
@@ -67,7 +67,7 @@ namespace Microsoft.OData.Tests
 
                 var bytesRead = await reader.ReadAsync(buffer, 0, maxLength);
 
-                Assert.Equal(bytesRead, maxLength);
+                Assert.Equal(maxLength, bytesRead);
                 Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 }, buffer);
             }
         }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "aggregate(Id with sum as TotalId)";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(TotalId)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(TotalId)", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -136,7 +136,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "aggregate(DynamicProperty with " + method + " as DynamicPropertyTotal)";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(DynamicPropertyTotal)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(DynamicPropertyTotal)", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "groupby((Name, Address/Street))";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(Name,Address(Street))");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Name,Address(Street))", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -156,7 +156,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "groupby((Name, DynamicProperty, Address/Street))";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(Name,DynamicProperty,Address(Street))");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Name,DynamicProperty,Address(Street))", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -166,7 +166,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "filter(Id eq 1)";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities");
+                Assert.Equal(MetadataDocumentUriString + "#Cities", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
         [Fact]
@@ -175,7 +175,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "groupby((Name), aggregate(Id with sum as TotalId))";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(Name,TotalId)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Name,TotalId)", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -185,7 +185,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "groupby((Name), aggregate(Id with sum as TotalId))";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri("Name", null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(Name)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Name)", this.CreateFeedContextUri("Name", null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -195,7 +195,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "expand(Districts, filter(true))";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities");
+                Assert.Equal(MetadataDocumentUriString + "#Cities", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -206,7 +206,7 @@ namespace Microsoft.OData.Tests
             string computeClause = "compute('Test' as NewColumn)";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, computeClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities");
+                Assert.Equal(MetadataDocumentUriString + "#Cities", this.CreateFeedContextUri(null, null, computeClause, null, version).OriginalString);
             }
         }
 
@@ -216,7 +216,7 @@ namespace Microsoft.OData.Tests
             string computeClause = "compute('Test' as NewColumn)";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri("Id,Name,NewColumn", null, computeClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(Id,Name,NewColumn)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Id,Name,NewColumn)", this.CreateFeedContextUri("Id,Name,NewColumn", null, computeClause, null, version).OriginalString);
             }
         }
 
@@ -226,7 +226,7 @@ namespace Microsoft.OData.Tests
             string computeClause = "'Test' as NewColumn";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, null, computeClause, version).OriginalString, MetadataDocumentUriString + "#Cities");
+                Assert.Equal(MetadataDocumentUriString + "#Cities", this.CreateFeedContextUri(null, null, null, computeClause, version).OriginalString);
             }
         }
 
@@ -236,7 +236,7 @@ namespace Microsoft.OData.Tests
             string computeClause = "'Test' as NewColumn";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri("Id,Name,NewColumn", null, null, computeClause, version).OriginalString, MetadataDocumentUriString + "#Cities(Id,Name,NewColumn)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Id,Name,NewColumn)", this.CreateFeedContextUri("Id,Name,NewColumn", null, null, computeClause, version).OriginalString);
             }
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataEntityReferenceLinkTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataEntityReferenceLinkTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.OData.Tests
             ODataEntityReferenceLink referencelink = new ODataEntityReferenceLink();
             Assert.NotNull(referencelink.InstanceAnnotations);
             referencelink.InstanceAnnotations.Add(new ODataInstanceAnnotation("TestNamespace.name", new ODataPrimitiveValue("value")));
-            Assert.Equal(1, referencelink.InstanceAnnotations.Count);
+            Assert.Single(referencelink.InstanceAnnotations);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void MaxReceivedMessageSizeShouldBeSetByDefault()
         {
-            Assert.Equal(this.settings.MessageQuotas.MaxReceivedMessageSize, 1024 * 1024);
+            Assert.Equal(1024 * 1024, this.settings.MessageQuotas.MaxReceivedMessageSize);
         }
 
         [Fact]
@@ -446,11 +446,11 @@ namespace Microsoft.OData.Tests
             Assert.Same(this.settings.BaseUri, baseUri);
             Assert.True(this.settings.EnableCharactersCheck);
             Assert.False(this.settings.EnableMessageStreamDisposal);
-            Assert.Equal(this.settings.MessageQuotas.MaxPartsPerBatch, maxPartsPerBatch);
-            Assert.Equal(this.settings.MessageQuotas.MaxOperationsPerChangeset, maxOperationsPerChangeset);
-            Assert.Equal(this.settings.MessageQuotas.MaxNestingDepth, maxNestingDepth);
-            Assert.Equal(this.settings.Version, version);
-            Assert.Equal(this.settings.LibraryCompatibility, library);
+            Assert.Equal(maxPartsPerBatch, this.settings.MessageQuotas.MaxPartsPerBatch);
+            Assert.Equal(maxOperationsPerChangeset, this.settings.MessageQuotas.MaxOperationsPerChangeset);
+            Assert.Equal(maxNestingDepth, this.settings.MessageQuotas.MaxNestingDepth);
+            Assert.Equal(version, this.settings.Version);
+            Assert.Equal(library, this.settings.LibraryCompatibility);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataTextStreamReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataTextStreamReaderTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.OData.Tests
 
                 var charsRead = reader.Read(charBuffer, 0, maxLength);
 
-                Assert.Equal(charsRead, maxLength);
+                Assert.Equal(maxLength, charsRead);
                 Assert.Equal("fox jumps over", new string(charBuffer));
             }
         }
@@ -67,7 +67,7 @@ namespace Microsoft.OData.Tests
 
                 var charsRead = await reader.ReadAsync(charBuffer, 0, maxLength);
 
-                Assert.Equal(charsRead, maxLength);
+                Assert.Equal(maxLength, charsRead);
                 Assert.Equal("fox jumps over", new string(charBuffer));
             }
         }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.Async.cs
@@ -244,10 +244,10 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.Roundtrip
 
             using (var writer = XmlWriter.Create(stringWriter, new XmlWriterSettings() { Async = true }))
             {
-                var (success, errors) = await CsdlWriter.TryWriteCsdlAsync(this.model, writer).ConfigureAwait(false);
+                var (success, errors) = await CsdlWriter.TryWriteCsdlAsync(this.model, writer);
                 if (!success)
                 {
-                    Assert.True(false, "Serialization was unsuccessful");
+                    Assert.Fail("Serialization was unsuccessful");
                 }
             }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/JsonBatchRoundTripTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/JsonBatchRoundTripTests.cs
@@ -295,7 +295,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.Json
                             }
                             else
                             {
-                                Assert.True(false, "Unexpected response id received: " + responseId);
+                                Assert.Fail("Unexpected response id received: " + responseId);
                             }
                             break;
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/SingletonBatchRoundtripJsonTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/SingletonBatchRoundtripJsonTests.cs
@@ -1285,7 +1285,7 @@ Content-Type: application/json;odata.metadata=none
 
                     default:
                         {
-                            Assert.True(false, "Unknown BatchFormat value");
+                            Assert.Fail("Unknown BatchFormat value");
                         }
                         break;
                 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonStreamReadingTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonStreamReadingTests.cs
@@ -257,7 +257,7 @@ namespace Microsoft.OData.Tests.Json
                             break;
 
                         case ODataReaderState.Primitive:
-                            Assert.False(true, "Should not read as Primitive if Caller Specifies Stream");
+                            Assert.Fail("Should not read as Primitive if Caller Specifies Stream");
                             break;
 
                         case ODataReaderState.NestedProperty:
@@ -314,7 +314,7 @@ namespace Microsoft.OData.Tests.Json
                             break;
 
                         case ODataReaderState.Stream:
-                            Assert.False(true, "Should not read as stream if caller returns false");
+                            Assert.Fail("Should not read as stream if caller returns false");
                             break;
                     }
                 }
@@ -505,7 +505,7 @@ namespace Microsoft.OData.Tests.Json
                             break;
 
                         case ODataReaderState.Primitive:
-                            Assert.False(true, "Should not read as Primitive if collection not streamed");
+                            Assert.Fail("Should not read as Primitive if collection not streamed");
                             break;
 
                         case ODataReaderState.NestedProperty:
@@ -560,7 +560,7 @@ namespace Microsoft.OData.Tests.Json
                             break;
 
                         case ODataReaderState.Primitive:
-                            Assert.False(true, "Should not read as Primitive if Caller Specifies Stream");
+                            Assert.Fail("Should not read as Primitive if Caller Specifies Stream");
                             break;
 
                         case ODataReaderState.NestedProperty:
@@ -654,11 +654,11 @@ namespace Microsoft.OData.Tests.Json
                             break;
 
                         case ODataReaderState.NestedProperty:
-                            Assert.False(true, "Should Not enter nested property without a value");
+                            Assert.Fail("Should Not enter nested property without a value");
                             break;
 
                         case ODataReaderState.Stream:
-                            Assert.False(true, "Should Not enter stream without a value");
+                            Assert.Fail("Should Not enter stream without a value");
                             break;
                     }
                 }
@@ -1489,7 +1489,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 Stream stream = reader.CreateReadStream();
                 {
-                    stream.Read(new byte[2],0,2);
+                    stream.ReadExactly(new byte[2], 0, 2);
                 }
             }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2916,7 +2916,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var inNode = Assert.IsType<InNode>(inFilter.Expression);
             Assert.Equal("SSN", Assert.IsType<SingleValuePropertyAccessNode>(inNode.Left).Property.Name);
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
-            Assert.Equal(1, collectionNode.Collection.Count);
+            Assert.Single(collectionNode.Collection);
 
             var eqNode = Assert.IsType<BinaryOperatorNode>(eqFilter.Expression);
             Assert.Equal("SSN", Assert.IsType<SingleValuePropertyAccessNode>(eqNode.Left).Property.Name);
@@ -2939,7 +2939,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var inNode = Assert.IsType<InNode>(inFilter.Expression);
             Assert.Equal("SSN", Assert.IsType<SingleValuePropertyAccessNode>(inNode.Left).Property.Name);
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
-            Assert.Equal(1, collectionNode.Collection.Count);
+            Assert.Single(collectionNode.Collection);
 
             Assert.Equal(constantString, collectionNode.Collection.ElementAt(0).Value);
 
@@ -3059,7 +3059,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var inNode = Assert.IsType<InNode>(filter.Expression);
 
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
-            Assert.Equal(0, collectionNode.Collection.Count);
+            Assert.Empty(collectionNode.Collection);
         }
 
         [Theory]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -560,7 +560,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             var result = RunParseSelectExpand("", "MyDog", HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
             Assert.True(result.AllSelected);
-            Assert.Empty(result.SelectedItems.Where(x => x is PathSelectItem));
+
+            Assert.DoesNotContain(result.SelectedItems, x => x is PathSelectItem);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/FullPayloadValidateTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/FullPayloadValidateTests.cs
@@ -1150,7 +1150,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.Json
                 }
                 else
                 {
-                    Assert.True(false, "Top level item to write must be entry or feed.");
+                    Assert.Fail("Top level item to write must be entry or feed.");
                 }
 
                 Assert.Equal(itemsToWrite.Length, currentIdx);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/ODataJsonInheritComplexCollectionWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/ODataJsonInheritComplexCollectionWriterTests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.Json
             WriteAndValidateSync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
             WriteAndValidateAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
             WriteAndValidatePrimitivesSync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
-            WriteAndValidatePrimitivesAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
+            WriteAndValidatePrimitivesAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse).Wait();
         }
 
         private static void WriteAndValidateSync(IEdmTypeReference itemTypeReference, ODataResourceSet collectionStart, IEnumerable<ODataResource> items, string expectedPayload, bool writingResponse)

--- a/test/UnitTests/Microsoft.OData.Core.Tests/TestUtils.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/TestUtils.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OData.Tests
                 }
                 else
                 {
-                    Assert.True(false, "Test only currently supports creating ODataResource from IEdmPrimitiveValue instances.");
+                    Assert.Fail("Test only currently supports creating ODataResource from IEdmPrimitiveValue instances.");
                     return null;
                 }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
@@ -991,7 +991,7 @@ namespace Microsoft.OData.Tests.UriParser
                     return ch;
                 }
             }
-            Assert.True(false, "Should never get here");
+            Assert.Fail("Should never get here");
             return (char)0;
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -1119,7 +1119,7 @@ namespace Microsoft.OData.Tests.UriParser
                     parser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Slash;
                     break;
                 default:
-                    Assert.True(false, "Unreachable code path");
+                    Assert.Fail("Unreachable code path");
                     break;
             }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralParserStoreTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralParserStoreTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.OData.Core.Tests.UriParser.Parsers
 
             var set = store.Snapshot();
             Assert.True(set.Contains(parser));
-            Assert.Equal(1, set.Count);
+            Assert.Single(set);
         }
 
         [Theory]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralPrefixesStoreTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralPrefixesStoreTests.cs
@@ -287,7 +287,7 @@ namespace Microsoft.OData.Core.Tests.UriParser
             // Ensure only one key exists with that name
             var snapshot = store.Snapshot();
             Assert.True(snapshot.ContainsKey(prefix));
-            Assert.Single(snapshot.Where(kv => kv.Key == prefix));
+            Assert.Single(snapshot, kv => kv.Key == prefix);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/ODataPathTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/ODataPathTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
             ODataPath clone = new ODataPath(existing);
 
             clone.FirstSegment.ShouldBeMetadataSegment();
-            Assert.Equal(1, clone.Segments.Count);
+            Assert.Single(clone.Segments);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/OperationImportSegmentTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/OperationImportSegmentTests.cs
@@ -166,7 +166,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
             {
                 // Dummy code, just need to access property to get the exception
                 var type = segment.EdmType;
-                Assert.True(false, "The EdmType getter returned '" + type + "', but should have thrown.");
+                Assert.Fail("The EdmType getter returned '" + type + "', but should have thrown.");
             }
             catch (ODataException e)
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

    Fixes the test project building warnings:

1.     Use Assert.Fail, not use Assert.True(false, message)
2.     Use Assert.Single for single item in the collection
3.     User Lambda version, not use Assert.Single(...Where...))
4.     Put Expect before actual when using Assert.Equal


### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
