### PR TITLE
Support 'case' conditional function in URI parser (#2309)

### DIFF
--- a/src/Microsoft.OData.Core/SRResources.Designer.cs
+++ b/src/Microsoft.OData.Core/SRResources.Designer.cs
@@ -773,6 +773,42 @@ namespace Microsoft.OData.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The &apos;case&apos; function requires condition:result pairs, but received {0} argument(s). Each condition must be followed by a colon and a result expression..
+        /// </summary>
+        internal static string FunctionCallBinder_CaseRequiresEvenNumberOfArgs {
+            get {
+                return ResourceManager.GetString("FunctionCallBinder_CaseRequiresEvenNumberOfArgs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Each condition in the &apos;case&apos; function must be a single-value expression..
+        /// </summary>
+        internal static string FunctionCallBinder_CaseConditionMustBeSingleValue {
+            get {
+                return ResourceManager.GetString("FunctionCallBinder_CaseConditionMustBeSingleValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Each result in the &apos;case&apos; function must be a single-value expression..
+        /// </summary>
+        internal static string FunctionCallBinder_CaseResultMustBeSingleValue {
+            get {
+                return ResourceManager.GetString("FunctionCallBinder_CaseResultMustBeSingleValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;:&apos; expected at position {0} in &apos;{1}&apos;..
+        /// </summary>
+        internal static string UriQueryExpressionParser_ColonExpected {
+            get {
+                return ResourceManager.GetString("UriQueryExpressionParser_ColonExpected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The operation overloads matching &apos;{0}&apos; are invalid. This is most likely an error in the IEdmModel..
         /// </summary>
         internal static string FunctionOverloadResolver_FoundInvalidOperation {

--- a/src/Microsoft.OData.Core/SRResources.resx
+++ b/src/Microsoft.OData.Core/SRResources.resx
@@ -2075,6 +2075,18 @@
   <data name="FunctionCallParser_DuplicateParameterOrEntityKeyName" xml:space="preserve">
     <value>Parameter or entity key names must be unique. There is most likely an error in the model.</value>
   </data>
+  <data name="FunctionCallBinder_CaseRequiresEvenNumberOfArgs" xml:space="preserve">
+    <value>The 'case' function requires condition:result pairs, but received {0} argument(s). Each condition must be followed by a colon and a result expression.</value>
+  </data>
+  <data name="FunctionCallBinder_CaseConditionMustBeSingleValue" xml:space="preserve">
+    <value>Each condition in the 'case' function must be a single-value expression.</value>
+  </data>
+  <data name="FunctionCallBinder_CaseResultMustBeSingleValue" xml:space="preserve">
+    <value>Each result in the 'case' function must be a single-value expression.</value>
+  </data>
+  <data name="UriQueryExpressionParser_ColonExpected" xml:space="preserve">
+    <value>':' expected at position {0} in '{1}'.</value>
+  </data>
   <data name="ODataUriParser_InvalidCount" xml:space="preserve">
     <value>'{0}' is not a valid count option.</value>
   </data>

--- a/src/Microsoft.OData.Core/Uri/ExpressionConstants.cs
+++ b/src/Microsoft.OData.Core/Uri/ExpressionConstants.cs
@@ -123,6 +123,9 @@ namespace Microsoft.OData
         /// <summary> "isof function </summary>
         internal const string UnboundFunctionIsOf = "isof";
 
+        /// <summary> "case" conditional function </summary>
+        internal const string UnboundFunctionCase = "case";
+
         /// <summary> Spatial length function </summary>
         internal const string UnboundFunctionLength = "geo.length";
 

--- a/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
@@ -30,6 +30,7 @@ namespace Microsoft.OData.UriParser
         {
             ExpressionConstants.UnboundFunctionCast,
             ExpressionConstants.UnboundFunctionIsOf,
+            ExpressionConstants.UnboundFunctionCase,
         };
 
         /// <summary>
@@ -672,6 +673,12 @@ namespace Microsoft.OData.UriParser
                         break;
                     }
 
+                case ExpressionConstants.UnboundFunctionCase:
+                    {
+                        returnType = ValidateAndBuildCaseArgs(args);
+                        break;
+                    }
+
                 default:
                     {
                         break;
@@ -703,6 +710,48 @@ namespace Microsoft.OData.UriParser
         private static IEdmTypeReference ValidateAndBuildIsOfArgs(BindingState state, ref List<QueryNode> args)
         {
             return ValidateIsOfOrCast(state, false, ref args);
+        }
+
+        /// <summary>
+        /// Validate the arguments for the case conditional function and determine the return type.
+        /// Arguments are expected as alternating condition/result pairs: condition1, result1, condition2, result2, ...
+        /// Each condition must be a boolean expression.
+        /// </summary>
+        /// <param name="args">The list of bound arguments (alternating condition, result pairs).</param>
+        /// <returns>The return type determined from the result expressions.</returns>
+        private static IEdmTypeReference ValidateAndBuildCaseArgs(List<QueryNode> args)
+        {
+            if (args.Count < 2 || args.Count % 2 != 0)
+            {
+                throw new ODataException(Error.Format(SRResources.FunctionCallBinder_CaseRequiresEvenNumberOfArgs, args.Count));
+            }
+
+            IEdmTypeReference returnType = null;
+
+            for (int i = 0; i < args.Count; i += 2)
+            {
+                // Validate condition is a SingleValueNode
+                SingleValueNode conditionNode = args[i] as SingleValueNode;
+                if (conditionNode == null)
+                {
+                    throw new ODataException(SRResources.FunctionCallBinder_CaseConditionMustBeSingleValue);
+                }
+
+                // Validate result is a SingleValueNode
+                SingleValueNode resultNode = args[i + 1] as SingleValueNode;
+                if (resultNode == null)
+                {
+                    throw new ODataException(SRResources.FunctionCallBinder_CaseResultMustBeSingleValue);
+                }
+
+                // Use the type of the first result expression as the return type
+                if (returnType == null && resultNode.TypeReference != null)
+                {
+                    returnType = resultNode.TypeReference;
+                }
+            }
+
+            return returnType;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
@@ -88,6 +88,9 @@ namespace Microsoft.OData.UriParser
         /// <summary>Indicates whether a double-quoted string is being parsed.</summary>
         private bool parsingDoubleQuotedString;
 
+        /// <summary>Whether the lexer should treat ':' as a token delimiter in numeric literals instead of trying to parse TimeOfDay.</summary>
+        private bool colonAsDelimiter;
+
         #endregion Protected and Private fields
 
         #region Constructors
@@ -141,6 +144,17 @@ namespace Microsoft.OData.UriParser
 
         /// <summary>Position on text being parsed.</summary>
         internal int Position => this.token.Position;
+
+        /// <summary>
+        /// Gets or sets whether the lexer should treat ':' as a token delimiter in numeric literals
+        /// instead of trying to parse TimeOfDay. Used when parsing 'case' function arguments where
+        /// ':' separates condition:result pairs.
+        /// </summary>
+        internal bool ColonAsDelimiter
+        {
+            get => this.colonAsDelimiter;
+            set => this.colonAsDelimiter = value;
+        }
 
         #endregion Internal properties
 
@@ -932,7 +946,7 @@ namespace Microsoft.OData.UriParser
                 }
 
                 // TimeOfDay will have ":" in them
-                if (this.ch == ':')
+                if (this.ch == ':' && !this.colonAsDelimiter)
                 {
                     if (this.TryParseTimeOfDay(tokenPos))
                     {

--- a/src/Microsoft.OData.Core/UriParser/Parsers/FunctionCallParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/FunctionCallParser.cs
@@ -187,30 +187,63 @@ namespace Microsoft.OData.UriParser
             Stack<QueryToken> expressionParents = new Stack<QueryToken>();
             bool isFunctionCallNameCastOrIsOf = functionName.Length > 0 &&
                 (functionName.SequenceEqual(ExpressionConstants.UnboundFunctionCast.AsSpan()) || functionName.SequenceEqual(ExpressionConstants.UnboundFunctionIsOf.AsSpan()));
-            List<FunctionParameterToken> argList = new List<FunctionParameterToken>();
-            while (true)
+            bool isFunctionCallNameCase = functionName.Length > 0 &&
+                functionName.SequenceEqual(ExpressionConstants.UnboundFunctionCase.AsSpan());
+
+            // For 'case' function, prevent the lexer from consuming ':' in numeric literals (e.g., 0:1 as TimeOfDay)
+            if (isFunctionCallNameCase)
             {
-                // If we have a parent expression, we need to set the parent of the next argument to the current argument.
-                QueryToken parentExpression = expressionParents.Count > 0 ? expressionParents.Pop() : null;
-                QueryToken parameterToken = this.parser.ParseExpression();
+                this.Lexer.ColonAsDelimiter = true;
+            }
 
-                // If the function call is cast or isof, set the parent of the next argument to the current argument.
-                if (parentExpression != null && isFunctionCallNameCastOrIsOf)
+            List<FunctionParameterToken> argList = new List<FunctionParameterToken>();
+            try
+            {
+                while (true)
                 {
-                    parameterToken = SetParentForCurrentParameterToken(parentExpression, parameterToken);
-                }
+                    // If we have a parent expression, we need to set the parent of the next argument to the current argument.
+                    QueryToken parentExpression = expressionParents.Count > 0 ? expressionParents.Pop() : null;
+                    QueryToken parameterToken = this.parser.ParseExpression();
 
-                argList.Add(new FunctionParameterToken(null, parameterToken));
-                if (this.Lexer.CurrentToken.Kind != ExpressionTokenKind.Comma)
+                    // If the function call is cast or isof, set the parent of the next argument to the current argument.
+                    if (parentExpression != null && isFunctionCallNameCastOrIsOf)
+                    {
+                        parameterToken = SetParentForCurrentParameterToken(parentExpression, parameterToken);
+                    }
+
+                    argList.Add(new FunctionParameterToken(null, parameterToken));
+
+                    // For 'case' function, expect a colon separator between condition and result
+                    if (isFunctionCallNameCase)
+                    {
+                        if (this.Lexer.CurrentToken.Kind != ExpressionTokenKind.Colon)
+                        {
+                            throw new ODataException(Error.Format(SRResources.UriQueryExpressionParser_ColonExpected, this.Lexer.CurrentToken.Position, this.Lexer.ExpressionText));
+                        }
+
+                        this.Lexer.NextToken();
+                        QueryToken resultToken = this.parser.ParseExpression();
+                        argList.Add(new FunctionParameterToken(null, resultToken));
+                    }
+
+                    if (this.Lexer.CurrentToken.Kind != ExpressionTokenKind.Comma)
+                    {
+                        break;
+                    }
+
+                    // In case of comma, we need to parse the next argument
+                    // but first we need to set the parent of the next argument to the current argument.
+                    expressionParents.Push(parameterToken);
+
+                    this.Lexer.NextToken();
+                }
+            }
+            finally
+            {
+                if (isFunctionCallNameCase)
                 {
-                    break;
+                    this.Lexer.ColonAsDelimiter = false;
                 }
-
-                // In case of comma, we need to parse the next argument
-                // but first we need to set the parent of the next argument to the current argument.
-                expressionParents.Push(parameterToken);
-
-                this.Lexer.NextToken();
             }
 
             return argList;

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -3712,6 +3712,64 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
         #endregion
 
+        #region case function tests
+
+        [Fact]
+        public void CaseFunctionWithSingleCondition()
+        {
+            FilterClause filter = ParseFilter("case(ID gt 0:true,true:false) eq true", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            var binaryNode = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
+            var functionCallNode = binaryNode.Left.ShouldBeSingleValueFunctionCallQueryNode("case");
+            Assert.Equal(4, functionCallNode.Parameters.Count());
+            // First pair: condition = ID gt 0, result = true
+            functionCallNode.Parameters.ElementAt(0).ShouldBeBinaryOperatorNode(BinaryOperatorKind.GreaterThan);
+            functionCallNode.Parameters.ElementAt(1).ShouldBeConstantQueryNode(true);
+            // Second pair: condition = true, result = false
+            functionCallNode.Parameters.ElementAt(2).ShouldBeConstantQueryNode(true);
+            functionCallNode.Parameters.ElementAt(3).ShouldBeConstantQueryNode(false);
+        }
+
+        [Fact]
+        public void CaseFunctionWithMultipleConditions()
+        {
+            FilterClause filter = ParseFilter("case(ID gt 100:1,ID gt 10:2,true:3) eq 1", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            var binaryNode = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
+            var functionCallNode = binaryNode.Left.ShouldBeSingleValueFunctionCallQueryNode("case");
+            Assert.Equal(6, functionCallNode.Parameters.Count());
+        }
+
+        [Fact]
+        public void CaseFunctionReturnsTypeOfFirstResult()
+        {
+            FilterClause filter = ParseFilter("case(ID gt 0:1,true:0) eq 1", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            var binaryNode = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
+            var functionCallNode = binaryNode.Left.ShouldBeSingleValueFunctionCallQueryNode("case");
+            Assert.Equal("Edm.Int32", functionCallNode.TypeReference.FullName());
+        }
+
+        [Fact]
+        public void CaseFunctionWithStringResults()
+        {
+            FilterClause filter = ParseFilter("case(ID gt 0:'positive',true:'non-positive') eq 'positive'", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            var binaryNode = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
+            var functionCallNode = binaryNode.Left.ShouldBeSingleValueFunctionCallQueryNode("case");
+            Assert.Equal(4, functionCallNode.Parameters.Count());
+            Assert.Equal("Edm.String", functionCallNode.TypeReference.FullName());
+        }
+
+        [Fact]
+        public void CaseFunctionWithPropertyResults()
+        {
+            FilterClause filter = ParseFilter("case(ID gt 0:Shoe,true:'unknown') eq 'test'", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            var binaryNode = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
+            var functionCallNode = binaryNode.Left.ShouldBeSingleValueFunctionCallQueryNode("case");
+            Assert.Equal(4, functionCallNode.Parameters.Count());
+            functionCallNode.Parameters.ElementAt(2).ShouldBeConstantQueryNode(true);
+            functionCallNode.Parameters.ElementAt(1).ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPersonShoeProp());
+        }
+
+        #endregion
+
         private static FilterClause ParseFilter(string text, IEdmModel edmModel, IEdmType edmType, IEdmNavigationSource edmEntitySet = null)
         {
             return new ODataQueryOptionParser(edmModel, edmType, edmEntitySet, new Dictionary<string, string>() { { "$filter", text } }) { Resolver = new ODataUriResolver() { EnableCaseInsensitive = false } }.ParseFilter();


### PR DESCRIPTION
Implement the OData V4.01 'case' conditional function (section 5.1.1.12) in the URI parser for use in $filter and $compute expressions.

Syntax: case(condition1:result1, condition2:result2, ..., true:default)
Example: $filter=case(ID gt 0:1,ID lt 0:-1,true:0) eq 1

Changes:
- Add 'case' as an unbound function in ExpressionConstants and FunctionCallBinder
- Parse colon-separated condition:result pairs in FunctionCallParser
- Add ColonAsDelimiter flag to ExpressionLexer to prevent digit:digit sequences from being misinterpreted as TimeOfDay literals
- Validate case arguments (even count, single-value expressions)
- Determine return type from first result expression
- Add end-to-end tests for case function in filter expressions

Fixes #2309

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
