### PR TITLE
Fixes #3270: ODataUriParser does not honor case-insensitiveness for alias qualified names

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
@@ -196,7 +196,7 @@ namespace Microsoft.OData.UriParser
                 return term;
             }
 
-            IReadOnlyList<IEdmTerm> results = FindSchemaElements(model, termName, (cache, key) => cache.FindTerms(key));
+            IReadOnlyList<IEdmTerm> results = FindSchemaElements(model, termName, (cache, key) => cache.FindTerms(key), EnableCaseInsensitive);
 
             if (results == null || results.Count == 0)
             {
@@ -228,7 +228,7 @@ namespace Microsoft.OData.UriParser
                 return type;
             }
 
-            IReadOnlyList<IEdmSchemaType> results = FindSchemaElements(model, typeName, (cache, key) => cache.FindSchemaTypes(key));
+            IReadOnlyList<IEdmSchemaType> results = FindSchemaElements(model, typeName, (cache, key) => cache.FindSchemaTypes(key), EnableCaseInsensitive);
 
             if (results == null || results.Count == 0)
             {
@@ -262,7 +262,7 @@ namespace Microsoft.OData.UriParser
                 return results;
             }
 
-            IReadOnlyList<IEdmOperation> operations = FindSchemaElements(model, identifier, (cache, key) => cache.FindOperations(key));
+            IReadOnlyList<IEdmOperation> operations = FindSchemaElements(model, identifier, (cache, key) => cache.FindOperations(key), EnableCaseInsensitive);
 
             if (operations != null && operations.Count > 0)
             {
@@ -298,7 +298,7 @@ namespace Microsoft.OData.UriParser
                 return results;
             }
 
-            IReadOnlyList<IEdmOperation> operations = FindSchemaElements(model, identifier, (cache, key) => cache.FindOperations(key));
+            IReadOnlyList<IEdmOperation> operations = FindSchemaElements(model, identifier, (cache, key) => cache.FindOperations(key), EnableCaseInsensitive);
 
             if (operations != null && operations.Count > 0)
             {
@@ -575,7 +575,7 @@ namespace Microsoft.OData.UriParser
         private static IReadOnlyList<T> FindSchemaElements<T>(
             IEdmModel model,
             string identifier,
-            Func<NormalizedModelElementsCache, string, List<T>> cacheLookupFunc) where T : IEdmSchemaElement
+            Func<NormalizedModelElementsCache, string, List<T>> cacheLookupFunc, bool caseInsensitive) where T : IEdmSchemaElement
         {
             if (model.IsImmutable())
             {
@@ -588,22 +588,25 @@ namespace Microsoft.OData.UriParser
 
         private static IReadOnlyList<T> FindAcrossModels<T>(IEdmModel model, string qualifiedName, bool caseInsensitive) where T : IEdmSchemaElement
         {
+            // Replace the possible alias in the qualified name.
+            ReadOnlySpan<char> modifiedQualifiedName = model.ReplaceAlias(qualifiedName.AsSpan(), caseInsensitive);
+
             IList<T> results = new List<T>();
-            FindSchemaElementsInModel<T>(model, qualifiedName, caseInsensitive, ref results);
+            FindSchemaElementsInModel<T>(model, modifiedQualifiedName, caseInsensitive, ref results);
 
             foreach (IEdmModel reference in model.ReferencedModels)
             {
-                FindSchemaElementsInModel<T>(reference, qualifiedName, caseInsensitive, ref results);
+                FindSchemaElementsInModel<T>(reference, modifiedQualifiedName, caseInsensitive, ref results);
             }
 
             return results as IReadOnlyList<T>;
         }
 
-        private static void FindSchemaElementsInModel<T>(IEdmModel model, string qualifiedName, bool caseInsensitive, ref IList<T> results) where T : IEdmSchemaElement
+        private static void FindSchemaElementsInModel<T>(IEdmModel model, ReadOnlySpan<char> qualifiedName, bool caseInsensitive, ref IList<T> results) where T : IEdmSchemaElement
         {
             foreach (IEdmSchemaElement schema in model.SchemaElements)
             {
-                if (string.Equals(qualifiedName, schema.FullName(), caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+                if (qualifiedName.Equals(schema.FullName(), caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
                 {
                     if (schema is T)
                     {
@@ -631,5 +634,7 @@ namespace Microsoft.OData.UriParser
 
             return cache;
         }
+
+
     }
 }

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.ReadOnlySpan.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.ReadOnlySpan.cs
@@ -512,8 +512,10 @@ namespace Microsoft.OData.Edm
         /// <param name="model">The model containing the element.</param>
         /// <param name="name">The alias- or namespace- qualified name of the element.</param>
         /// <returns>The namespace qualified name of the element.</returns>
-        internal static ReadOnlySpan<char> ReplaceAlias(this IEdmModel model, ReadOnlySpan<char> name)
+        public static ReadOnlySpan<char> ReplaceAlias(this IEdmModel model, ReadOnlySpan<char> name, bool enableCaseInsensitive = false)
         {
+            EdmUtil.CheckArgumentNull(model, "model");
+
             VersioningDictionary<string, string> mappings = model.GetNamespaceAliases();
             VersioningList<string> list = model.GetUsedNamespacesHavingAlias();
             int idx = name.IndexOf(".", StringComparison.Ordinal);
@@ -525,7 +527,8 @@ namespace Microsoft.OData.Edm
                 string ns = null;
                 for (int i = 0; i < list.Count; i++)
                 {
-                    if (mappings.TryGetValue(list[i], out string alias) && typeAlias.Equals(alias, StringComparison.Ordinal))
+                    if (mappings.TryGetValue(list[i], out string alias)
+                        && typeAlias.Equals(alias, enableCaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
                     {
                         ns = list[i];
                         break;

--- a/src/Microsoft.OData.Edm/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 static Microsoft.OData.Edm.ExtensionMethods.SetOptimisticConcurrencyAnnotation(this Microsoft.OData.Edm.EdmModel model, Microsoft.OData.Edm.IEdmSingleton target, System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.IEdmStructuralProperty> properties) -> void
 static Microsoft.OData.Edm.ExtensionMethods.SetOptimisticConcurrencyAnnotation(this Microsoft.OData.Edm.EdmModel model, Microsoft.OData.Edm.IEdmSingleton target, System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.IEdmStructuralProperty> properties, Microsoft.OData.Edm.Csdl.EdmVocabularyAnnotationSerializationLocation location) -> void
 static readonly Microsoft.OData.Edm.Vocabularies.V1.CoreVocabularyModel.OrderedTerm -> Microsoft.OData.Edm.Vocabularies.IEdmTerm
+static Microsoft.OData.Edm.ExtensionMethods.ReplaceAlias(this Microsoft.OData.Edm.IEdmModel model, System.ReadOnlySpan<char> name, bool enableCaseInsensitive = false) -> System.ReadOnlySpan<char>

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -1449,7 +1449,94 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.Equal(fullUriString, Uri.UnescapeDataString(resultUri.OriginalString));
         }
 
-#region Escape Function Parse
+        // use static to make sure one model used in all tests
+        private static IEdmModel ModelWithAlias = GetEdmModelWithAlias();
+
+        private static IEdmModel GetEdmModelWithAlias()
+        {
+            EdmModel model = new EdmModel();
+            var person = new EdmEntityType("MyNameSpace", "Person");
+            var person_ID = person.AddStructuralProperty("ID", EdmCoreModel.Instance.GetString(false));
+            person.AddKeys(person_ID);
+            var person_SSN = person.AddStructuralProperty("SSN", EdmCoreModel.Instance.GetString(true));
+            model.AddElement(person);
+            var employee = new EdmEntityType("MyNameSpace", "Employee", person);
+            employee.AddStructuralProperty("BadgeId", EdmCoreModel.Instance.GetInt32(false));
+            model.AddElement(employee);
+            EdmEntityContainer container = new EdmEntityContainer("MyNameSpace", "Container");
+            container.AddEntitySet("People", person);
+            model.AddElement(container);
+            model.SetNamespaceAlias("MyNameSpace", "MyAlias");
+            return model;
+        }
+
+        [Theory]
+        [InlineData("MyNameSpace", "Employee", true)] // Exact match using Qualified Namespace, but case insensitive enabled
+        [InlineData("MyNameSpace", "Employee", false)] // Exact match using Qualified Namespace, but case insensitive disabled
+        [InlineData("myNamespace", "Employee", true)]
+        [InlineData("MyNameSpace", "emploYee", true)]
+        [InlineData("mynameSpace", "employEE", true)]
+        [InlineData("MyAlias", "Employee", true)] // Exact match using alias Namespace, but case insensitive enabled
+        [InlineData("MyAlias", "Employee", false)] // Exact match using alias Namespace, but case insensitive disabled
+        [InlineData("myAlias", "Employee", true)]
+        [InlineData("MyAlias", "emploYee", true)]
+        [InlineData("mYalias", "employEE", true)]
+        public void ParsePathUsingNamespaceOrAlias_CaseInsensitiveEnabled(string namespaceOrAlias, string typeShortName, bool caseInsensitive)
+        {
+            IEdmModel model = ModelWithAlias;
+
+            Uri uri = new Uri($"/People/{namespaceOrAlias}.{typeShortName}", UriKind.Relative);
+            ODataUriParser uriParser = new ODataUriParser(model, ServiceRoot, uri)
+            {
+                Resolver = new UnqualifiedODataUriResolver()
+                {
+                    EnableCaseInsensitive = caseInsensitive,
+                },
+                UrlKeyDelimiter = ODataUrlKeyDelimiter.Slash,
+            };
+            ODataPath path = uriParser.ParsePath();
+
+            ODataPathSegment segment = path.LastSegment;
+
+            Assert.NotNull(segment);
+            TypeSegment typeSegment = Assert.IsType<TypeSegment>(segment);
+            Assert.Equal("Collection(MyNameSpace.Employee)", typeSegment.EdmType.FullTypeName());
+        }
+
+        [Theory]
+        [InlineData("myNamespace", "Employee")]
+        [InlineData("MyNameSpace", "emploYee")]
+        [InlineData("mynameSpace", "employEE")]
+        [InlineData("myAlias", "Employee")]
+        [InlineData("MyAlias", "emploYee")]
+        [InlineData("mYalias", "employEE")]
+        public void ParsePathUsingNonMatchedNamespaceOrAlias_CaseInsensitiveDisabled(string namespaceOrAlias, string typeShortName)
+        {
+            IEdmModel model = ModelWithAlias;
+            string segmentString = $"{namespaceOrAlias}.{typeShortName}";
+            Uri uri = new Uri($"/People/{segmentString}", UriKind.Relative);
+            ODataUriParser uriParser = new ODataUriParser(model, ServiceRoot, uri)
+            {
+                Resolver = new UnqualifiedODataUriResolver()
+                {
+                    EnableCaseInsensitive = false,
+                },
+                UrlKeyDelimiter = ODataUrlKeyDelimiter.Slash,
+            };
+            ODataPath path = uriParser.ParsePath();
+
+            ODataPathSegment segment = path.LastSegment;
+
+            Assert.NotNull(segment);
+
+            // The segment should be treated as a key segment since
+            // 1) the type could not be resolved
+            // 2) the key is string type
+            // 3) key as segment is enabled
+            segment.ShouldBeKeySegment(new KeyValuePair<string, object>("ID", segmentString));
+        }
+
+        #region Escape Function Parse
         [Theory]
         [InlineData("/root:/", "/root/NS.NormalFunction(path='')")]
         [InlineData("/root:/abc", "/root/NS.NormalFunction(path='abc')")]


### PR DESCRIPTION
…lias qualified names

Maybe port back to 8.x version.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3270.*

OData Uri parser should work for alias qualified name in different case if case insensitive enabled.

Might port back to 8.x version later.

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
