### PR TITLE
Temporarily revert the nullable reference for the Edm.E2E project. We…

### DIFF
--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/Common/CsdlToEdmModelComparer.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/Common/CsdlToEdmModelComparer.cs
@@ -124,14 +124,14 @@ public static class CsdlToEdmModelComparer
 
                 var possibleMatches = model.FindDeclaredOperations(namespaceName + "." + operationName).ToArray();
                 
-                IEdmOperation? operation = null;
+                IEdmOperation operation = null;
                 foreach (var possibleMatch in possibleMatches)
                 {
                     CompareOperationParameters(parameterElements, possibleMatch.Parameters);
                     operation = possibleMatch;
                 }
 
-                if (operationElement.TryGetAttributeValue("ReturnType", out string? returnTypeValue) && returnTypeValue != null)
+                if (operationElement.TryGetAttributeValue("ReturnType", out string returnTypeValue) && returnTypeValue != null)
                 {
                     CompareTypeValue(returnTypeValue, operation.ReturnType);
                 }
@@ -478,7 +478,7 @@ public static class CsdlToEdmModelComparer
         bool isCollectionType = typeName.StartsWith(EdmModelUtils.CollectionTypeNamePrefix);
         if (isCollectionType)
         {
-            string? elementTypeName = EdmModelUtils.GetCollectionItemTypeName(typeName);
+            string elementTypeName = EdmModelUtils.GetCollectionItemTypeName(typeName);
             CompareTypeValue(elementTypeName, typeReference.GetCollectionItemType());
         }
         else

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/Common/EdmLibTestCaseBase.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/Common/EdmLibTestCaseBase.cs
@@ -140,7 +140,7 @@ public class EdmLibTestCaseBase
     {
         public void Add(int? lineNumber, int? linePostion, EdmErrorCode edmErrorCode)
         {
-            EdmLibTestCsdlLocation? errorLocation = null;
+            EdmLibTestCsdlLocation errorLocation = null;
             if (lineNumber != null && linePostion != null)
             {
                 errorLocation = new EdmLibTestCsdlLocation(lineNumber, linePostion);

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/Common/EdmModelUtils.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/Common/EdmModelUtils.cs
@@ -26,7 +26,7 @@ public static class EdmModelUtils
     /// </summary>
     /// <param name="collectionTypeName">The collection item type name to parse.</param>
     /// <returns>The item type name or null if the <paramref name="collectionTypeName"/> is not a collection type name.</returns>
-    public static string? GetCollectionItemTypeName(string collectionTypeName)
+    public static string GetCollectionItemTypeName(string collectionTypeName)
     {
         if (collectionTypeName.StartsWith(CollectionTypeNamePrefix) && collectionTypeName.EndsWith(CollectionTypeNameSuffix))
         {

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/Common/MetadataUtils.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/Common/MetadataUtils.cs
@@ -72,7 +72,7 @@ public static class MetadataUtils
     /// <param name="entityType">The entity type to search for navigation properties on.</param>
     /// <param name="navigationPropertyName">The navigation property name.</param>
     /// <returns>The navigation property with the specified name or null if none exists.</returns>
-    public static IEdmNavigationProperty? GetNavigationProperty(this IEdmEntityType entityType, string navigationPropertyName)
+    public static IEdmNavigationProperty GetNavigationProperty(this IEdmEntityType entityType, string navigationPropertyName)
     {
         Assert.NotNull(entityType);
         Assert.NotEmpty(navigationPropertyName);
@@ -90,7 +90,7 @@ public static class MetadataUtils
         int lastDot = typeAndPropertyName.LastIndexOf('.');
         string propertyName = typeAndPropertyName.Substring(lastDot + 1);
         string typeName = typeAndPropertyName.Substring(0, lastDot);
-        IEdmStructuredType? type = model.ResolveType(typeName) as IEdmStructuredType;
+        IEdmStructuredType type = model.ResolveType(typeName) as IEdmStructuredType;
         Assert.NotNull(type);
 
         return type.ResolveProperty(propertyName);
@@ -112,7 +112,7 @@ public static class MetadataUtils
     /// <param name="fullName">The name of the type to find. For the namespace the namespace of the model is used.</param>
     /// <param name="nullable">true if the type reference should be nullable; otherwise false.</param>
     /// <returns>The type found.</returns>
-    public static IEdmTypeReference? ResolveTypeReference(this IEdmModel model, string fullName, bool nullable)
+    public static IEdmTypeReference ResolveTypeReference(this IEdmModel model, string fullName, bool nullable)
     {
         IEdmType type = model.ResolveType(fullName);
         Assert.NotNull(type);
@@ -162,7 +162,7 @@ public static class MetadataUtils
     /// names for collection types. For EdmLib, collection types are functions and thus don't have a full name.
     /// The name/string they use in CSDL is just shorthand for them.
     /// </remarks>
-    public static string? TestFullName(this IEdmType type)
+    public static string TestFullName(this IEdmType type)
     {
         Assert.NotNull(type);
         // Handle collection type names here since for EdmLib collections are functions
@@ -247,7 +247,7 @@ public static class MetadataUtils
     /// </summary>
     /// <param name="type">The type to convert.</param>
     /// <returns>A non-nullable type reference for the <paramref name="type"/>.</returns>
-    public static IEdmTypeReference? ToTypeReference(this IEdmType type)
+    public static IEdmTypeReference ToTypeReference(this IEdmType type)
     {
         return type.ToTypeReference(false /*nullable*/);
     }
@@ -258,7 +258,7 @@ public static class MetadataUtils
     /// <param name="type">The type to convert.</param>
     /// <param name="nullable">true if the returned type reference should be nullable; otherwise false.</param>
     /// <returns>A type reference for the <paramref name="type"/>.</returns>
-    public static IEdmTypeReference? ToTypeReference(this IEdmType type, bool nullable)
+    public static IEdmTypeReference ToTypeReference(this IEdmType type, bool nullable)
     {
         if (type == null)
         {
@@ -311,7 +311,7 @@ public static class MetadataUtils
     /// </summary>
     /// <param name="clrType">The Clr type to resolve.</param>
     /// <returns>The primitive type reference for the given Clr type.</returns>
-    public static IEdmPrimitiveTypeReference? GetPrimitiveTypeReference(Type clrType)
+    public static IEdmPrimitiveTypeReference GetPrimitiveTypeReference(Type clrType)
     {
         Assert.NotNull(clrType);
 
@@ -319,7 +319,7 @@ public static class MetadataUtils
         TypeCode typeCode = Type.GetTypeCode(targetType);
         bool nullable = TypeAllowsNull(clrType);
 
-        IEdmPrimitiveType? primitiveType = null;
+        IEdmPrimitiveType primitiveType = null;
         switch (typeCode)
         {
             case TypeCode.Boolean:
@@ -496,9 +496,9 @@ public static class MetadataUtils
     /// </summary>
     /// <param name="edmTypeName">The edm type name to resolve.</param>
     /// <returns>The primitive type reference for the given edm type name.</returns>
-    public static IEdmPrimitiveTypeReference? GetPrimitiveTypeReference(string edmTypeName)
+    public static IEdmPrimitiveTypeReference GetPrimitiveTypeReference(string edmTypeName)
     {
-        IEdmPrimitiveType? primitiveType = null;
+        IEdmPrimitiveType primitiveType = null;
         bool nullable = true;
         switch (edmTypeName)
         {
@@ -612,7 +612,7 @@ public static class MetadataUtils
     /// <param name="typeReference">The type reference to clone.</param>
     /// <param name="nullable">true to make the cloned type reference nullable; false to make it non-nullable.</param>
     /// <returns>The cloned <see cref="IEdmTypeReference"/> instance.</returns>
-    public static IEdmTypeReference? Clone(this IEdmTypeReference typeReference, bool nullable)
+    public static IEdmTypeReference Clone(this IEdmTypeReference typeReference, bool nullable)
     {
         if (typeReference == null)
         {
@@ -712,7 +712,7 @@ public static class MetadataUtils
     /// </summary>
     /// <param name="typeReference">The collection type to get the item type for.</param>
     /// <returns>The item type of the <paramref name="typeReference"/>.</returns>
-    public static IEdmTypeReference? GetCollectionItemType(this IEdmTypeReference typeReference)
+    public static IEdmTypeReference GetCollectionItemType(this IEdmTypeReference typeReference)
     {
         IEdmCollectionTypeReference collectionType = typeReference.AsCollection();
         return collectionType?.ElementType();
@@ -762,7 +762,7 @@ public static class MetadataUtils
     /// <param name="type">The type to inspect.</param>
     /// <returns>If the <paramref name="type"/> was IEnumerable then it returns the type of a single element
     /// otherwise it returns null.</returns>
-    public static Type? GetIEnumerableElementType(Type type)
+    public static Type GetIEnumerableElementType(Type type)
     {
         Assert.NotNull(type);
         var iEnum = FindIEnumerable(type);
@@ -779,7 +779,7 @@ public static class MetadataUtils
     /// </summary>
     /// <param name="seqType">The Type to check</param>
     /// <returns>returns the type which implements IEnumerable</returns>
-    public static Type? FindIEnumerable(Type seqType)
+    public static Type FindIEnumerable(Type seqType)
     {
         Assert.NotNull(seqType);
 
@@ -867,7 +867,7 @@ public static class MetadataUtils
     /// <param name="attributeName">The name of the attribute to retrieve.</param>
     /// <param name="attributeValue">The value of the attribute as a string, or null if not found.</param>
     /// <returns>Whether or not the attribute was found.</returns>
-    public static bool TryGetAttributeValue(this XElement element, string attributeName, out string? attributeValue)
+    public static bool TryGetAttributeValue(this XElement element, string attributeName, out string attributeValue)
     {
         Assert.NotEmpty(attributeName);
         Assert.NotNull(attributeName);
@@ -984,7 +984,7 @@ public static class MetadataUtils
     /// <param name="property">Property to evaluate.</param>
     /// <param name="expressionEvaluator">Evaluator to use to perform expression evaluation.</param>
     /// <returns>Value of the property evaluated against the supplied value, or null if no relevant annotation exists.</returns>
-    public static IEdmValue? GetPropertyValue(this IEdmModel model, IEdmStructuredValue context, IEdmTerm term, IEdmProperty property, EdmExpressionEvaluator expressionEvaluator)
+    public static IEdmValue GetPropertyValue(this IEdmModel model, IEdmStructuredValue context, IEdmTerm term, IEdmProperty property, EdmExpressionEvaluator expressionEvaluator)
     {
         return model.GetPropertyValue(context, context.Type.AsEntity().EntityDefinition(), term, property, null, expressionEvaluator.Evaluate);
     }
@@ -999,7 +999,7 @@ public static class MetadataUtils
     /// <param name="property">Property to evaluate.</param>
     /// <param name="evaluator">Evaluator to use to perform expression evaluation.</param>
     /// <returns>Value of the property evaluated against the supplied value, or default(<typeparamref name="T"/>) if no relevant annotation exists.</returns>
-    public static T? GetPropertyValue<T>(this IEdmModel model, IEdmStructuredValue context, IEdmTerm term, IEdmProperty property, EdmToClrEvaluator evaluator)
+    public static T GetPropertyValue<T>(this IEdmModel model, IEdmStructuredValue context, IEdmTerm term, IEdmProperty property, EdmToClrEvaluator evaluator)
     {
         return model.GetPropertyValue(context, context.Type.AsEntity().EntityDefinition(), term, property, null, evaluator.EvaluateToClrValue<T>);
     }
@@ -1015,12 +1015,12 @@ public static class MetadataUtils
     /// <param name="qualifier">Qualifier to apply.</param>
     /// <param name="evaluator">Evaluator to use to perform expression evaluation.</param>
     /// <returns>Value of the property evaluated against the supplied value, or default(<typeparamref name="T"/>) if no relevant annotation exists.</returns>
-    public static T? GetPropertyValue<T>(this IEdmModel model, IEdmStructuredValue context, IEdmTerm term, IEdmProperty property, string qualifier, EdmToClrEvaluator evaluator)
+    public static T GetPropertyValue<T>(this IEdmModel model, IEdmStructuredValue context, IEdmTerm term, IEdmProperty property, string qualifier, EdmToClrEvaluator evaluator)
     {
         return model.GetPropertyValue(context, context.Type.AsEntity().EntityDefinition(), term, property, qualifier, evaluator.EvaluateToClrValue<T>);
     }
 
-    private static T? GetPropertyValue<T>(this IEdmModel model, IEdmStructuredValue context, IEdmEntityType contextType, IEdmTerm term, IEdmProperty property, string? qualifier, Func<IEdmExpression, IEdmStructuredValue, T> evaluator)
+    private static T GetPropertyValue<T>(this IEdmModel model, IEdmStructuredValue context, IEdmEntityType contextType, IEdmTerm term, IEdmProperty property, string qualifier, Func<IEdmExpression, IEdmStructuredValue, T> evaluator)
     {
         IEnumerable<IEdmVocabularyAnnotation> annotations = model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>(contextType, term, qualifier);
 

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/AmbiguousTypeTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/AmbiguousTypeTests.cs
@@ -304,7 +304,7 @@ public class AmbiguousTypeTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Act & Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Equal(7, actualErrors.Count());
 
         Assert.Equal(EdmErrorCode.TypeMustNotHaveKindOfNone, actualErrors.ElementAt(0).ErrorCode);
@@ -469,7 +469,7 @@ public class AmbiguousTypeTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(model, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -477,11 +477,11 @@ public class AmbiguousTypeTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is valid, the round-tripped model should be well-formed and valid.
-        IEdmModel? roundtrippedModel = null;
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        IEdmModel roundtrippedModel = null;
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed && !parserErrors.Any());
 
-        var isValid = roundtrippedModel.Validate(out IEnumerable<EdmError>? validationErrors);
+        var isValid = roundtrippedModel.Validate(out IEnumerable<EdmError> validationErrors);
         Assert.True(!validationErrors.Any() && isValid);
     }
 

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/AnnotatableTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/AnnotatableTests.cs
@@ -675,7 +675,7 @@ public class AnnotatableTests : EdmLibTestCaseBase
             }
         }
 
-        public override bool Equals(object? obj)
+        public override bool Equals(object obj)
         {
             var other = obj as MyQualifiedName;
             if (other == null)
@@ -686,7 +686,7 @@ public class AnnotatableTests : EdmLibTestCaseBase
             return this.Equals(other);
         }
 
-        public bool Equals(MyQualifiedName? other)
+        public bool Equals(MyQualifiedName other)
         {
             return this.NamespaceName == other.NamespaceName && this.Name == other.Name;
         }

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/AnnotationsOnNonRepresentedElementTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/AnnotationsOnNonRepresentedElementTests.cs
@@ -71,7 +71,7 @@ public class AnnotationsOnNonRepresentedElementTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(testModel, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -79,11 +79,11 @@ public class AnnotationsOnNonRepresentedElementTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is valid, the round-tripped model should be well-formed and valid.
-        IEdmModel? roundtrippedModel = null;
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        IEdmModel roundtrippedModel = null;
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed && !parserErrors.Any());
 
-        var isValid = roundtrippedModel.Validate(out IEnumerable<EdmError>? validationErrors);
+        var isValid = roundtrippedModel.Validate(out IEnumerable<EdmError> validationErrors);
         Assert.True(!validationErrors.Any() && isValid);
     }
 
@@ -125,7 +125,7 @@ public class AnnotationsOnNonRepresentedElementTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -138,7 +138,7 @@ public class AnnotationsOnNonRepresentedElementTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -176,7 +176,7 @@ public class AnnotationsOnNonRepresentedElementTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -189,7 +189,7 @@ public class AnnotationsOnNonRepresentedElementTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -223,7 +223,7 @@ public class AnnotationsOnNonRepresentedElementTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(testModel, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -231,11 +231,11 @@ public class AnnotationsOnNonRepresentedElementTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is valid, the round-tripped model should be well-formed and valid.
-        IEdmModel? roundtrippedModel = null;
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        IEdmModel roundtrippedModel = null;
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed && !parserErrors.Any());
 
-        var isValid = roundtrippedModel.Validate(out IEnumerable<EdmError>? validationErrors);
+        var isValid = roundtrippedModel.Validate(out IEnumerable<EdmError> validationErrors);
         Assert.True(!validationErrors.Any() && isValid);
     }
 
@@ -268,7 +268,7 @@ public class AnnotationsOnNonRepresentedElementTests : EdmLibTestCaseBase
 
         // Assert
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(testModel, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -276,11 +276,11 @@ public class AnnotationsOnNonRepresentedElementTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is valid, the round-tripped model should be well-formed and valid.
-        IEdmModel? roundtrippedModel = null;
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        IEdmModel roundtrippedModel = null;
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed && !parserErrors.Any());
 
-        var isValid = roundtrippedModel.Validate(out IEnumerable<EdmError>? validationErrors);
+        var isValid = roundtrippedModel.Validate(out IEnumerable<EdmError> validationErrors);
         Assert.True(!validationErrors.Any() && isValid);
     }
 
@@ -317,7 +317,7 @@ public class AnnotationsOnNonRepresentedElementTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -330,7 +330,7 @@ public class AnnotationsOnNonRepresentedElementTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -367,7 +367,7 @@ public class AnnotationsOnNonRepresentedElementTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Empty(actualErrors);
 
@@ -376,10 +376,10 @@ public class AnnotationsOnNonRepresentedElementTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is valid, the round-tripped model should be well-formed and valid.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed && !parserErrors.Any());
 
-        var isValid = roundtrippedModel.Validate(out IEnumerable<EdmError>? validationErrors);
+        var isValid = roundtrippedModel.Validate(out IEnumerable<EdmError> validationErrors);
         Assert.True(!validationErrors.Any() && isValid);
     }
 }

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ClrTypeMappingTests.cs.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ClrTypeMappingTests.cs.cs
@@ -1865,7 +1865,7 @@ public class ClrTypeMappingTests : EdmLibTestCaseBase
 
         var isObjectPopulated = true;
         var isObjectInitialized = true;
-        object? createdObjectInstance = null;
+        object createdObjectInstance = null;
         TryCreateObjectInstance tryCreateObjectInstance = (IEdmStructuredValue edmValue, Type clrType, EdmToClrConverter converter, out object objectInstance, out bool objectInstanceInitialized) =>
         {
             objectInstance = createdObjectInstance;
@@ -1897,7 +1897,7 @@ public class ClrTypeMappingTests : EdmLibTestCaseBase
         ev.EdmToClrConverter = new EdmToClrConverter(tryCreateObjectInstance);
         Assert.True(CompareObjects((Display2)ev.EdmToClrConverter.AsClrValue(value, typeof(Display2)), createdObjectInstance));
 
-        ev.EdmToClrConverter = new EdmToClrConverter((IEdmStructuredValue edmValue, Type clrType, EdmToClrConverter converter, out object? objectInstance, out bool objectInstanceInitialized) =>
+        ev.EdmToClrConverter = new EdmToClrConverter((IEdmStructuredValue edmValue, Type clrType, EdmToClrConverter converter, out object objectInstance, out bool objectInstanceInitialized) =>
         {
             if (clrType == typeof(Display2))
             {

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ConstantExpressionValidationTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ConstantExpressionValidationTests.cs
@@ -45,7 +45,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -58,7 +58,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -91,7 +91,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -104,7 +104,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -139,7 +139,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -152,7 +152,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -185,7 +185,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -198,7 +198,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -233,7 +233,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -246,7 +246,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -279,7 +279,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -292,7 +292,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -327,7 +327,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
        
@@ -340,7 +340,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -373,7 +373,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -386,7 +386,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -421,7 +421,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -434,7 +434,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -467,7 +467,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -480,7 +480,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -515,7 +515,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -528,7 +528,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -561,7 +561,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -574,7 +574,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -609,7 +609,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -622,7 +622,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -655,7 +655,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -668,7 +668,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -701,7 +701,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -714,7 +714,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -749,7 +749,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -762,7 +762,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -795,7 +795,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -808,7 +808,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -841,7 +841,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -854,7 +854,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -885,7 +885,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Act & Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Equal(2, actualErrors.Count());
 
@@ -903,7 +903,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -936,7 +936,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = testModel.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.True(expectedErrors.Count == actualErrors.Count());
         Assert.Single(actualErrors);
 
@@ -949,7 +949,7 @@ public class ConstantExpressionValidationTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 }

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ConstructibleModelTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ConstructibleModelTests.cs
@@ -1464,7 +1464,7 @@ public class ConstructibleModelTests : EdmLibTestCaseBase
         model.AddElement(entityType);
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Equal(3, actualErrors.Count());
 
         Assert.Equal(EdmErrorCode.KeyPropertyMustBelongToEntity, actualErrors.ElementAt(0).ErrorCode);
@@ -1484,7 +1484,7 @@ public class ConstructibleModelTests : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
 
         var roundTripCsdls = this.GetSerializerResult(roundtrippedModel).Select(n => XElement.Parse(n));

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/CsdlParsingTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/CsdlParsingTests.cs
@@ -35,7 +35,7 @@ public class CsdlParsingTests : EdmLibTestCaseBase
   </edmx:DataServices>
 </edmx:Edmx>";
 
-        IEnumerable<IEdmModel>? refs = null;
+        IEnumerable<IEdmModel> refs = null;
         var exception = Assert.Throws<ArgumentNullException>(() => CsdlReader.TryParse(XmlReader.Create(new StringReader(edmx)), refs, out IEdmModel model, out IEnumerable<EdmError> errors));
         Assert.Equal("Value cannot be null. (Parameter 'references')", exception.Message);
 

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ExpressionSemanticValidationTest.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ExpressionSemanticValidationTest.cs
@@ -44,7 +44,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.NullCannotBeAssertedToBeANonNullableType, actualErrors.Last().ErrorCode);
@@ -56,7 +56,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -91,7 +91,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.PrimitiveConstantExpressionNotValidForNonPrimitiveType, actualErrors.Last().ErrorCode);
@@ -103,7 +103,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -135,7 +135,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionPrimitiveKindNotValidForAssertedType, actualErrors.Last().ErrorCode);
@@ -147,7 +147,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -179,7 +179,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(model, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -187,7 +187,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -224,7 +224,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(model, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -232,7 +232,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -280,7 +280,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(model, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -288,7 +288,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -326,7 +326,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.InvalidInteger, actualErrors.Last().ErrorCode);
@@ -338,7 +338,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -375,7 +375,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Equal(3, actualErrors.Count());
 
         Assert.Equal(EdmErrorCode.ExpressionNotValidForTheAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -395,7 +395,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -443,7 +443,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.RecordExpressionHasExtraProperties, actualErrors.ElementAt(0).ErrorCode);
@@ -455,7 +455,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -503,7 +503,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionPrimitiveKindNotValidForAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -515,7 +515,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -552,7 +552,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionPrimitiveKindNotValidForAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -564,7 +564,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -614,7 +614,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.TypeSemanticsCouldNotConvertTypeReference, actualErrors.ElementAt(0).ErrorCode);
@@ -626,7 +626,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -674,7 +674,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionPrimitiveKindNotValidForAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -686,7 +686,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -728,7 +728,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.InvalidBinary, actualErrors.ElementAt(0).ErrorCode);
@@ -740,7 +740,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -784,7 +784,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(model, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -792,7 +792,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -833,7 +833,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionNotValidForTheAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -845,7 +845,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -881,7 +881,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionNotValidForTheAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -892,7 +892,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -933,7 +933,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionNotValidForTheAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -945,7 +945,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -981,7 +981,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionNotValidForTheAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -992,7 +992,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1032,7 +1032,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionNotValidForTheAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -1044,7 +1044,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1080,7 +1080,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionNotValidForTheAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -1091,7 +1091,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1139,7 +1139,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(model, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -1147,7 +1147,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1187,7 +1187,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(model, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -1195,7 +1195,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1243,7 +1243,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(model, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -1251,7 +1251,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1296,7 +1296,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(model, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -1304,7 +1304,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1333,7 +1333,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionPrimitiveKindNotValidForAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -1345,7 +1345,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1369,7 +1369,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionPrimitiveKindNotValidForAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -1380,7 +1380,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1417,7 +1417,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionNotValidForTheAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -1429,7 +1429,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1462,7 +1462,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionNotValidForTheAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -1473,7 +1473,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1502,7 +1502,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(model, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -1510,7 +1510,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1534,7 +1534,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(model, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -1542,7 +1542,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1578,7 +1578,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(model, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -1586,7 +1586,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1614,7 +1614,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Empty(actualErrors);
 
         var serializedCsdls = GetSerializerResult(model, edmVersion, out IEnumerable<EdmError> serializationErrors).Select(n => XElement.Parse(n));
@@ -1622,7 +1622,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1658,7 +1658,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.CollectionExpressionNotValidForNonCollectionType, actualErrors.ElementAt(0).ErrorCode);
@@ -1670,7 +1670,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1704,7 +1704,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionPrimitiveKindNotValidForAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -1716,7 +1716,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1750,7 +1750,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionPrimitiveKindNotValidForAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -1762,7 +1762,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1796,7 +1796,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionPrimitiveKindNotValidForAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -1808,7 +1808,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1842,7 +1842,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionPrimitiveKindNotValidForAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -1854,7 +1854,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1882,7 +1882,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.InvalidDate, actualErrors.ElementAt(0).ErrorCode);
@@ -1894,7 +1894,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1928,7 +1928,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionPrimitiveKindNotValidForAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -1940,7 +1940,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -1974,7 +1974,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionPrimitiveKindNotValidForAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -1986,7 +1986,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -2020,7 +2020,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.ExpressionPrimitiveKindNotValidForAssertedType, actualErrors.ElementAt(0).ErrorCode);
@@ -2032,7 +2032,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -2060,7 +2060,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.InvalidTimeOfDay, actualErrors.ElementAt(0).ErrorCode);
@@ -2072,7 +2072,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -2106,7 +2106,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.StringConstantLengthOutOfRange, actualErrors.ElementAt(0).ErrorCode);
@@ -2118,7 +2118,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 
@@ -2152,7 +2152,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         var validationRuleSet = ValidationRuleSet.GetEdmModelRuleSet(this.GetProductVersion(edmVersion));
 
         // Assert
-        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError>? actualErrors);
+        var validationResult = model.Validate(validationRuleSet, out IEnumerable<EdmError> actualErrors);
         Assert.Single(actualErrors);
 
         Assert.Equal(EdmErrorCode.BinaryConstantLengthOutOfRange, actualErrors.ElementAt(0).ErrorCode);
@@ -2164,7 +2164,7 @@ public class ExpressionSemanticValidationTest : EdmLibTestCaseBase
         Assert.False(serializationErrors.Any());
 
         // if the original test model is not valid, the serializer should still generate CSDLs that parser can handle, but the round trip-ability is not guaranteed.
-        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel? roundtrippedModel, out IEnumerable<EdmError>? parserErrors);
+        var isWellFormed = SchemaReader.TryParse(serializedCsdls.Select(e => e.CreateReader()), out IEdmModel roundtrippedModel, out IEnumerable<EdmError> parserErrors);
         Assert.True(isWellFormed);
     }
 }

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ExtensionMethodsTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ExtensionMethodsTests.cs
@@ -286,7 +286,7 @@ public class ExtensionMethodsTests : EdmLibTestCaseBase
     [Fact]
     public void Validate_SetPrimitiveValueConverterWithNullModel_ThrowsArgumentNullException()
     {
-        EdmModel? model = null;
+        EdmModel model = null;
         var typeReference = new EdmTypeDefinitionReference(new EdmTypeDefinition("NS", "Test", EdmPrimitiveTypeKind.Int32), true);
         var converter = new TestPrimitiveValueConverter();
 
@@ -307,7 +307,7 @@ public class ExtensionMethodsTests : EdmLibTestCaseBase
     [Fact]
     public void Validate_GetPrimitiveValueConverterWithNullModel_ThrowsArgumentNullException()
     {
-        EdmModel? model = null;
+        EdmModel model = null;
         var typeReference = new EdmTypeDefinitionReference(new EdmTypeDefinition("NS", "Test", EdmPrimitiveTypeKind.Int32), true);
 
         Assert.Throws<ArgumentNullException>(() => model.GetPrimitiveValueConverter(typeReference));
@@ -336,7 +336,7 @@ public class ExtensionMethodsTests : EdmLibTestCaseBase
     [Fact]
     public void Validate_GetUIntWithNullModel_ThrowsArgumentNullException()
     {
-        EdmModel? model = null;
+        EdmModel model = null;
         var exception = Assert.Throws<ArgumentNullException>(() => model.GetUInt16("MyNS", false));
         Assert.Equal("Value cannot be null. (Parameter 'model')", exception.Message);
     }

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/FindMethodTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/FindMethodTests.cs
@@ -3313,12 +3313,12 @@ public class FindMethodTests : EdmLibTestCaseBase
 
     private static void VerifyFindDerivedType(IEnumerable<XElement> sourceCsdls, IEdmModel testModel, EdmVersion edmVersion)
     {
-        Func<IEdmStructuredType, string?> getFullName = (type) =>
+        Func<IEdmStructuredType, string> getFullName = (type) =>
         {
             return type as IEdmComplexType != null ? ((IEdmComplexType)type).FullName() : type as IEdmEntityType != null ? ((IEdmEntityType)type).FullName() : null;
         };
 
-        Func<IEdmStructuredType, string?> getNamespace = (type) =>
+        Func<IEdmStructuredType, string> getNamespace = (type) =>
         {
             return type as IEdmComplexType != null ? ((IEdmComplexType)type).Namespace : type as IEdmEntityType != null ? ((IEdmEntityType)type).Namespace : null;
         };
@@ -3404,7 +3404,7 @@ public class FindMethodTests : EdmLibTestCaseBase
         {
             foreach (var propertyElement in sourceCsdl.Descendants().Elements(XName.Get(schemaElementType, csdlNamespace.NamespaceName)))
             {
-                IEdmProperty? foundProperty = null;
+                IEdmProperty foundProperty = null;
                 Assert.Contains(new string[] { "EntityType", "ComplexType", "RowType" }, n => n == propertyElement.Parent?.Name.LocalName);
 
                 if (propertyElement.Parent.Name.LocalName != "RowType")
@@ -3439,7 +3439,7 @@ public class FindMethodTests : EdmLibTestCaseBase
                     var elementName = string.Format("{0}.{1}", namespaceValue, propertyElement.Parent?.Attribute("Name")?.Value);
                     var elementTypeFound = testModel.FindType(elementName) as IEdmStructuredType;
 
-                    IEdmStructuredTypeReference? elementTypeReferenceFound = null;
+                    IEdmStructuredTypeReference elementTypeReferenceFound = null;
                     if (propertyElement.Parent.Name.LocalName.Equals("ComplexType"))
                     {
                         elementTypeReferenceFound = new EdmComplexTypeReference((IEdmComplexType)elementTypeFound, true);
@@ -3470,7 +3470,7 @@ public class FindMethodTests : EdmLibTestCaseBase
         {
             foreach (var parameterElement in sourceCsdl.Descendants().Elements(XName.Get(schemaElementType, csdlNamespace.NamespaceName)))
             {
-                IEdmOperationParameter? parameterFound = null;
+                IEdmOperationParameter parameterFound = null;
                 var parameterName = parameterElement.Attribute("Name")?.Value;
                 Assert.Contains(new string[] { "Function", "Action" }, n => n == parameterElement.Parent?.Name.LocalName);
 
@@ -3513,7 +3513,7 @@ public class FindMethodTests : EdmLibTestCaseBase
 
                 Assert.False((typeFound == null) && (operationGroup == null) && (valueTermFound == null));
 
-                IEdmSchemaElement? schemaElementFound = null;
+                IEdmSchemaElement schemaElementFound = null;
                 if (operationGroup.Count() > 0)
                 {
                     schemaElementFound = (IEdmSchemaElement)operationGroup.First();
@@ -3574,7 +3574,7 @@ public class FindMethodTests : EdmLibTestCaseBase
                 var entitySetFound = entityContainerObj.FindEntitySet(entityContainerElementName);
                 var functionImportsFound = entityContainerObj.FindOperationImports(entityContainerElementName);
 
-                IEdmEntityContainerElement? entityContainerElementFound = null;
+                IEdmEntityContainerElement entityContainerElementFound = null;
                 var elementsWithSameName = entityContainerElements.Where(n => n.Attribute("Name").Value.Equals(entityContainerElementName)).Count();
 
                 if (functionImportsFound != null && functionImportsFound.Count() == elementsWithSameName)

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ParserTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ParserTests.cs
@@ -599,7 +599,7 @@ public class ParserTests : EdmLibTestCaseBase
     public void Validate_ParsingSelfReferencingNavigationPropertyWithBaseType_ReportsExpectedErrors()
     {
         var csdl = @"
-< Schema Namespace=""DefaultNamespace"" Alias=""Self"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+<Schema Namespace=""DefaultNamespace"" Alias=""Self"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
     <EntityType Name=""Person"">
         <Key>
             <PropertyRef Name=""Id"" />

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/SchemaParsingTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/SchemaParsingTests.cs
@@ -1924,7 +1924,7 @@ public class SchemaParsingTests : EdmLibTestCaseBase
         Assert.True(parsed);
 
         IEdmOperation operation = (IEdmOperation)model.SchemaElements.First();
-        IEdmTypeReference? returnType = operation.Return?.Type;
+        IEdmTypeReference returnType = operation.Return?.Type;
         IEdmTypeReference parameterType = operation.Parameters.First().Type;
 
         Assert.False(returnType.IsBad());
@@ -1953,7 +1953,7 @@ public class SchemaParsingTests : EdmLibTestCaseBase
         Assert.True(parsed);
 
         IEdmOperation operation = (IEdmOperation)model.SchemaElements.First();
-        IEdmTypeReference? returnType = operation.Return?.Type;
+        IEdmTypeReference returnType = operation.Return.Type;
         IEdmTypeReference parameterType = operation.Parameters.First().Type;
 
         Assert.False(returnType.IsBad());

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/SchemaParsingTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/SchemaParsingTests.cs
@@ -1924,7 +1924,7 @@ public class SchemaParsingTests : EdmLibTestCaseBase
         Assert.True(parsed);
 
         IEdmOperation operation = (IEdmOperation)model.SchemaElements.First();
-        IEdmTypeReference returnType = operation.Return?.Type;
+        IEdmTypeReference returnType = operation.ReturnType;
         IEdmTypeReference parameterType = operation.Parameters.First().Type;
 
         Assert.False(returnType.IsBad());
@@ -1953,7 +1953,7 @@ public class SchemaParsingTests : EdmLibTestCaseBase
         Assert.True(parsed);
 
         IEdmOperation operation = (IEdmOperation)model.SchemaElements.First();
-        IEdmTypeReference returnType = operation.Return.Type;
+        IEdmTypeReference returnType = operation.ReturnType;
         IEdmTypeReference parameterType = operation.Parameters.First().Type;
 
         Assert.False(returnType.IsBad());

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/Microsoft.OData.Edm.E2E.Tests.csproj
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/Microsoft.OData.Edm.E2E.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/StubEdm/StubEdmEntityType.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/StubEdm/StubEdmEntityType.cs
@@ -89,7 +89,7 @@ public class StubEdmEntityType : StubEdmElement, IEdmEntityType
     /// </summary>
     /// <param name="name">The name of the property</param>
     /// <returns>The property.</returns>
-    public IEdmProperty? FindProperty(string name)
+    public IEdmProperty FindProperty(string name)
     {
         if (name == null)
         {
@@ -104,7 +104,7 @@ public class StubEdmEntityType : StubEdmElement, IEdmEntityType
     /// </summary>
     /// <param name="name">The name of the property</param>
     /// <returns>The property.</returns>
-    public IEdmProperty? FindProperty(ReadOnlySpan<char> name)
+    public IEdmProperty FindProperty(ReadOnlySpan<char> name)
     {
         foreach (var p in this.StructuralProperties().Cast<IEdmProperty>()
                    .Concat(this.NavigationProperties().Cast<IEdmProperty>()))


### PR DESCRIPTION
… should enable the nullable reference for the product projects and test projects together.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
