### PR TITLE
test: Add comprehensive test coverage for matchesPattern built-in function

### DIFF
--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2654,6 +2654,37 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void MatchesPatternInFilterWithTheReturnType()
+        {
+            // Arrange & Act - Filter people whose names match capitalized pattern
+            var filterClause = ParseFilter("matchesPattern(Name, '^[A-Z][a-z]+$')", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            // Assert
+            var functionCallNode = filterClause.Expression.ShouldBeSingleValueFunctionCallQueryNode("matchesPattern");
+            Assert.Equal(2, functionCallNode.Parameters.Count());
+            Assert.True(functionCallNode.TypeReference.IsBoolean());
+
+            // Verify first parameter is the Name property
+            functionCallNode.Parameters.ElementAt(0)
+                .ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPersonNameProp());
+
+            // Verify second parameter is the regex pattern
+            functionCallNode.Parameters.ElementAt(1).ShouldBeConstantQueryNode("^[A-Z][a-z]+$");
+        }
+
+        [Fact]
+        public void MatchesPatternInFilterWithBooleanComparison()
+        {
+            // Arrange & Act - Use matchesPattern in boolean expression
+            var filterClause = ParseFilter("matchesPattern(Name, '[0-9]+') eq true", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            // Assert
+            var binaryOp = filterClause.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
+            binaryOp.Left.ShouldBeSingleValueFunctionCallQueryNode("matchesPattern");
+            binaryOp.Right.ShouldBeConstantQueryNode(true);
+        }
+
+        [Fact]
         public void FilterWithInOperationWithAny()
         {
             // https://github.com/OData/odata.net/issues/1447

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Binders/FunctionCallBinderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Binders/FunctionCallBinderTests.cs
@@ -1298,6 +1298,32 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         }
 
         [Fact]
+        public void MatchesPatternFunctionBindsCorrectly()
+        {
+            // Arrange
+            var arguments = new List<QueryToken>()
+            {
+                new EndPathToken("Name", new RangeVariableToken(ExpressionConstants.It)),
+                new LiteralToken(@"^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$")
+            };
+            var token = new FunctionCallToken("matchesPattern", arguments);
+
+            // Act
+            var result = functionCallBinder.BindFunctionCall(token);
+
+            // Assert
+            var functionCallNode = result.ShouldBeSingleValueFunctionCallQueryNode("matchesPattern", EdmCoreModel.Instance.GetBoolean(false));
+            Assert.Equal(2, functionCallNode.Parameters.Count());
+            Assert.True(functionCallNode.TypeReference.IsBoolean());
+
+            // Verify first parameter is the Name property
+            functionCallNode.Parameters.ElementAt(0).ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPersonNameProp());
+
+            // Verify second parameter is the regex pattern
+            functionCallNode.Parameters.ElementAt(1).ShouldBeConstantQueryNode(@"^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$");
+        }
+
+        [Fact]
         public void GetUriFunction_CombineCustomFunctionsAndBuiltInFunctions()
         {
             const string BUILT_IN_GEODISTANCE_FUNCTION_NAME = "geo.distance";


### PR DESCRIPTION
'MatchesPattern' function call was added at https://github.com/OData/odata.net/pull/2519.

This PR is to add more test cases to verify the changes.

New Test Cases:

FunctionCallBinderTests.cs - MatchesPatternFunctionBindsCorrectly: Tests binder layer binding, validates two string parameters, verifies Edm.Boolean return type

FilterAndOrderByFunctionalTests.cs - MatchesPatternInFilterWithTheReturnType: Tests complete filter parsing pipeline with Name property, query: matchesPattern(Name, '^[A-Z][a-z]+dollar'), validates property access and pattern parameters

FilterAndOrderByFunctionalTests.cs - MatchesPatternInFilterWithBooleanComparison: Tests matchesPattern in boolean expression, query: matchesPattern(Name, '[0-9]+') eq true

Coverage: Binder layer, filter parser end-to-end, property access parameters, literal patterns, boolean expressions, return type validation. matchesPattern was added in commit 023bede05 (PR #2519) by Avi Levin on Oct 24, 2022.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
