### PR TITLE
 Fixes the test project building warnings

### DIFF
--- a/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
@@ -2374,9 +2374,7 @@ namespace Microsoft.OData.Json
         [Conditional("DEBUG")]
         private void AssertAsynchronous()
         {
-#if DEBUG
             Debug.Assert(this.innerReader != null, "The method should only be called on an asynchronous buffering json reader.");
-#endif
         }
 
 #if DEBUG

--- a/src/Microsoft.OData.Core/Json/IJsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/IJsonWriter.cs
@@ -19,18 +19,6 @@ namespace Microsoft.OData.Json
     public interface IJsonWriter
     {
         /// <summary>
-        /// Start the padding function scope.
-        /// </summary>
-        [Obsolete("This will be dropped in the 9.x release.")]
-        void StartPaddingFunctionScope();
-
-        /// <summary>
-        /// End the padding function scope.
-        /// </summary>
-        [Obsolete("This will be dropped in the 9.x release.")]
-        void EndPaddingFunctionScope();
-
-        /// <summary>
         /// Start the object scope.
         /// </summary>
         void StartObjectScope();
@@ -55,13 +43,6 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="name">Name of the object property.</param>
         void WriteName(string name);
-
-        /// <summary>
-        /// Writes a function name for JSON padding.
-        /// </summary>
-        /// <param name="functionName">Name of the padding function to write.</param>
-        [Obsolete("This will be dropped in the 9.x release.")]
-        void WritePaddingFunctionName(string functionName);
 
         /// <summary>
         /// Write a boolean value.
@@ -204,20 +185,6 @@ namespace Microsoft.OData.Json
         void EndTextWriterValueScope();
 
         /// <summary>
-        /// Asynchronously starts the padding function scope.
-        /// </summary>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        [Obsolete("This will be dropped in the 9.x release.")]
-        Task StartPaddingFunctionScopeAsync();
-
-        /// <summary>
-        /// Asynchronously ends the padding function scope.
-        /// </summary>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        [Obsolete("This will be dropped in the 9.x release.")]
-        Task EndPaddingFunctionScopeAsync();
-
-        /// <summary>
         /// Asynchronously starts the object scope.
         /// </summary>
         /// <returns>A task that represents the asynchronous operation.</returns>
@@ -247,14 +214,6 @@ namespace Microsoft.OData.Json
         /// <param name="name">Name of the object property.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
         Task WriteNameAsync(string name);
-
-        /// <summary>
-        /// Asynchronously writes a function name for JSON padding.
-        /// </summary>
-        /// <param name="functionName">Name of the padding function to write.</param>
-        /// <returns>A task that represents the asynchronous write operation.</returns>
-        [Obsolete("This will be dropped in the 9.x release.")]
-        Task WritePaddingFunctionNameAsync(string functionName);
 
         /// <summary>
         /// Asynchronously writes a boolean value.

--- a/src/Microsoft.OData.Core/Json/JsonWriter.Async.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriter.Async.cs
@@ -20,27 +20,6 @@ namespace Microsoft.OData.Json
     internal sealed partial class JsonWriter
     {
         /// <inheritdoc/>
-        public Task StartPaddingFunctionScopeAsync()
-        {
-            Debug.Assert(this.scopes.Count == 0, "Padding scope can only be the outer most scope.");
-            return this.StartScopeAsync(ScopeType.Padding);
-        }
-
-        /// <inheritdoc/>
-        public async Task EndPaddingFunctionScopeAsync()
-        {
-            Debug.Assert(this.scopes.Count > 0, "No scope to end.");
-
-            await this.writer.WriteLineAsync().ConfigureAwait(false);
-            await this.writer.DecreaseIndentationAsync().ConfigureAwait(false);
-            Scope scope = this.scopes.Pop();
-
-            Debug.Assert(scope.Type == ScopeType.Padding, "Ending scope does not match.");
-
-            await this.writer.WriteAsync(scope.EndString).ConfigureAwait(false);
-        }
-
-        /// <inheritdoc/>
         public Task StartObjectScopeAsync()
         {
             return this.StartScopeAsync(ScopeType.Object);
@@ -98,12 +77,6 @@ namespace Microsoft.OData.Json
             await this.writer.WriteEscapedJsonStringAsync(name, this.stringEscapeOption, this.wrappedBuffer, this.ArrayPool)
                 .ConfigureAwait(false);
             await this.writer.WriteAsync(JsonConstants.NameValueSeparator).ConfigureAwait(false);
-        }
-
-        /// <inheritdoc/>
-        public Task WritePaddingFunctionNameAsync(string functionName)
-        {
-            return this.writer.WriteAsync(functionName);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OData.Core/Json/JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriter.cs
@@ -124,31 +124,6 @@ namespace Microsoft.OData.Json
         }
 
         /// <summary>
-        /// Start the padding function scope.
-        /// </summary>
-        public void StartPaddingFunctionScope()
-        {
-            Debug.Assert(this.scopes.Count == 0, "Padding scope can only be the outer most scope.");
-            this.StartScope(ScopeType.Padding);
-        }
-
-        /// <summary>
-        /// End the padding function scope.
-        /// </summary>
-        public void EndPaddingFunctionScope()
-        {
-            Debug.Assert(this.scopes.Count > 0, "No scope to end.");
-
-            this.writer.WriteLine();
-            this.writer.DecreaseIndentation();
-            Scope scope = this.scopes.Pop();
-
-            Debug.Assert(scope.Type == ScopeType.Padding, "Ending scope does not match.");
-
-            this.writer.Write(scope.EndString);
-        }
-
-        /// <summary>
         /// Start the object scope.
         /// </summary>
         public void StartObjectScope()
@@ -216,15 +191,6 @@ namespace Microsoft.OData.Json
 
             JsonValueUtils.WriteEscapedJsonString(this.writer, name, this.stringEscapeOption, this.wrappedBuffer, this.ArrayPool);
             this.writer.Write(JsonConstants.NameValueSeparator);
-        }
-
-        /// <summary>
-        /// Writes a function name for JSON padding.
-        /// </summary>
-        /// <param name="functionName">Name of the padding function to write.</param>
-        public void WritePaddingFunctionName(string functionName)
-        {
-            this.writer.Write(functionName);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -38,7 +38,6 @@ Microsoft.OData.IServiceCollectionProvider
 Microsoft.OData.IServiceCollectionProvider.ServiceProvider.get -> System.IServiceProvider
 Microsoft.OData.Json.IJsonWriter.EndArrayScopeAsync() -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.EndObjectScopeAsync() -> System.Threading.Tasks.Task
-Microsoft.OData.Json.IJsonWriter.EndPaddingFunctionScopeAsync() -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.EndStreamValueScope() -> void
 Microsoft.OData.Json.IJsonWriter.EndStreamValueScopeAsync() -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.EndTextWriterValueScope() -> void
@@ -46,13 +45,11 @@ Microsoft.OData.Json.IJsonWriter.EndTextWriterValueScopeAsync() -> System.Thread
 Microsoft.OData.Json.IJsonWriter.FlushAsync() -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.StartArrayScopeAsync() -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.StartObjectScopeAsync() -> System.Threading.Tasks.Task
-Microsoft.OData.Json.IJsonWriter.StartPaddingFunctionScopeAsync() -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.StartStreamValueScope() -> System.IO.Stream
 Microsoft.OData.Json.IJsonWriter.StartStreamValueScopeAsync() -> System.Threading.Tasks.Task<System.IO.Stream>
 Microsoft.OData.Json.IJsonWriter.StartTextWriterValueScope(string contentType) -> System.IO.TextWriter
 Microsoft.OData.Json.IJsonWriter.StartTextWriterValueScopeAsync(string contentType) -> System.Threading.Tasks.Task<System.IO.TextWriter>
 Microsoft.OData.Json.IJsonWriter.WriteNameAsync(string name) -> System.Threading.Tasks.Task
-Microsoft.OData.Json.IJsonWriter.WritePaddingFunctionNameAsync(string functionName) -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.WriteRawValueAsync(string rawValue) -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.WriteValueAsync(bool value) -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.WriteValueAsync(byte value) -> System.Threading.Tasks.Task
@@ -305,13 +302,10 @@ Microsoft.OData.Json.IJsonReaderFactory.CreateJsonReader(System.IO.TextReader te
 Microsoft.OData.Json.IJsonWriter
 Microsoft.OData.Json.IJsonWriter.EndArrayScope() -> void
 Microsoft.OData.Json.IJsonWriter.EndObjectScope() -> void
-Microsoft.OData.Json.IJsonWriter.EndPaddingFunctionScope() -> void
 Microsoft.OData.Json.IJsonWriter.Flush() -> void
 Microsoft.OData.Json.IJsonWriter.StartArrayScope() -> void
 Microsoft.OData.Json.IJsonWriter.StartObjectScope() -> void
-Microsoft.OData.Json.IJsonWriter.StartPaddingFunctionScope() -> void
 Microsoft.OData.Json.IJsonWriter.WriteName(string name) -> void
-Microsoft.OData.Json.IJsonWriter.WritePaddingFunctionName(string functionName) -> void
 Microsoft.OData.Json.IJsonWriter.WriteRawValue(string rawValue) -> void
 Microsoft.OData.Json.IJsonWriter.WriteValue(bool value) -> void
 Microsoft.OData.Json.IJsonWriter.WriteValue(byte value) -> void

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/SchemaParsingTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/SchemaParsingTests.cs
@@ -925,7 +925,7 @@ public class SchemaParsingTests : EdmLibTestCaseBase
         Assert.Equal("Address", type2.StructuralProperties().Last().Name);
 
         IEdmStringTypeReference addressType = type2.StructuralProperties().Last().Type.AsPrimitive().AsString();
-        Assert.Equal(addressType.PrimitiveKind(), EdmPrimitiveTypeKind.String);
+        Assert.Equal(EdmPrimitiveTypeKind.String, addressType.PrimitiveKind());
         Assert.Equal(2048, addressType.MaxLength);
         Assert.True(addressType.IsNullable);
 
@@ -955,7 +955,7 @@ public class SchemaParsingTests : EdmLibTestCaseBase
         IEdmPrimitiveTypeReference resolvedIdType = id.Type.AsPrimitive();
         Assert.Equal(EdmPrimitiveTypeKind.Int32, resolvedIdType.PrimitiveKind());
 
-        Assert.Equal(1, smod.DeclaredKey.Count());
+        Assert.Single(smod.DeclaredKey);
         Assert.Equal(id, smod.DeclaredKey.First());
         Assert.Equal(smod.DeclaredKey.First(), clod.Key().First());
     }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Evaluation/NoOpResourceMetadataBuilderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Evaluation/NoOpResourceMetadataBuilderTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.OData.Tests.Evaluation
 
             ODataResource entry = new ODataResource();
             entry.AddAction(action);
-            Assert.Single(new NoOpResourceMetadataBuilder(entry).GetActions().Where(a => a == action));
+            Assert.Single(new NoOpResourceMetadataBuilder(entry).GetActions(), a => a == action);
 
             // Verify that the action information wasn't removed or changed.
             Assert.Equal(new Uri("http://example.com/$metadata#Action"), action.Metadata);
@@ -115,7 +115,7 @@ namespace Microsoft.OData.Tests.Evaluation
             ODataResource entry = new ODataResource();
             entry.AddFunction(function);
 
-            Assert.Single(new NoOpResourceMetadataBuilder(entry).GetFunctions().Where(f => f == function));
+            Assert.Single(new NoOpResourceMetadataBuilder(entry).GetFunctions(), f => f == function);
 
             // Verify that the Function information wasn't removed or changed.
             Assert.Equal(new Uri("http://example.com/$metadata#Function"), function.Metadata);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Evaluation/NullEntityMetadataBuilderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Evaluation/NullEntityMetadataBuilderTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.OData.Tests.Evaluation
                     new ODataProperty() {Name = "StreamProperty", Value = new ODataStreamReferenceValue()}
                 };
 
-            Assert.Single(this.testSubject.GetProperties(properties).Where(p => p.Name == "IntegerProperty"));
+            Assert.Single(this.testSubject.GetProperties(properties), p => p.Name == "IntegerProperty");
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
@@ -1243,7 +1243,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
             resourceWriter.WriteEnd();
 
             var str = Encoding.UTF8.GetString(stream.ToArray());
-            Assert.Equal(str, "{\"@odata.context\":\"http://svc/$metadata#Customers/$entity\"," +
+            Assert.Equal("{\"@odata.context\":\"http://svc/$metadata#Customers/$entity\"," +
                 "\"Id\":9," +
                 "\"ComplexProperty\":{" +
                     "\"@odata.type\":\"#NS.Address\"," +
@@ -1255,7 +1255,8 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
                 "\"EntityProperty\":{" +
                     "\"@odata.type\":\"#NS.Customer\"," +
                     "\"Id\":42" +
-                "}}");
+                "}}",
+                str);
         }
 
         [Fact]
@@ -3250,7 +3251,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
                 }
                 else
                 {
-                    Assert.True(false, "Top level item to write must be entry or feed.");
+                    Assert.Fail("Top level item to write must be entry or feed.");
                 }
 
                 Assert.Equal(itemsToWrite.Length, currentIdx);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/UriParameterWriterIntegrationTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/UriParameterWriterIntegrationTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
         public void WriteComplexColParameter_WithoutModel()
         {
             WriteResourceSetParameter(false, false,
-                (actual) => Assert.Equal(actual,
+                (actual) => Assert.Equal(
                     "[" +
                         "{" +
                             "\"@odata.type\":\"#NS.Address\"," +
@@ -104,7 +104,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
                             "\"CompanyName\":\"MS\"," +
                             "\"City\":{\"@odata.type\":\"#NS.City\",\"CityName\":\"City1\",\"AreaCode\":\"AreaCode1\"}" +
                         "}" +
-                    "]"));
+                    "]", actual));
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/BufferingJsonReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/BufferingJsonReaderTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OData.Tests.Json
             // Assert
             Assert.True(result);
             Assert.Equal("any target", error.Target);
-            Assert.Equal(1, error.Details.Count);
+            Assert.Single(error.Details);
             var detail = error.Details.Single();
             Assert.Equal("500", detail.Code);
             Assert.Equal("another target", detail.Target);
@@ -380,10 +380,10 @@ namespace Microsoft.OData.Tests.Json
                 var innerError = error.InnerError;
                 Assert.NotNull(innerError);
                 Assert.Equal(3, innerError.Properties.Count);
-                Assert.Single(innerError.Properties.Where(d => d.Key.Equals("message")));
-                Assert.Single(innerError.Properties.Where(d => d.Key.Equals("type")));
-                Assert.Single(innerError.Properties.Where(d => d.Key.Equals("stacktrace")));
-                Assert.Empty(innerError.Properties.Where(d => d.Key.Equals("foo")));
+                Assert.Single(innerError.Properties, d => d.Key.Equals("message"));
+                Assert.Single(innerError.Properties, d => d.Key.Equals("type"));
+                Assert.Single(innerError.Properties, d => d.Key.Equals("stacktrace"));
+                Assert.DoesNotContain(innerError.Properties, d => d.Key.Equals("foo"));
             }
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
@@ -30,28 +30,6 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
-        public async Task StartPaddingFunctionScopeAsyncWritesParenthesis()
-        {
-            await this.writer.StartPaddingFunctionScopeAsync();
-            Assert.Equal("(", this.builder.ToString());
-        }
-
-        [Fact]
-        public async Task EndPaddingFunctionScopeAsyncWritesParenthesis()
-        {
-            await this.writer.StartPaddingFunctionScopeAsync();
-            await this.writer.EndPaddingFunctionScopeAsync();
-            Assert.Equal("()", this.builder.ToString());
-        }
-
-        [Fact]
-        public async Task WritePaddingFunctionNameAsyncWritesName()
-        {
-            await this.writer.WritePaddingFunctionNameAsync("example");
-            Assert.Equal("example", this.builder.ToString());
-        }
-
-        [Fact]
         public async Task StartObjectScopeAsyncWritesCurlyBraces()
         {
             await this.writer.StartObjectScopeAsync();

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
@@ -30,28 +30,6 @@ namespace Microsoft.OData.Tests.Json
             
         }
 
-        [Fact]
-        public void StartPaddingFunctionScopeWritesParenthesis()
-        {
-            this.writer.StartPaddingFunctionScope();
-            Assert.Equal("(", this.builder.ToString());
-        }
-
-        [Fact]
-        public void EndPaddingFunctionScopeWritesParenthesis()
-        {
-            this.writer.StartPaddingFunctionScope();
-            this.writer.EndPaddingFunctionScope();
-            Assert.Equal("()", this.builder.ToString());
-        }
-
-        [Fact]
-        public void WritePaddingFunctionNameWritesName()
-        {
-            this.writer.WritePaddingFunctionName("example");
-            Assert.Equal("example", this.builder.ToString());
-        }
-
         #region WritePrimitiveValue
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonBatchReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonBatchReaderTests.cs
@@ -392,7 +392,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     }
                     catch (NullReferenceException ex)
                     {
-                        Assert.False(true, ex.Message);
+                        Assert.Fail(ex.Message);
                     }
                 },
                 isResponse: false);
@@ -428,7 +428,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     }
                     catch (NullReferenceException ex)
                     {
-                        Assert.False(true, ex.Message);
+                        Assert.Fail(ex.Message);
                     }
                 },
                 isResponse: false);
@@ -459,7 +459,7 @@ namespace Microsoft.OData.Core.Tests.Json
                             jsonBatchReader.CreateOperationRequestMessage();
                         }
                     }
-                    Assert.False(true, "The test failed, because the duplicate header has not thrown an ODataException");
+                    Assert.Fail("The test failed, because the duplicate header has not thrown an ODataException");
                 },
                 isResponse: false));
 
@@ -492,7 +492,7 @@ namespace Microsoft.OData.Core.Tests.Json
                             await jsonBatchReader.CreateOperationRequestMessageAsync();
                         }
                     }
-                    Assert.False(true, "The test failed, because the duplicate header has not thrown an ODataException");
+                    Assert.Fail("The test failed, because the duplicate header has not thrown an ODataException");
                 },
                 isResponse: false));
 
@@ -523,7 +523,7 @@ namespace Microsoft.OData.Core.Tests.Json
                             jsonBatchReader.CreateOperationRequestMessage();
                         }
                     }
-                    Assert.False(true, "The test failed, because the duplicate header has thrown no ODataException");
+                    Assert.Fail("The test failed, because the duplicate header has thrown no ODataException");
                 },
                 isResponse: false));
 
@@ -554,7 +554,7 @@ namespace Microsoft.OData.Core.Tests.Json
                                 await jsonBatchReader.CreateOperationRequestMessageAsync();
                             }
                         }
-                        Assert.False(true, "The test failed, because the duplicate header has thrown no ODataException");
+                        Assert.Fail("The test failed, because the duplicate header has thrown no ODataException");
                 },
                 isResponse: false));
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionDeserializerTests.cs
@@ -149,7 +149,6 @@ namespace Microsoft.OData.Tests.Json
                     await jsonCollectionDeserializer.ReadCollectionEndAsync(
                         isReadingNestedPayload: false);
 
-                    Assert.NotNull(readCollectionStartResult);
                     var collectionStart = Assert.IsType<ODataCollectionStart>(readCollectionStartResult.Item1);
                     var actualItemTypeReference = Assert.IsAssignableFrom<IEdmTypeReference>(readCollectionStartResult.Item2);
                     Assert.NotNull(collectionStart);
@@ -196,7 +195,6 @@ namespace Microsoft.OData.Tests.Json
                     await jsonCollectionDeserializer.ReadCollectionEndAsync(
                         isReadingNestedPayload: false);
 
-                    Assert.NotNull(readCollectionStartResult);
                     Assert.Equal("Tea", collectionItem1);
                     Assert.Equal("Coffee", collectionItem2);
                 });

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionWriterTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.OData.Tests.Json
                             }
                         }))));
             var str = Encoding.UTF8.GetString(stream.ToArray());
-            Assert.Equal(str,
+            Assert.Equal(
                 "{" +
                     "\"@odata.context\":\"http://svc/$metadata#EntitySet/$entity\"," +
                     "\"ID\":1," +
@@ -92,7 +92,7 @@ namespace Microsoft.OData.Tests.Json
                     "\"DynamicPrimitive\":[1,2,null]," +
                     "\"DynamicComplex@odata.type\":\"#Collection(NS.ComplexType)\"," +
                     "\"DynamicComplex\":[null,null,{\"Prop1\":1,\"Prop2\":2}]" +
-                "}");
+                "}", str);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeltaReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeltaReaderTests.cs
@@ -558,7 +558,7 @@ namespace Microsoft.OData.Tests.Json
                         break;
                     case ODataReaderState.Stream:
                     case ODataReaderState.NestedResourceInfoStart:
-                        Assert.True(false, "Should not add stream or navigation properties to delta payload");
+                        Assert.Fail("Should not add stream or navigation properties to delta payload");
                         break;
                 }
             }
@@ -4254,12 +4254,12 @@ namespace Microsoft.OData.Tests.Json
                                 Assert.True(nestedResourceInfo.Name.Equals("Details") || nestedResourceInfo.Name.Equals("Address") || nestedResourceInfo.Name.Equals("City"));
                                 break;
                             default:
-                                Assert.True(false, "Wrong reader sub state.");
+                                Assert.Fail("Wrong reader sub state.");
                                 break;
                         }
                         break;
                     default:
-                        Assert.True(false, "Wrong reader state.");
+                        Assert.Fail("Wrong reader state.");
                         break;
                 }
             }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeltaWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeltaWriterTests.cs
@@ -856,8 +856,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.WriteExpandedFeedWithModelImplementation();
 
-            Assert.Equal(this.TestPayload(),
-                "{" +
+            Assert.Equal("{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
                     "[" +
@@ -880,7 +879,7 @@ namespace Microsoft.OData.Tests.Json
                             "]" +
                         "}" +
                     "]" +
-                "}");
+                "}", this.TestPayload());
         }
 
         [Fact]
@@ -890,8 +889,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.WriteExpandedFeedWithModelImplementation();
 
-            Assert.Equal(this.TestPayload(),
-                "{" +
+            Assert.Equal("{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
                     "[" +
@@ -924,7 +922,7 @@ namespace Microsoft.OData.Tests.Json
                             "\"ProductBeingViewed@odata.navigationLink\":\"http://host/service/Customers('BOTTM')/ProductBeingViewed\"" +
                         "}" +
                     "]" +
-                "}");
+                "}", this.TestPayload());
         }
 
         [InlineData(/*isResponse*/true)]
@@ -951,8 +949,7 @@ namespace Microsoft.OData.Tests.Json
             writer.WriteEnd(); // deltaFeedWithInfo
             writer.Flush();
 
-            Assert.Equal(this.TestPayload(),
-                "{" +
+            Assert.Equal("{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
                     "[" +
@@ -975,7 +972,7 @@ namespace Microsoft.OData.Tests.Json
                             "]" +
                         "}" +
                     "]" +
-                "}");
+                "}", this.TestPayload());
         }
 
         [InlineData(/*isResponse*/true)]
@@ -1008,8 +1005,7 @@ namespace Microsoft.OData.Tests.Json
             writer.WriteEnd(); // deltaFeed
             writer.Flush();
 
-            Assert.Equal(this.TestPayload(),
-                "{" +
+            Assert.Equal("{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
                     "[" +
@@ -1040,7 +1036,7 @@ namespace Microsoft.OData.Tests.Json
                             "]" +
                         "}" +
                     "]" +
-                "}");
+                "}", this.TestPayload());
         }
 
         [InlineData(/*isResponse*/true)]
@@ -1069,8 +1065,7 @@ namespace Microsoft.OData.Tests.Json
             writer.WriteEnd(); // deltaFeed
             writer.Flush();
 
-            Assert.Equal(this.TestPayload(),
-                "{" +
+            Assert.Equal("{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
                     "[" +
@@ -1094,7 +1089,7 @@ namespace Microsoft.OData.Tests.Json
                             "]" +
                         "}" +
                     "]" +
-                "}");
+                "}", this.TestPayload());
         }
 
         [InlineData(/*isResponse*/true)]
@@ -1106,8 +1101,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.WriteNestedDeltaFeedImplementation(isResponse);
 
-            Assert.Equal(this.TestPayload(),
-                "{" +
+            Assert.Equal("{" +
                     "\"@context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
                     "[" +
@@ -1137,8 +1131,7 @@ namespace Microsoft.OData.Tests.Json
                             "]" +
                         "}" +
                     "]" +
-                "}"
-                );
+                "}", this.TestPayload());
         }
 
         [InlineData(/*isResponse*/true)]
@@ -1367,8 +1360,7 @@ namespace Microsoft.OData.Tests.Json
             writer.WriteEnd(); // deltaFeed
             writer.Flush();
 
-            Assert.Equal(this.TestPayload(),
-                "{" +
+            Assert.Equal("{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
                     "[" +
@@ -1390,7 +1382,7 @@ namespace Microsoft.OData.Tests.Json
                             "}" +
                         "}" +
                     "]" +
-                "}");
+                "}", this.TestPayload());
         }
 
         #endregion

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeserializerTests.cs
@@ -633,7 +633,7 @@ namespace Microsoft.OData.Tests.Json
                     jsonReader.ShouldBeOn(JsonNodeType.Property, "@odata.unknown");
                     var propertyAnnotation = duplicateChecker.GetODataPropertyAnnotations("NavProp").Keys;
                     Assert.Contains("odata.navigationLink", propertyAnnotation);
-                    Assert.Equal(1, propertyAnnotation.Count);
+                    Assert.Single(propertyAnnotation);
                 },
                 (jsonReader, name) =>
                 {
@@ -827,13 +827,13 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
-        public void ReadPayloadStartAsyncTestForDetla()
+        public async Task ReadPayloadStartAsyncTestForDetla()
         {
             var model = this.CreateEdmModelWithEntity();
             var primitiveTypeRef = ((IEdmEntityType)model.SchemaElements.First()).Properties().First().Type;
             this.messageReaderSettings = new ODataMessageReaderSettings();
             ODataJsonPropertyAndValueDeserializer deserializer = new ODataJsonPropertyAndValueDeserializer(this.CreateJsonInputContext("{\"@odata.context\":\"http://odata.org/test/$metadata#Customers/$delta\",\"value\":\"Joe\"}", model));
-            deserializer.ReadPayloadStartAsync(ODataPayloadKind.Delta, null, false, true);
+            await deserializer.ReadPayloadStartAsync(ODataPayloadKind.Delta, null, false, true);
             Assert.Equal(ODataDeltaKind.ResourceSet, deserializer.ContextUriParseResult.DeltaKind);
         }
 
@@ -965,7 +965,7 @@ namespace Microsoft.OData.Tests.Json
                     if (odataReader.State == ODataReaderState.ResourceEnd)
                     {
                         var resource = odataReader.Item as ODataResource;
-                        Assert.Equal(0, resource.Properties.First().InstanceAnnotations.Count);
+                        Assert.Empty(resource.Properties.First().InstanceAnnotations);
                     }
                 }
             };
@@ -2063,8 +2063,8 @@ namespace Microsoft.OData.Tests.Json
 
                     var resource = Assert.IsType<ODataResourceValue>(property.ODataValue);
                     Assert.Equal(2, resource.Properties.Count());
-                    var streetProperty = Assert.Single(resource.Properties.Where(d => d.Name.Equals("Street")));
-                    var cityProperty = Assert.Single(resource.Properties.Where(d => d.Name.Equals("City")));
+                    var streetProperty = Assert.Single(resource.Properties, d => d.Name.Equals("Street"));
+                    var cityProperty = Assert.Single(resource.Properties, d => d.Name.Equals("City"));
                     Assert.Equal("S1", streetProperty.Value);
                     Assert.Equal("C1", cityProperty.Value);
                 });

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerTests.cs
@@ -327,7 +327,7 @@ namespace Microsoft.OData.Tests.Json
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             ODataResourceSet feed = new ODataResourceSet();
             deserializer.ReadAndApplyResourceSetInstanceAnnotationValue("custom.Int32Annotation", feed, propertyAndAnnotationCollector);
-            Assert.Equal(1, feed.InstanceAnnotations.Count);
+            Assert.Single(feed.InstanceAnnotations);
             TestUtils.AssertODataValueAreEqual(new ODataPrimitiveValue(123), feed.InstanceAnnotations.Single(ia => ia.Name == "custom.Int32Annotation").Value);
         }
 
@@ -374,7 +374,7 @@ namespace Microsoft.OData.Tests.Json
             AdvanceReaderToFirstPropertyValue(deserializer.JsonReader);
             var entryState = new TestJsonReaderEntryState();
             deserializer.ApplyEntryInstanceAnnotation(entryState, "custom.Int32Annotation", 123);
-            Assert.Equal(1, entryState.Resource.InstanceAnnotations.Count);
+            Assert.Single(entryState.Resource.InstanceAnnotations);
             TestUtils.AssertODataValueAreEqual(new ODataPrimitiveValue(123), entryState.Resource.InstanceAnnotations.Single(ia => ia.Name == "custom.Int32Annotation").Value);
         }
 
@@ -403,7 +403,7 @@ namespace Microsoft.OData.Tests.Json
             var feed = new ODataResourceSet();
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             deserializer.ReadTopLevelResourceSetAnnotations(feed, propertyAndAnnotationCollector, true /*forResourceSetStart*/, true /*readAllFeedProperties*/);
-            Assert.Equal(0, feed.InstanceAnnotations.Count);
+            Assert.Empty(feed.InstanceAnnotations);
         }
 
         [Fact]
@@ -414,7 +414,7 @@ namespace Microsoft.OData.Tests.Json
             var feed = new ODataResourceSet();
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             deserializer.ReadTopLevelResourceSetAnnotations(feed, propertyAndAnnotationCollector, true /*forResourceSetStart*/, false /*readAllFeedProperties*/);
-            Assert.Equal(1, feed.InstanceAnnotations.Count);
+            Assert.Single(feed.InstanceAnnotations);
             TestUtils.AssertODataValueAreEqual(new ODataPrimitiveValue(123), feed.InstanceAnnotations.Single(ia => ia.Name == "custom.before").Value);
         }
 
@@ -426,7 +426,7 @@ namespace Microsoft.OData.Tests.Json
             var feed = new ODataResourceSet();
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             deserializer.ReadTopLevelResourceSetAnnotations(feed, propertyAndAnnotationCollector, true /*forResourceSetStart*/, false /*readAllFeedProperties*/);
-            Assert.Equal(0, feed.InstanceAnnotations.Count);
+            Assert.Empty(feed.InstanceAnnotations);
         }
 
         [Fact]
@@ -448,7 +448,7 @@ namespace Microsoft.OData.Tests.Json
             var feed = new ODataResourceSet();
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             deserializer.ReadTopLevelResourceSetAnnotations(feed, propertyAndAnnotationCollector, false /*forResourceSetStart*/, false /*readAllFeedProperties*/);
-            Assert.Equal(1, feed.InstanceAnnotations.Count);
+            Assert.Single(feed.InstanceAnnotations);
             TestUtils.AssertODataValueAreEqual(new ODataPrimitiveValue(456), feed.InstanceAnnotations.Single(ia => ia.Name == "custom.after").Value);
         }
 
@@ -460,7 +460,7 @@ namespace Microsoft.OData.Tests.Json
             var feed = new ODataResourceSet();
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             deserializer.ReadTopLevelResourceSetAnnotations(feed, propertyAndAnnotationCollector, false /*forResourceSetStart*/, false /*readAllFeedProperties*/);
-            Assert.Equal(0, feed.InstanceAnnotations.Count);
+            Assert.Empty(feed.InstanceAnnotations);
         }
 
         #endregion Test ReadTopLevelResourceSetAnnotations
@@ -486,7 +486,7 @@ namespace Microsoft.OData.Tests.Json
             AdvanceReaderToFirstProperty(deserializer.JsonReader);
             var entryState = new TestJsonReaderEntryState();
             deserializer.ReadResourceContent(entryState);
-            Assert.Equal(0, entryState.Resource.InstanceAnnotations.Count);
+            Assert.Empty(entryState.Resource.InstanceAnnotations);
         }
 
         #endregion Test ReadResourceContent

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonErrorDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonErrorDeserializerTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OData.Tests.Json
 
             // Assert
             Assert.Equal("any target", error.Target);
-            Assert.Equal(1, error.Details.Count);
+            Assert.Single(error.Details);
             var detail = error.Details.Single();
             Assert.Equal("500", detail.Code);
             Assert.Equal("another target", detail.Target);
@@ -132,7 +132,7 @@ namespace Microsoft.OData.Tests.Json
 
             // Assert Top Level properties
             Assert.Equal("any target", error.Target);
-            Assert.Equal(1, error.Details.Count);
+            Assert.Single(error.Details);
             var detail = error.Details.Single();
             Assert.Equal("500", detail.Code);
             Assert.Equal("any target", detail.Target);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonPayloadKindDetectionDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonPayloadKindDetectionDeserializerTests.cs
@@ -41,8 +41,8 @@ namespace Microsoft.OData.Tests.Json
                     var payloadKinds = jsonPayloadKindDetectionDeserializer.DetectPayloadKind(this.payloadKindDetectionInfo);
 
                     Assert.Equal(2, payloadKinds.Count());
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Resource)));
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Delta)));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Resource));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Delta));
                 });
         }
 
@@ -59,7 +59,7 @@ namespace Microsoft.OData.Tests.Json
                     var payloadKinds = jsonPayloadKindDetectionDeserializer.DetectPayloadKind(this.payloadKindDetectionInfo);
 
                     Assert.Single(payloadKinds);
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Error)));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Error));
                 });
         }
 
@@ -97,8 +97,8 @@ namespace Microsoft.OData.Tests.Json
                     var payloadKinds = await jsonPayloadKindDetectionDeserializer.DetectPayloadKindAsync(this.payloadKindDetectionInfo);
 
                     Assert.Equal(2, payloadKinds.Count());
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Resource)));
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Delta)));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Resource));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Delta));
                 });
         }
 
@@ -115,7 +115,7 @@ namespace Microsoft.OData.Tests.Json
                     var payloadKinds = await jsonPayloadKindDetectionDeserializer.DetectPayloadKindAsync(this.payloadKindDetectionInfo);
 
                     Assert.Single(payloadKinds);
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Error)));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Error));
                 });
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonResourceDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonResourceDeserializerTests.cs
@@ -682,7 +682,7 @@ namespace Microsoft.OData.Tests.Json
                 this.categoryEntityType,
                 (resourceState) =>
                 {
-                    var mediaProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Media"))));
+                    var mediaProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("Media")));
                     var streamReferenceValue = Assert.IsType<ODataStreamReferenceValue>(mediaProperty.Value);
 
                     Assert.Equal("http://tempuri.org/Categories(1)/Media", streamReferenceValue.EditLink.AbsoluteUri);
@@ -741,7 +741,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var warehousePinProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("WarehousePin"))));
+                    var warehousePinProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("WarehousePin")));
                     var geographyPoint = Assert.IsAssignableFrom<GeographyPoint>(warehousePinProperty.Value);
                     Assert.Equal(22.2, geographyPoint.Latitude);
                     Assert.Equal(22.2, geographyPoint.Longitude);
@@ -765,7 +765,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var piProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Pi"))));
+                    var piProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("Pi")));
                     Assert.Equal(3.1428571429m, piProperty.Value);
                 });
         }
@@ -788,7 +788,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var creditLimitProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("CreditLimit"))));
+                    var creditLimitProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("CreditLimit")));
                     Assert.Equal(1730, creditLimitProperty.Value);
                 });
         }
@@ -812,7 +812,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var creditLimitProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("CreditLimit"))));
+                    var creditLimitProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("CreditLimit")));
                     Assert.Equal(1730M, creditLimitProperty.Value);
                 });
         }
@@ -1054,7 +1054,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var photoProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Photo"))));
+                    var photoProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("Photo")));
                     var streamReferenceValue = Assert.IsType<ODataStreamReferenceValue>(photoProperty.Value);
 
                     Assert.Equal("http://tempuri.org/Products(1)/Photo", streamReferenceValue.EditLink.AbsoluteUri);
@@ -1080,7 +1080,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var photoProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Photo"))));
+                    var photoProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("Photo")));
                     var streamReferenceValue = Assert.IsType<ODataStreamReferenceValue>(photoProperty.Value);
 
                     Assert.Equal("http://tempuri.org/Products(1)/Photo", streamReferenceValue.EditLink.AbsoluteUri);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterTests.cs
@@ -814,7 +814,7 @@ namespace Microsoft.OData.Core.Tests.Json
                 {
                     if (!CsdlReader.TryParse(xmlReader, out model, out var errors))
                     {
-                        Assert.True(false, string.Join(Environment.NewLine, errors));
+                        Assert.Fail(string.Join(Environment.NewLine, errors));
                     }
                 }
             }
@@ -875,7 +875,7 @@ namespace Microsoft.OData.Core.Tests.Json
                 {
                     if (!CsdlReader.TryParse(xmlReader, out model, out var errors))
                     {
-                        Assert.True(false, string.Join(Environment.NewLine, errors));
+                        Assert.Fail(string.Join(Environment.NewLine, errors));
                     }
                 }
             }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -53,28 +53,6 @@ namespace Microsoft.OData.Tests.Json
             await this.stream.DisposeAsync();
         }
 
-        [Fact]
-        public async Task StartPaddingFunctionScopeAsync_WritesParenthesis()
-        {
-            await this.writer.StartPaddingFunctionScopeAsync();
-            Assert.Equal("(", await this.ReadStreamAsync());
-        }
-
-        [Fact]
-        public async Task EndPaddingFunctionScopeAsync_WritesParenthesis()
-        {
-            await this.writer.StartPaddingFunctionScopeAsync();
-            await this.writer.EndPaddingFunctionScopeAsync();
-            Assert.Equal("()", await this.ReadStreamAsync());
-        }
-
-        [Fact]
-        public async Task WritePaddingFunctionNameAsync_WritesName()
-        {
-            await this.writer.WritePaddingFunctionNameAsync("example");
-            Assert.Equal("example", await this.ReadStreamAsync());
-        }
-
         #region WritePrimitiveValue
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
@@ -61,28 +61,6 @@ namespace Microsoft.OData.Tests.Json
             this.disposed = true;
         }
 
-        [Fact]
-        public void StartPaddingFunctionScopeWritesParenthesis()
-        {
-            this.writer.StartPaddingFunctionScope();
-            Assert.Equal("(", this.ReadStream());
-        }
-
-        [Fact]
-        public void EndPaddingFunctionScopeWritesParenthesis()
-        {
-            this.writer.StartPaddingFunctionScope();
-            this.writer.EndPaddingFunctionScope();
-            Assert.Equal("()", this.ReadStream());
-        }
-
-        [Fact]
-        public void WritePaddingFunctionNameWritesName()
-        {
-            this.writer.WritePaddingFunctionName("example");
-            Assert.Equal("example", this.ReadStream());
-        }
-
         #region WritePrimitiveValue
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataBinaryStreamReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataBinaryStreamReaderTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.OData.Tests
 
                 var bytesRead = reader.Read(buffer, 0, maxLength);
 
-                Assert.Equal(bytesRead, maxLength);
+                Assert.Equal(maxLength, bytesRead);
                 Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 }, buffer);
             }
         }
@@ -67,7 +67,7 @@ namespace Microsoft.OData.Tests
 
                 var bytesRead = await reader.ReadAsync(buffer, 0, maxLength);
 
-                Assert.Equal(bytesRead, maxLength);
+                Assert.Equal(maxLength, bytesRead);
                 Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 }, buffer);
             }
         }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "aggregate(Id with sum as TotalId)";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(TotalId)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(TotalId)", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -136,7 +136,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "aggregate(DynamicProperty with " + method + " as DynamicPropertyTotal)";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(DynamicPropertyTotal)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(DynamicPropertyTotal)", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "groupby((Name, Address/Street))";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(Name,Address(Street))");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Name,Address(Street))", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -156,7 +156,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "groupby((Name, DynamicProperty, Address/Street))";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(Name,DynamicProperty,Address(Street))");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Name,DynamicProperty,Address(Street))", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -166,7 +166,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "filter(Id eq 1)";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities");
+                Assert.Equal(MetadataDocumentUriString + "#Cities", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
         [Fact]
@@ -175,7 +175,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "groupby((Name), aggregate(Id with sum as TotalId))";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(Name,TotalId)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Name,TotalId)", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -185,7 +185,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "groupby((Name), aggregate(Id with sum as TotalId))";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri("Name", null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(Name)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Name)", this.CreateFeedContextUri("Name", null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -195,7 +195,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "expand(Districts, filter(true))";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities");
+                Assert.Equal(MetadataDocumentUriString + "#Cities", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -206,7 +206,7 @@ namespace Microsoft.OData.Tests
             string computeClause = "compute('Test' as NewColumn)";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, computeClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities");
+                Assert.Equal(MetadataDocumentUriString + "#Cities", this.CreateFeedContextUri(null, null, computeClause, null, version).OriginalString);
             }
         }
 
@@ -216,7 +216,7 @@ namespace Microsoft.OData.Tests
             string computeClause = "compute('Test' as NewColumn)";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri("Id,Name,NewColumn", null, computeClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(Id,Name,NewColumn)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Id,Name,NewColumn)", this.CreateFeedContextUri("Id,Name,NewColumn", null, computeClause, null, version).OriginalString);
             }
         }
 
@@ -226,7 +226,7 @@ namespace Microsoft.OData.Tests
             string computeClause = "'Test' as NewColumn";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, null, computeClause, version).OriginalString, MetadataDocumentUriString + "#Cities");
+                Assert.Equal(MetadataDocumentUriString + "#Cities", this.CreateFeedContextUri(null, null, null, computeClause, version).OriginalString);
             }
         }
 
@@ -236,7 +236,7 @@ namespace Microsoft.OData.Tests
             string computeClause = "'Test' as NewColumn";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri("Id,Name,NewColumn", null, null, computeClause, version).OriginalString, MetadataDocumentUriString + "#Cities(Id,Name,NewColumn)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Id,Name,NewColumn)", this.CreateFeedContextUri("Id,Name,NewColumn", null, null, computeClause, version).OriginalString);
             }
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataEntityReferenceLinkTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataEntityReferenceLinkTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.OData.Tests
             ODataEntityReferenceLink referencelink = new ODataEntityReferenceLink();
             Assert.NotNull(referencelink.InstanceAnnotations);
             referencelink.InstanceAnnotations.Add(new ODataInstanceAnnotation("TestNamespace.name", new ODataPrimitiveValue("value")));
-            Assert.Equal(1, referencelink.InstanceAnnotations.Count);
+            Assert.Single(referencelink.InstanceAnnotations);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void MaxReceivedMessageSizeShouldBeSetByDefault()
         {
-            Assert.Equal(this.settings.MessageQuotas.MaxReceivedMessageSize, 1024 * 1024);
+            Assert.Equal(1024 * 1024, this.settings.MessageQuotas.MaxReceivedMessageSize);
         }
 
         [Fact]
@@ -446,11 +446,11 @@ namespace Microsoft.OData.Tests
             Assert.Same(this.settings.BaseUri, baseUri);
             Assert.True(this.settings.EnableCharactersCheck);
             Assert.False(this.settings.EnableMessageStreamDisposal);
-            Assert.Equal(this.settings.MessageQuotas.MaxPartsPerBatch, maxPartsPerBatch);
-            Assert.Equal(this.settings.MessageQuotas.MaxOperationsPerChangeset, maxOperationsPerChangeset);
-            Assert.Equal(this.settings.MessageQuotas.MaxNestingDepth, maxNestingDepth);
-            Assert.Equal(this.settings.Version, version);
-            Assert.Equal(this.settings.LibraryCompatibility, library);
+            Assert.Equal(maxPartsPerBatch, this.settings.MessageQuotas.MaxPartsPerBatch);
+            Assert.Equal(maxOperationsPerChangeset, this.settings.MessageQuotas.MaxOperationsPerChangeset);
+            Assert.Equal(maxNestingDepth, this.settings.MessageQuotas.MaxNestingDepth);
+            Assert.Equal(version, this.settings.Version);
+            Assert.Equal(library, this.settings.LibraryCompatibility);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataTextStreamReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataTextStreamReaderTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.OData.Tests
 
                 var charsRead = reader.Read(charBuffer, 0, maxLength);
 
-                Assert.Equal(charsRead, maxLength);
+                Assert.Equal(maxLength, charsRead);
                 Assert.Equal("fox jumps over", new string(charBuffer));
             }
         }
@@ -67,7 +67,7 @@ namespace Microsoft.OData.Tests
 
                 var charsRead = await reader.ReadAsync(charBuffer, 0, maxLength);
 
-                Assert.Equal(charsRead, maxLength);
+                Assert.Equal(maxLength, charsRead);
                 Assert.Equal("fox jumps over", new string(charBuffer));
             }
         }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.Async.cs
@@ -244,10 +244,10 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.Roundtrip
 
             using (var writer = XmlWriter.Create(stringWriter, new XmlWriterSettings() { Async = true }))
             {
-                var (success, errors) = await CsdlWriter.TryWriteCsdlAsync(this.model, writer).ConfigureAwait(false);
+                var (success, errors) = await CsdlWriter.TryWriteCsdlAsync(this.model, writer);
                 if (!success)
                 {
-                    Assert.True(false, "Serialization was unsuccessful");
+                    Assert.Fail("Serialization was unsuccessful");
                 }
             }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/JsonBatchRoundTripTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/JsonBatchRoundTripTests.cs
@@ -295,7 +295,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.Json
                             }
                             else
                             {
-                                Assert.True(false, "Unexpected response id received: " + responseId);
+                                Assert.Fail("Unexpected response id received: " + responseId);
                             }
                             break;
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/SingletonBatchRoundtripJsonTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/SingletonBatchRoundtripJsonTests.cs
@@ -1285,7 +1285,7 @@ Content-Type: application/json;odata.metadata=none
 
                     default:
                         {
-                            Assert.True(false, "Unknown BatchFormat value");
+                            Assert.Fail("Unknown BatchFormat value");
                         }
                         break;
                 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonStreamReadingTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonStreamReadingTests.cs
@@ -257,7 +257,7 @@ namespace Microsoft.OData.Tests.Json
                             break;
 
                         case ODataReaderState.Primitive:
-                            Assert.False(true, "Should not read as Primitive if Caller Specifies Stream");
+                            Assert.Fail("Should not read as Primitive if Caller Specifies Stream");
                             break;
 
                         case ODataReaderState.NestedProperty:
@@ -314,7 +314,7 @@ namespace Microsoft.OData.Tests.Json
                             break;
 
                         case ODataReaderState.Stream:
-                            Assert.False(true, "Should not read as stream if caller returns false");
+                            Assert.Fail("Should not read as stream if caller returns false");
                             break;
                     }
                 }
@@ -505,7 +505,7 @@ namespace Microsoft.OData.Tests.Json
                             break;
 
                         case ODataReaderState.Primitive:
-                            Assert.False(true, "Should not read as Primitive if collection not streamed");
+                            Assert.Fail("Should not read as Primitive if collection not streamed");
                             break;
 
                         case ODataReaderState.NestedProperty:
@@ -560,7 +560,7 @@ namespace Microsoft.OData.Tests.Json
                             break;
 
                         case ODataReaderState.Primitive:
-                            Assert.False(true, "Should not read as Primitive if Caller Specifies Stream");
+                            Assert.Fail("Should not read as Primitive if Caller Specifies Stream");
                             break;
 
                         case ODataReaderState.NestedProperty:
@@ -654,11 +654,11 @@ namespace Microsoft.OData.Tests.Json
                             break;
 
                         case ODataReaderState.NestedProperty:
-                            Assert.False(true, "Should Not enter nested property without a value");
+                            Assert.Fail("Should Not enter nested property without a value");
                             break;
 
                         case ODataReaderState.Stream:
-                            Assert.False(true, "Should Not enter stream without a value");
+                            Assert.Fail("Should Not enter stream without a value");
                             break;
                     }
                 }
@@ -1489,7 +1489,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 Stream stream = reader.CreateReadStream();
                 {
-                    stream.Read(new byte[2],0,2);
+                    stream.ReadExactly(new byte[2], 0, 2);
                 }
             }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2916,7 +2916,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var inNode = Assert.IsType<InNode>(inFilter.Expression);
             Assert.Equal("SSN", Assert.IsType<SingleValuePropertyAccessNode>(inNode.Left).Property.Name);
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
-            Assert.Equal(1, collectionNode.Collection.Count);
+            Assert.Single(collectionNode.Collection);
 
             var eqNode = Assert.IsType<BinaryOperatorNode>(eqFilter.Expression);
             Assert.Equal("SSN", Assert.IsType<SingleValuePropertyAccessNode>(eqNode.Left).Property.Name);
@@ -2939,7 +2939,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var inNode = Assert.IsType<InNode>(inFilter.Expression);
             Assert.Equal("SSN", Assert.IsType<SingleValuePropertyAccessNode>(inNode.Left).Property.Name);
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
-            Assert.Equal(1, collectionNode.Collection.Count);
+            Assert.Single(collectionNode.Collection);
 
             Assert.Equal(constantString, collectionNode.Collection.ElementAt(0).Value);
 
@@ -3059,7 +3059,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var inNode = Assert.IsType<InNode>(filter.Expression);
 
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
-            Assert.Equal(0, collectionNode.Collection.Count);
+            Assert.Empty(collectionNode.Collection);
         }
 
         [Theory]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -560,7 +560,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             var result = RunParseSelectExpand("", "MyDog", HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
             Assert.True(result.AllSelected);
-            Assert.Empty(result.SelectedItems.Where(x => x is PathSelectItem));
+
+            Assert.DoesNotContain(result.SelectedItems, x => x is PathSelectItem);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/FullPayloadValidateTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/FullPayloadValidateTests.cs
@@ -1150,7 +1150,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.Json
                 }
                 else
                 {
-                    Assert.True(false, "Top level item to write must be entry or feed.");
+                    Assert.Fail("Top level item to write must be entry or feed.");
                 }
 
                 Assert.Equal(itemsToWrite.Length, currentIdx);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/ODataJsonInheritComplexCollectionWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/ODataJsonInheritComplexCollectionWriterTests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.Json
             WriteAndValidateSync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
             WriteAndValidateAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
             WriteAndValidatePrimitivesSync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
-            WriteAndValidatePrimitivesAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
+            WriteAndValidatePrimitivesAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse).Wait();
         }
 
         private static void WriteAndValidateSync(IEdmTypeReference itemTypeReference, ODataResourceSet collectionStart, IEnumerable<ODataResource> items, string expectedPayload, bool writingResponse)

--- a/test/UnitTests/Microsoft.OData.Core.Tests/TestUtils.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/TestUtils.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OData.Tests
                 }
                 else
                 {
-                    Assert.True(false, "Test only currently supports creating ODataResource from IEdmPrimitiveValue instances.");
+                    Assert.Fail("Test only currently supports creating ODataResource from IEdmPrimitiveValue instances.");
                     return null;
                 }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
@@ -991,7 +991,7 @@ namespace Microsoft.OData.Tests.UriParser
                     return ch;
                 }
             }
-            Assert.True(false, "Should never get here");
+            Assert.Fail("Should never get here");
             return (char)0;
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -1120,7 +1120,7 @@ namespace Microsoft.OData.Tests.UriParser
                     parser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Slash;
                     break;
                 default:
-                    Assert.True(false, "Unreachable code path");
+                    Assert.Fail("Unreachable code path");
                     break;
             }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralParserStoreTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralParserStoreTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.OData.Core.Tests.UriParser.Parsers
 
             var set = store.Snapshot();
             Assert.True(set.Contains(parser));
-            Assert.Equal(1, set.Count);
+            Assert.Single(set);
         }
 
         [Theory]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralPrefixesStoreTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralPrefixesStoreTests.cs
@@ -287,7 +287,7 @@ namespace Microsoft.OData.Core.Tests.UriParser
             // Ensure only one key exists with that name
             var snapshot = store.Snapshot();
             Assert.True(snapshot.ContainsKey(prefix));
-            Assert.Single(snapshot.Where(kv => kv.Key == prefix));
+            Assert.Single(snapshot, kv => kv.Key == prefix);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/ODataPathTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/ODataPathTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
             ODataPath clone = new ODataPath(existing);
 
             clone.FirstSegment.ShouldBeMetadataSegment();
-            Assert.Equal(1, clone.Segments.Count);
+            Assert.Single(clone.Segments);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/OperationImportSegmentTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/OperationImportSegmentTests.cs
@@ -166,7 +166,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
             {
                 // Dummy code, just need to access property to get the exception
                 var type = segment.EdmType;
-                Assert.True(false, "The EdmType getter returned '" + type + "', but should have thrown.");
+                Assert.Fail("The EdmType getter returned '" + type + "', but should have thrown.");
             }
             catch (ODataException e)
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

    Fixes the test project building warnings:

1.  Remove the obsolote
2. Use Assert.Fail, not use Assert.True(false, message)
3. Use Assert.Single for single item in the collection
4. User Lambda version, not use Assert.Single(...Where...))
5. Put Expect before actual when using Assert.Equal

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
