### PR TITLE
Convert string parameters and return types to ReadOnlyMemory<char> URI parsers and lexers

### DIFF
--- a/src/Microsoft.OData.Client/BaseEntityType.cs
+++ b/src/Microsoft.OData.Client/BaseEntityType.cs
@@ -16,6 +16,7 @@ namespace Microsoft.OData.Client
         /// </summary>
         protected internal DataServiceContext Context { get; set; }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1033:Interface methods should be callable by child types", Justification = "<Pending>")]
         DataServiceContext IBaseEntityType.DataServiceContext
         {
             get => Context;

--- a/src/Microsoft.OData.Client/BaseEntityType.cs
+++ b/src/Microsoft.OData.Client/BaseEntityType.cs
@@ -16,7 +16,8 @@ namespace Microsoft.OData.Client
         /// </summary>
         protected internal DataServiceContext Context { get; set; }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1033:Interface methods should be callable by child types", Justification = "<Pending>")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1033:Interface methods should be callable by child types",
+            Justification = "Implemented explicitly to satisfy IBaseEntityType without exposing DataServiceContext on the public API; derived types access the same value through the protected internal Context property.")]
         DataServiceContext IBaseEntityType.DataServiceContext
         {
             get => Context;

--- a/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
+++ b/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.OData.Metadata
         private static readonly Dictionary<Type, IEdmPrimitiveTypeReference> PrimitiveTypeReferenceMap = new Dictionary<Type, IEdmPrimitiveTypeReference>(EqualityComparer<Type>.Default);
 
         /// <summary>
-        /// Packs the <see cref="TypeCode"/> of supported primitive types. This is used to speed up the <see cref="IsPrimitiveType(Type)"/> method.
+        /// Packs the <see cref="TypeCode"/> of supported primitive types. This is used to speed up the "IsPrimitiveType(Type)" method.
         /// If the bit at a given type code position is set, it means that's a support primitive type.
         /// </summary>
         private static int PrimitiveTypeCodeBitMap = 0;

--- a/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1922,6 +1922,7 @@ Microsoft.OData.UriParser.UriPathParser
 Microsoft.OData.UriParser.UriPathParser.UriPathParser(Microsoft.OData.UriParser.ODataUriParserSettings settings) -> void
 Microsoft.OData.UriParser.UriQueryExpressionParser
 Microsoft.OData.UriParser.UriQueryExpressionParser.ParseFilter(string filter) -> Microsoft.OData.UriParser.QueryToken
+Microsoft.OData.UriParser.UriQueryExpressionParser.ParseFilter(System.ReadOnlyMemory<char> filter) -> Microsoft.OData.UriParser.QueryToken
 Microsoft.OData.UriParser.UriQueryExpressionParser.UriQueryExpressionParser(Microsoft.OData.Edm.IEdmModel model, int maxDepth) -> void
 Microsoft.OData.UriParser.UriTemplateExpression
 Microsoft.OData.UriParser.UriTemplateExpression.ExpectedType.get -> Microsoft.OData.Edm.IEdmTypeReference

--- a/src/Microsoft.OData.Core/UriParser/Binders/EnumBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/EnumBinder.cs
@@ -40,9 +40,9 @@ namespace Microsoft.OData.UriParser
         /// <param name="modelWhenNoTypeReference">the current model when no enum typeReference.</param>
         /// <param name="boundEnum">an enum node .</param>
         /// <returns>true if we bound an enum for this token.</returns>
-        internal static bool TryBindIdentifier(string identifier, IEdmEnumTypeReference typeReference, IEdmModel modelWhenNoTypeReference, out QueryNode boundEnum)
+        internal static bool TryBindIdentifier(ReadOnlyMemory<char> identifier, IEdmEnumTypeReference typeReference, IEdmModel modelWhenNoTypeReference, out QueryNode boundEnum)
         {
-            return TryBindIdentifier(identifier.AsMemory(), typeReference, modelWhenNoTypeReference, null, out boundEnum);
+            return TryBindIdentifier(identifier, typeReference, modelWhenNoTypeReference, null, out boundEnum);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.OData.UriParser
         #region Protected and Private fields
 
         /// <summary>Text being parsed.</summary>
-        protected readonly string Text;
+        protected readonly ReadOnlyMemory<char> Text;
 
         /// <summary>Length of text being parsed.</summary>
         protected readonly int TextLen;
@@ -105,6 +105,11 @@ namespace Microsoft.OData.UriParser
         {
         }
 
+        internal ExpressionLexer(IEdmModel model, ReadOnlyMemory<char> expression, bool moveToFirstToken, bool useSemicolonDelimiter)
+            : this(model, expression, moveToFirstToken, useSemicolonDelimiter, parsingFunctionParameters: false)
+        {
+        }
+
         /// <summary>Initializes a new <see cref="ExpressionLexer"/>.</summary>
         /// <param name="model">The Edm model associated with this lexer, used when resolving custom URI literal prefixes.</param>
         /// <param name="expression">Expression to parse.</param>
@@ -112,9 +117,13 @@ namespace Microsoft.OData.UriParser
         /// <param name="useSemicolonDelimiter">If true, the lexer will tokenize based on semicolons as well.</param>
         /// <param name="parsingFunctionParameters">Whether the lexer is being used to parse function parameters. If true, will allow/recognize parameter aliases and typed nulls.</param>
         internal ExpressionLexer(IEdmModel model, string expression, bool moveToFirstToken, bool useSemicolonDelimiter, bool parsingFunctionParameters)
+            : this (model, expression.AsMemory(), moveToFirstToken, useSemicolonDelimiter, parsingFunctionParameters)
+        {
+        }
+
+        internal ExpressionLexer(IEdmModel model, ReadOnlyMemory<char> expression, bool moveToFirstToken, bool useSemicolonDelimiter, bool parsingFunctionParameters)
         {
             Debug.Assert(model != null, "model != null");
-            Debug.Assert(expression != null, "expression != null");
 
             this.model = model;
             this.ignoreWhitespace = true;
@@ -144,10 +153,13 @@ namespace Microsoft.OData.UriParser
         }
 
         /// <summary>Text being parsed.</summary>
-        internal string ExpressionText => this.Text;
+        internal ReadOnlyMemory<char> ExpressionText => this.Text;
+
+        /// <summary>Position on current token being parsed.</summary>
+        internal int Position => this.token.Position;
 
         /// <summary>Position on text being parsed.</summary>
-        internal int Position => this.token.Position;
+        internal int TextPosition => this.textPos;
 
         #endregion Internal properties
 
@@ -252,11 +264,11 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         /// <param name="acceptStar">do we allow a star in this identifier</param>
         /// <returns>The dotted identifier starting at the current identifier.</returns>
-        internal ReadOnlySpan<char> ReadDottedIdentifier(bool acceptStar)
+        internal ReadOnlyMemory<char> ReadDottedIdentifier(bool acceptStar)
         {
             this.ValidateToken(ExpressionTokenKind.Identifier);
 
-            ReadOnlySpan<char> result = this.CurrentToken.Span;
+            ReadOnlyMemory<char> result = this.CurrentToken.Text;
             int position = this.CurrentToken.Position;
             int oldLength = this.CurrentToken.Length;
             int length = this.CurrentToken.Length;
@@ -288,7 +300,7 @@ namespace Microsoft.OData.UriParser
 
             if (oldLength != length)
             {
-                return this.Text.AsSpan(position, length);
+                return this.Text.Slice(position, length);
             }
 
             return result;
@@ -352,7 +364,7 @@ namespace Microsoft.OData.UriParser
 
             if (matched)
             {
-                this.token.Text = this.Text.AsMemory(tokenStartPos, this.textPos - tokenStartPos);
+                this.token.Text = this.Text.Slice(tokenStartPos, this.textPos - tokenStartPos);
                 this.token.Position = tokenStartPos;
             }
             else
@@ -383,10 +395,10 @@ namespace Microsoft.OData.UriParser
         /// The CurrentToken of the lexer after this method call will be whatever comes after the advanced text.
         /// </summary>
         /// <returns>All of the text that was read.</returns>
-        internal string AdvanceThroughExpandOption()
+        internal ReadOnlyMemory<char> AdvanceThroughExpandOption()
         {
             int startingPosition = this.textPos;
-            string textToReturn;
+            ReadOnlyMemory<char> textToReturn;
 
             while (true)
             {
@@ -404,13 +416,13 @@ namespace Microsoft.OData.UriParser
 
                 if (this.ch == ';' || this.ch == ')')
                 {
-                    textToReturn = this.Text.Substring(startingPosition, this.textPos - startingPosition);
+                    textToReturn = this.Text.Slice(startingPosition, this.textPos - startingPosition);
                     break;
                 }
 
                 if (this.ch == null)
                 {
-                    textToReturn = this.Text.Substring(startingPosition);
+                    textToReturn = this.Text.Slice(startingPosition);
                     break;
                 }
 
@@ -434,16 +446,11 @@ namespace Microsoft.OData.UriParser
         ///    For this reason, you probably want to call NextToken() after this method, since CurrentToken wil be garbage.
         /// </remarks>
         /// <returns>The parenthesis expression, including the outer parenthesis.</returns>
-        internal string AdvanceThroughBalancedParentheticalExpression()
+        internal ReadOnlyMemory<char> AdvanceThroughBalancedParentheticalExpression()
         {
             int startPosition = this.Position;
             this.AdvanceThroughBalancedExpression('(', ')');
-            string expressionText = this.Text.Substring(startPosition, this.textPos - startPosition);
-
-            //// TODO: Consider introducing a token type and setting up the current token instead of returning string.
-            //// We've done weird stuff, and the state of hte lexer is weird now. All will be well once NextToken() is called,
-            //// but until then CurrentToken is stale and misleading.
-
+            ReadOnlyMemory<char> expressionText = this.Text.Slice(startPosition, this.textPos - startPosition);
             return expressionText;
         }
 
@@ -499,7 +506,8 @@ namespace Microsoft.OData.UriParser
                 this.textPos++;
                 if (this.textPos < this.TextLen)
                 {
-                    this.ch = this.Text[this.textPos];
+                    // Accessing the .Span property is a near-instant, O(1) operation with no heap allocations.
+                    this.ch = this.Text.Span[this.textPos];
                     return;
                 }
             }
@@ -572,7 +580,7 @@ namespace Microsoft.OData.UriParser
                     break;
                 case '-':
                     bool hasNext = this.textPos + 1 < this.TextLen;
-                    if (hasNext && Char.IsDigit(this.Text[this.textPos + 1]))
+                    if (hasNext && Char.IsDigit(this.Text.Span[this.textPos + 1]))
                     {
                         // don't separate '-' and its following digits : -2147483648 is valid int.MinValue, but 2147483648 is long.
                         t = this.ParseFromDigit();
@@ -585,12 +593,11 @@ namespace Microsoft.OData.UriParser
                         // we'll rewind and fall through to a simple '-' token.
                         this.SetTextPos(tokenPos);
                     }
-                    else if (hasNext && this.Text[tokenPos + 1] == ExpressionConstants.InfinityLiteral[0])
+                    else if (hasNext && this.Text.Span[tokenPos + 1] == ExpressionConstants.InfinityLiteral[0])
                     {
                         this.NextChar();
                         this.ParseIdentifier();
-                        string currentIdentifier = this.Text.Substring(tokenPos + 1, this.textPos - tokenPos - 1);
-
+                        ReadOnlySpan<char> currentIdentifier = this.Text.Slice(tokenPos + 1, this.textPos - tokenPos - 1).Span;
                         if (ExpressionLexerUtils.IsInfinityLiteralDouble(currentIdentifier))
                         {
                             t = ExpressionTokenKind.DoubleLiteral;
@@ -728,10 +735,10 @@ namespace Microsoft.OData.UriParser
                         this.ParseIdentifier(true /*includingDots*/);
 
                         // Extract the identifier from expression.
-                        string leftToken = ExpressionText.Substring(start, this.textPos - start);
+                        ReadOnlyMemory<char> leftToken = ExpressionText.Slice(start, this.textPos - start);
 
 
-                        t = this.parsingFunctionParameters && !leftToken.Contains(".", StringComparison.Ordinal)
+                        t = this.parsingFunctionParameters && !leftToken.Span.Contains(".", StringComparison.Ordinal)
                             ? ExpressionTokenKind.ParameterAlias
                             : ExpressionTokenKind.Identifier;
                         break;
@@ -743,7 +750,7 @@ namespace Microsoft.OData.UriParser
             }
 
             this.token.Kind = t;
-            this.token.Text = this.Text.AsMemory(tokenPos, this.textPos - tokenPos);
+            this.token.Text = this.Text.Slice(tokenPos, this.textPos - tokenPos);
             this.token.Position = tokenPos;
 
             this.HandleTypePrefixedLiterals();
@@ -829,7 +836,7 @@ namespace Microsoft.OData.UriParser
             while (this.ch.HasValue && this.ch == '\'');
 
             // Update token.Text to include the literal + the quoted value
-            this.token.Text = this.Text.AsMemory(startPosition, this.textPos - startPosition);
+            this.token.Text = this.Text.Slice(startPosition, this.textPos - startPosition);
         }
 
         /// <summary>
@@ -1009,8 +1016,8 @@ namespace Microsoft.OData.UriParser
                 }
                 else
                 {
-                    string valueStr = this.Text.Substring(tokenPos, this.textPos - tokenPos);
-                    result = MakeBestGuessOnNoSuffixStr(valueStr, result);
+                    ReadOnlyMemory<char> valueStr = this.Text.Slice(tokenPos, this.textPos - tokenPos);
+                    result = MakeBestGuessOnNoSuffixStr(valueStr.Span, result);
                 }
             }
 
@@ -1037,7 +1044,7 @@ namespace Microsoft.OData.UriParser
             else
             {
                 this.textPos = initialIndex;
-                this.ch = this.Text[initialIndex];
+                this.ch = this.Text.Span[initialIndex];
                 return false;
             }
         }
@@ -1062,7 +1069,7 @@ namespace Microsoft.OData.UriParser
             else
             {
                 this.textPos = initialIndex;
-                this.ch = this.Text[initialIndex];
+                this.ch = this.Text.Span[initialIndex];
                 return false;
             }
         }
@@ -1078,7 +1085,7 @@ namespace Microsoft.OData.UriParser
             else
             {
                 this.textPos = initialIndex;
-                this.ch = this.Text[initialIndex];
+                this.ch = this.Text.Span[initialIndex];
                 return false;
             }
         }
@@ -1102,7 +1109,7 @@ namespace Microsoft.OData.UriParser
             else
             {
                 this.textPos = initialIndex;
-                this.ch = this.Text[initialIndex];
+                this.ch = this.Text.Span[initialIndex];
                 return false;
             }
         }
@@ -1125,7 +1132,7 @@ namespace Microsoft.OData.UriParser
                 this.NextChar();
             }
 
-            return this.Text.AsSpan(tokenPos, this.textPos - tokenPos);
+            return this.Text.Slice(tokenPos, this.textPos - tokenPos).Span;
         }
 
         /// <summary>
@@ -1262,7 +1269,7 @@ namespace Microsoft.OData.UriParser
         private void SetTextPos(int pos)
         {
             this.textPos = pos;
-            this.ch = this.textPos < this.TextLen ? this.Text[this.textPos] : (char?)null;
+            this.ch = this.textPos < this.TextLen ? this.Text.Span[this.textPos] : (char?)null;
         }
 
         /// <summary>Validates the current character is a digit.</summary>
@@ -1276,7 +1283,7 @@ namespace Microsoft.OData.UriParser
 
         private void DoubleQuotedStringCheckpoint()
         {
-            if (this.textPos != 0 && this.Text[this.textPos - 1] != '\\')
+            if (this.textPos != 0 && this.Text.Span[this.textPos - 1] != '\\')
             {
                 this.parsingDoubleQuotedString = !this.parsingDoubleQuotedString;
             }

--- a/src/Microsoft.OData.Core/UriParser/ExpressionToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionToken.cs
@@ -94,7 +94,7 @@ namespace Microsoft.OData.UriParser
 
         /// <summary>Gets the current identifier text.</summary>
         /// <returns>The current identifier text.</returns>
-        internal ReadOnlySpan<char> GetIdentifier()
+        internal ReadOnlyMemory<char> GetIdentifier()
         {
             if (this.Kind != ExpressionTokenKind.Identifier)
             {
@@ -103,7 +103,7 @@ namespace Microsoft.OData.UriParser
             }
 
             Debug.Assert(!this.Text.IsEmpty, "Text is null");
-            return this.Span;
+            return this.Text;
         }
 
         /// <summary>Checks that this token has the specified identifier.</summary>

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -426,7 +426,7 @@ namespace Microsoft.OData.UriParser
                 configuration.Model,
                 configuration.Settings.FilterLimit,
                 configuration.EnableCaseInsensitiveUriFunctionIdentifier);
-            var applyTokens = expressionParser.ParseApply(apply);
+            var applyTokens = expressionParser.ParseApply(apply.AsMemory());
 
             // Bind it to metadata
             BindingState state = new BindingState(configuration, odataPathInfo.Segments.ToList());
@@ -457,7 +457,7 @@ namespace Microsoft.OData.UriParser
             SelectToken selectTree;
 
             // syntactic pass , pass in the expand parent entity type name, in case expand option contains star, will get all the parent entity navigation properties (both declared and dynamical).
-            SelectExpandSyntacticParser.Parse(select, expand, odataPathInfo.TargetStructuredType, configuration, out expandTree, out selectTree);
+            SelectExpandSyntacticParser.Parse(select.AsMemory(), expand.AsMemory(), odataPathInfo.TargetStructuredType, configuration, out expandTree, out selectTree);
 
             // semantic pass
             BindingState state = CreateBindingState(configuration, odataPathInfo);
@@ -483,7 +483,7 @@ namespace Microsoft.OData.UriParser
                 configuration.Model,
                 configuration.Settings.OrderByLimit,
                 configuration.EnableCaseInsensitiveUriFunctionIdentifier);
-            var orderByQueryTokens = expressionParser.ParseOrderBy(orderBy);
+            var orderByQueryTokens = expressionParser.ParseOrderBy(orderBy.AsMemory());
 
             // Bind it to metadata
             BindingState state = CreateBindingState(configuration, odataPathInfo);
@@ -633,7 +633,7 @@ namespace Microsoft.OData.UriParser
             ExceptionUtils.CheckArgumentNotNull(search, "search");
 
             SearchParser searchParser = new SearchParser(configuration.Model, configuration.Settings.SearchLimit);
-            QueryToken queryToken = searchParser.ParseSearch(search);
+            QueryToken queryToken = searchParser.ParseSearch(search.AsMemory());
 
             // Bind it to metadata
             BindingState state = new BindingState(configuration);
@@ -661,7 +661,7 @@ namespace Microsoft.OData.UriParser
                 configuration.Model,
                 configuration.Settings.FilterLimit,
                 configuration.EnableCaseInsensitiveUriFunctionIdentifier);
-            ComputeToken computeToken = expressionParser.ParseCompute(compute);
+            ComputeToken computeToken = expressionParser.ParseCompute(compute.AsMemory());
 
             // Bind it to metadata
             BindingState state = CreateBindingState(configuration, odataPathInfo);

--- a/src/Microsoft.OData.Core/UriParser/Parsers/CountSegmentParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/CountSegmentParser.cs
@@ -118,7 +118,7 @@ namespace Microsoft.OData.UriParser
         {
             // advance to the equal sign
             this.lexer.NextToken();
-            string filterText = UriParserHelper.ReadQueryOption(this.lexer);
+            ReadOnlyMemory<char> filterText = UriParserHelper.ReadQueryOption(this.lexer);
 
             UriQueryExpressionParser filterParser = new UriQueryExpressionParser(this.UriQueryExpressionParser.Model, ODataUriParserSettings.DefaultFilterLimit, this.UriQueryExpressionParser.EnableCaseInsensitiveBuiltinIdentifier);
             return filterParser.ParseFilter(filterText);
@@ -132,7 +132,7 @@ namespace Microsoft.OData.UriParser
         {
             // advance to the equal sign
             this.lexer.NextToken();
-            string searchText = UriParserHelper.ReadQueryOption(this.lexer);
+            ReadOnlyMemory<char> searchText = UriParserHelper.ReadQueryOption(this.lexer);
 
             SearchParser searchParser = new SearchParser(this.UriQueryExpressionParser.Model, ODataUriParserSettings.DefaultSearchLimit);
             return searchParser.ParseSearch(searchText);

--- a/src/Microsoft.OData.Core/UriParser/Parsers/FunctionCallParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/FunctionCallParser.cs
@@ -86,7 +86,7 @@ namespace Microsoft.OData.UriParser
         public bool TryParseIdentifierAsFunction(QueryToken parent, out QueryToken result)
         {
             result = null;
-            ReadOnlySpan<char> functionName;
+            ReadOnlyMemory<char> functionName;
 
             ExpressionLexer.ExpressionLexerPosition position = lexer.SnapshotPosition();
 
@@ -98,11 +98,11 @@ namespace Microsoft.OData.UriParser
             else
             {
                 Debug.Assert(this.Lexer.CurrentToken.Kind == ExpressionTokenKind.Identifier, "Only identifier tokens can be treated as function calls.");
-                functionName = this.Lexer.CurrentToken.Span;
+                functionName = this.Lexer.CurrentToken.Text;
                 this.Lexer.NextToken();
             }
 
-            FunctionParameterToken[] arguments = this.ParseArgumentListOrEntityKeyList(() => lexer.RestorePosition(position), functionName);
+            FunctionParameterToken[] arguments = this.ParseArgumentListOrEntityKeyList(() => lexer.RestorePosition(position), functionName.Span);
             if (arguments != null)
             {
                 result = new FunctionCallToken(functionName.ToString(), arguments, parent);

--- a/src/Microsoft.OData.Core/UriParser/Parsers/FunctionParameterParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/FunctionParameterParser.cs
@@ -79,7 +79,7 @@ namespace Microsoft.OData.UriParser
             while (currentToken.Kind != endTokenKind)
             {
                 lexer.ValidateToken(ExpressionTokenKind.Identifier);
-                ReadOnlySpan<char> identifier = lexer.CurrentToken.GetIdentifier();
+                ReadOnlyMemory<char> identifier = lexer.CurrentToken.GetIdentifier();
                 lexer.NextToken();
 
                 lexer.ValidateToken(ExpressionTokenKind.Equal);

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SearchParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SearchParser.cs
@@ -58,10 +58,10 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         /// <param name="expressionText">The expression string to Parse.</param>
         /// <returns>The lexical token representing the expression text.</returns>
-        internal QueryToken ParseSearch(string expressionText)
-        {
-            Debug.Assert(expressionText != null, "expressionText != null");
+        internal QueryToken ParseSearch(string expressionText) => ParseSearch(expressionText.AsMemory());
 
+        internal QueryToken ParseSearch(ReadOnlyMemory<char> expressionText)
+        {
             this.recursionDepth = 0;
             this.lexer = new SearchLexer(this.model, expressionText);
             QueryToken result = this.ParseExpression();

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SegmentArgumentParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SegmentArgumentParser.cs
@@ -239,7 +239,7 @@ namespace Microsoft.OData.UriParser
             if (typeReference.IsEnum())
             {
                 QueryNode enumNode = null;
-                if (EnumBinder.TryBindIdentifier(valueText, typeReference.AsEnum(), null, out enumNode))
+                if (EnumBinder.TryBindIdentifier(valueText.AsMemory(), typeReference.AsEnum(), null, out enumNode))
                 {
                     convertedValue = ((ConstantNode)enumNode).Value;
                     return true;

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandOptionParser.cs
@@ -117,9 +117,12 @@ namespace Microsoft.OData.UriParser
         /// <param name="optionsText">A string of the text between the parenthesis after a select option.</param>
         /// <returns>The select term token based on the path token, and all available select options.</returns>
         internal SelectTermToken BuildSelectTermToken(PathSegmentToken pathToken, string optionsText)
+            => BuildSelectTermToken(pathToken, optionsText.AsMemory());
+
+        internal SelectTermToken BuildSelectTermToken(PathSegmentToken pathToken, ReadOnlyMemory<char> optionsText)
         {
             // Setup a new lexer for parsing the optionsText
-            this.lexer = new ExpressionLexer(this.model, expression: optionsText ?? "", moveToFirstToken: true, useSemicolonDelimiter: true);
+            this.lexer = new ExpressionLexer(this.model, expression: optionsText, moveToFirstToken: true, useSemicolonDelimiter: true);
 
             QueryToken filterOption = null;
             IEnumerable<OrderByToken> orderByOptions = null;
@@ -215,9 +218,12 @@ namespace Microsoft.OData.UriParser
         /// <param name="optionsText">A string of the text between the parenthesis after an expand option.</param>
         /// <returns>The list of expand term tokens based on the path token, and all available expand options.</returns>
         internal List<ExpandTermToken> BuildExpandTermToken(PathSegmentToken pathToken, string optionsText)
+            => BuildExpandTermToken(pathToken, optionsText.AsMemory());
+
+        internal List<ExpandTermToken> BuildExpandTermToken(PathSegmentToken pathToken, ReadOnlyMemory<char> optionsText)
         {
             // Setup a new lexer for parsing the optionsText
-            this.lexer = new ExpressionLexer(this.model, expression: optionsText ?? "", moveToFirstToken: true, useSemicolonDelimiter: true);
+            this.lexer = new ExpressionLexer(this.model, expression: optionsText, moveToFirstToken: true, useSemicolonDelimiter: true);
 
             // $expand option with star only support $ref option, $expand option property could be "*" or "*/$ref", special logic will be adopted.
             if (pathToken.Identifier == UriQueryConstants.Star || (pathToken.Identifier == UriQueryConstants.RefSegment && pathToken.NextToken.Identifier == UriQueryConstants.Star))
@@ -449,7 +455,7 @@ namespace Microsoft.OData.UriParser
         {
             // advance to the equal sign
             this.lexer.NextToken();
-            string filterText = UriParserHelper.ReadQueryOption(this.lexer);
+            ReadOnlyMemory<char> filterText = UriParserHelper.ReadQueryOption(this.lexer);
 
             UriQueryExpressionParser filterParser = new UriQueryExpressionParser(this.model, this.MaxFilterDepth, enableCaseInsensitiveBuiltinIdentifier);
             return filterParser.ParseFilter(filterText);
@@ -463,7 +469,7 @@ namespace Microsoft.OData.UriParser
         {
             // advance to the equal sign
             this.lexer.NextToken();
-            string orderByText = UriParserHelper.ReadQueryOption(this.lexer);
+            ReadOnlyMemory<char> orderByText = UriParserHelper.ReadQueryOption(this.lexer);
 
             UriQueryExpressionParser orderbyParser = new UriQueryExpressionParser(this.model, this.MaxOrderByDepth, enableCaseInsensitiveBuiltinIdentifier);
             return orderbyParser.ParseOrderBy(orderByText);
@@ -477,13 +483,13 @@ namespace Microsoft.OData.UriParser
         {
             // advance to the equal sign
             this.lexer.NextToken();
-            string topText = UriParserHelper.ReadQueryOption(this.lexer);
+            ReadOnlyMemory<char> topText = UriParserHelper.ReadQueryOption(this.lexer);
 
             // TryParse requires a non-nullable non-negative long.
             long top;
-            if (!long.TryParse(topText, out top) || top < 0)
+            if (!long.TryParse(topText.Span, out top) || top < 0)
             {
-                throw new ODataException(Error.Format(SRResources.UriSelectParser_InvalidTopOption, topText));
+                throw new ODataException(Error.Format(SRResources.UriSelectParser_InvalidTopOption, topText.ToString()));
             }
 
             return top;
@@ -497,13 +503,13 @@ namespace Microsoft.OData.UriParser
         {
             // advance to the equal sign
             this.lexer.NextToken();
-            string skipText = UriParserHelper.ReadQueryOption(this.lexer);
+            ReadOnlyMemory<char> skipText = UriParserHelper.ReadQueryOption(this.lexer);
 
             // TryParse requires a non-nullable non-negative long.
             long skip;
-            if (!long.TryParse(skipText, out skip) || skip < 0)
+            if (!long.TryParse(skipText.Span, out skip) || skip < 0)
             {
-                throw new ODataException(Error.Format(SRResources.UriSelectParser_InvalidSkipOption, skipText));
+                throw new ODataException(Error.Format(SRResources.UriSelectParser_InvalidSkipOption, skipText.ToString()));
             }
 
             return skip;
@@ -517,17 +523,19 @@ namespace Microsoft.OData.UriParser
         {
             // advance to the equal sign
             this.lexer.NextToken();
-            string countText = UriParserHelper.ReadQueryOption(this.lexer);
-            switch (countText)
+            ReadOnlySpan<char> countText = UriParserHelper.ReadQueryOption(this.lexer).Span;
+
+            if (countText.Equals(ExpressionConstants.KeywordTrue, StringComparison.Ordinal))
             {
-                case ExpressionConstants.KeywordTrue:
-                    return true;
-
-                case ExpressionConstants.KeywordFalse:
-                    return false;
-
-                default:
-                    throw new ODataException(Error.Format(SRResources.UriSelectParser_InvalidCountOption, countText));
+                return true;
+            }
+            else if (countText.Equals(ExpressionConstants.KeywordFalse, StringComparison.Ordinal))
+            {
+                return false;
+            }
+            else
+            {
+                throw new ODataException(Error.Format(SRResources.UriSelectParser_InvalidCountOption, countText.ToString()));
             }
         }
 
@@ -539,7 +547,7 @@ namespace Microsoft.OData.UriParser
         {
             // advance to the equal sign
             this.lexer.NextToken();
-            string searchText = UriParserHelper.ReadQueryOption(this.lexer);
+            ReadOnlyMemory<char> searchText = UriParserHelper.ReadQueryOption(this.lexer);
 
             SearchParser searchParser = new SearchParser(this.model, this.MaxSearchDepth);
             return searchParser.ParseSearch(searchText);
@@ -554,7 +562,7 @@ namespace Microsoft.OData.UriParser
         {
             // advance to the equal sign
             this.lexer.NextToken();
-            string selectText = UriParserHelper.ReadQueryOption(this.lexer);
+            ReadOnlyMemory<char> selectText = UriParserHelper.ReadQueryOption(this.lexer);
 
             IEdmStructuredType targetStructuredType = null;
             if (this.resolver != null && this.parentStructuredType != null)
@@ -591,7 +599,7 @@ namespace Microsoft.OData.UriParser
             // advance to the equal sign
             this.lexer.NextToken();
 
-            string expandText = UriParserHelper.ReadQueryOption(this.lexer);
+            ReadOnlyMemory<char> expandText = UriParserHelper.ReadQueryOption(this.lexer);
 
             IEdmStructuredType targetStructuredType = null;
             if (this.resolver != null && this.parentStructuredType != null)
@@ -630,19 +638,17 @@ namespace Microsoft.OData.UriParser
 
             // advance to the equal sign
             this.lexer.NextToken();
-            string levelsText = UriParserHelper.ReadQueryOption(this.lexer);
+            ReadOnlySpan<char> levelsText = UriParserHelper.ReadQueryOption(this.lexer).Span;
             long level;
 
-            if (string.Equals(
-                ExpressionConstants.KeywordMax,
-                levelsText,
+            if (levelsText.Equals(ExpressionConstants.KeywordMax,
                 this.enableCaseInsensitiveBuiltinIdentifier ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
             {
                 levelsOption = long.MinValue;
             }
             else if (!long.TryParse(levelsText, NumberStyles.None, CultureInfo.InvariantCulture, out level) || level < 0)
             {
-                throw new ODataException(Error.Format(SRResources.UriSelectParser_InvalidLevelsOption, levelsText));
+                throw new ODataException(Error.Format(SRResources.UriSelectParser_InvalidLevelsOption, levelsText.ToString()));
             }
             else
             {
@@ -659,7 +665,7 @@ namespace Microsoft.OData.UriParser
         private ComputeToken ParseInnerCompute()
         {
             this.lexer.NextToken();
-            string computeText = UriParserHelper.ReadQueryOption(this.lexer);
+            ReadOnlyMemory<char> computeText = UriParserHelper.ReadQueryOption(this.lexer);
 
             UriQueryExpressionParser computeParser = new UriQueryExpressionParser(this.model, this.MaxOrderByDepth, enableCaseInsensitiveBuiltinIdentifier);
             return computeParser.ParseCompute(computeText);
@@ -672,7 +678,7 @@ namespace Microsoft.OData.UriParser
         private IEnumerable<QueryToken> ParseInnerApply()
         {
             this.lexer.NextToken();
-            string applyText = UriParserHelper.ReadQueryOption(this.lexer);
+            ReadOnlyMemory<char> applyText = UriParserHelper.ReadQueryOption(this.lexer);
 
             UriQueryExpressionParser applyParser = new UriQueryExpressionParser(this.model, this.MaxOrderByDepth, enableCaseInsensitiveBuiltinIdentifier);
             return applyParser.ParseApply(applyText);

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandParser.cs
@@ -62,6 +62,16 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         private bool isSelect;
 
+        internal SelectExpandParser(
+            IEdmModel model,
+            string clauseToParse,
+            int maxRecursiveDepth,
+            bool enableCaseInsensitiveBuiltinIdentifier = false,
+            bool enableNoDollarQueryOptions = false)
+            : this (model, clauseToParse.AsMemory(), maxRecursiveDepth, enableCaseInsensitiveBuiltinIdentifier, enableNoDollarQueryOptions)
+        {
+        }
+
         /// <summary>
         /// Build the SelectOption strategy.
         /// TODO: Really should not take the clauseToParse here. Instead it should be provided with a call to ParseSelect() or ParseExpand().
@@ -72,7 +82,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="enableNoDollarQueryOptions">Whether to enable no dollar query options.</param>
         public SelectExpandParser(
             IEdmModel model,
-            string clauseToParse,
+            ReadOnlyMemory<char> clauseToParse,
             int maxRecursiveDepth,
             bool enableCaseInsensitiveBuiltinIdentifier = false,
             bool enableNoDollarQueryOptions = false)
@@ -88,11 +98,23 @@ namespace Microsoft.OData.UriParser
 
             // Sets up our lexer. We don't turn useSemicolonDelimiter on since the parsing code for expand options,
             // which is the only thing that needs it, is in a different class that uses it's own lexer.
-            this.lexer = clauseToParse != null ? new ExpressionLexer(this.model, clauseToParse, moveToFirstToken: false, useSemicolonDelimiter: false) : null;
+            this.lexer = clauseToParse.IsEmpty ? null : new ExpressionLexer(this.model, clauseToParse, moveToFirstToken: false, useSemicolonDelimiter: false);
 
             this.enableCaseInsensitiveBuiltinIdentifier = enableCaseInsensitiveBuiltinIdentifier;
 
             this.enableNoDollarQueryOptions = enableNoDollarQueryOptions;
+        }
+
+        internal SelectExpandParser(
+            IEdmModel model,
+            ODataUriResolver resolver,
+            string clauseToParse,
+            IEdmStructuredType parentStructuredType,
+            int maxRecursiveDepth,
+            bool enableCaseInsensitiveBuiltinIdentifier = false,
+            bool enableNoDollarQueryOptions = false)
+            : this (model, resolver, clauseToParse.AsMemory(), parentStructuredType, maxRecursiveDepth, enableCaseInsensitiveBuiltinIdentifier, enableNoDollarQueryOptions)
+        {
         }
 
         /// <summary>
@@ -107,7 +129,7 @@ namespace Microsoft.OData.UriParser
         public SelectExpandParser(
             IEdmModel model,
             ODataUriResolver resolver,
-            string clauseToParse,
+            ReadOnlyMemory<char> clauseToParse,
             IEdmStructuredType parentStructuredType,
             int maxRecursiveDepth,
             bool enableCaseInsensitiveBuiltinIdentifier = false,
@@ -196,7 +218,7 @@ namespace Microsoft.OData.UriParser
             var termParser = new SelectExpandTermParser(this.lexer, this.MaxPathDepth, this.isSelect);
             PathSegmentToken pathToken = termParser.ParseTerm();
 
-            string optionsText = null;
+            ReadOnlyMemory<char> optionsText = null;
             if (this.lexer.CurrentToken.Kind == ExpressionTokenKind.OpenParen)
             {
                 optionsText = this.lexer.AdvanceThroughBalancedParentheticalExpression();
@@ -219,7 +241,7 @@ namespace Microsoft.OData.UriParser
             var termParser = new SelectExpandTermParser(this.lexer, this.MaxPathDepth, this.isSelect);
             PathSegmentToken pathToken = termParser.ParseTerm(allowRef: true);
 
-            string optionsText = null;
+            ReadOnlyMemory<char> optionsText = null;
             if (this.lexer.CurrentToken.Kind == ExpressionTokenKind.OpenParen)
             {
                 optionsText = this.lexer.AdvanceThroughBalancedParentheticalExpression();

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandParser.cs
@@ -218,7 +218,7 @@ namespace Microsoft.OData.UriParser
             var termParser = new SelectExpandTermParser(this.lexer, this.MaxPathDepth, this.isSelect);
             PathSegmentToken pathToken = termParser.ParseTerm();
 
-            ReadOnlyMemory<char> optionsText = null;
+            ReadOnlyMemory<char> optionsText = default;
             if (this.lexer.CurrentToken.Kind == ExpressionTokenKind.OpenParen)
             {
                 optionsText = this.lexer.AdvanceThroughBalancedParentheticalExpression();
@@ -241,7 +241,7 @@ namespace Microsoft.OData.UriParser
             var termParser = new SelectExpandTermParser(this.lexer, this.MaxPathDepth, this.isSelect);
             PathSegmentToken pathToken = termParser.ParseTerm(allowRef: true);
 
-            ReadOnlyMemory<char> optionsText = null;
+            ReadOnlyMemory<char> optionsText = default;
             if (this.lexer.CurrentToken.Kind == ExpressionTokenKind.OpenParen)
             {
                 optionsText = this.lexer.AdvanceThroughBalancedParentheticalExpression();

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandSyntacticParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandSyntacticParser.cs
@@ -7,6 +7,7 @@
 namespace Microsoft.OData.UriParser
 {
     using Microsoft.OData.Edm;
+    using System;
 
     /// <summary>
     /// Parse the raw select and expand clause syntax.
@@ -23,8 +24,8 @@ namespace Microsoft.OData.UriParser
         /// <param name="expandTree">the resulting expand AST</param>
         /// <param name="selectTree">the resulting select AST</param>
         public static void Parse(
-            string selectClause,
-            string expandClause,
+            ReadOnlyMemory<char> selectClause,
+            ReadOnlyMemory<char> expandClause,
             IEdmStructuredType parentStructuredType,
             ODataUriParserConfiguration configuration,
             out ExpandToken expandTree,

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandTermParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandTermParser.cs
@@ -119,7 +119,7 @@ namespace Microsoft.OData.UriParser
             // Some check here to throw exception, prop1/*/prop2 and */$ref/prop and prop1/$count/prop2 will throw exception, all are $expand cases.
             if (!isSelect)
             {
-                if (previousSegment != null && previousSegment.Identifier == UriQueryConstants.Star && !this.lexer.CurrentToken.GetIdentifier().Equals(UriQueryConstants.RefSegment, StringComparison.Ordinal))
+                if (previousSegment != null && previousSegment.Identifier == UriQueryConstants.Star && !this.lexer.CurrentToken.GetIdentifier().Span.Equals(UriQueryConstants.RefSegment, StringComparison.Ordinal))
                 {
                     // Star can only be followed with $ref. $count is not supported with star as expand option
                     throw new ODataException(SRResources.ExpressionToken_OnlyRefAllowWithStarInExpand);
@@ -137,7 +137,7 @@ namespace Microsoft.OData.UriParser
             }
 
 
-            ReadOnlySpan<char> propertyName;
+            ReadOnlyMemory<char> propertyName;
 
             if (this.lexer.PeekNextToken().Kind == ExpressionTokenKind.Dot)
             {
@@ -156,7 +156,7 @@ namespace Microsoft.OData.UriParser
                     throw new ODataException(SRResources.ExpressionToken_NoSegmentAllowedBeforeStarInExpand);
                 }
 
-                propertyName = this.lexer.CurrentToken.Span;
+                propertyName = this.lexer.CurrentToken.Text;
                 this.lexer.NextToken();
             }
             else

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriParserHelper.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriParserHelper.cs
@@ -275,8 +275,8 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// Read a query option from the lexer.
         /// </summary>
-        /// <returns>The query option as a string.</returns>
-        internal static string ReadQueryOption(ExpressionLexer lexer)
+        /// <returns>The query option as a ReadOnlyMemory of characters.</returns>
+        internal static ReadOnlyMemory<char> ReadQueryOption(ExpressionLexer lexer)
         {
             if (lexer.CurrentToken.Kind != ExpressionTokenKind.Equal)
             {
@@ -286,7 +286,7 @@ namespace Microsoft.OData.UriParser
             // get the full text from the current location onward
             // there could be literals like 'A string literal; tricky!' in there, so we need to be careful.
             // Also there could be more nested (...) expressions that we ignore until we recurse enough times to get there.
-            string expressionText = lexer.AdvanceThroughExpandOption();
+            ReadOnlyMemory<char> expressionText = lexer.AdvanceThroughExpandOption();
 
             if (lexer.CurrentToken.Kind == ExpressionTokenKind.SemiColon)
             {

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -15,7 +15,6 @@ namespace Microsoft.OData.UriParser
     using Microsoft.OData.UriParser.Aggregation;
     using Microsoft.OData.Edm;
     using Microsoft.OData.Core;
-    using System.Runtime.CompilerServices;
     #endregion Namespaces
 
     /// <summary>
@@ -1212,7 +1211,7 @@ namespace Microsoft.OData.UriParser
 
         private static bool TryParseIdentifierAsFunction(ExpressionLexer lexer, out ReadOnlyMemory<char> result)
         {
-            result = null;
+            result = default;
             ReadOnlyMemory<char> functionName;
 
             int startPosition = lexer.CurrentToken.Position;

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -15,6 +15,7 @@ namespace Microsoft.OData.UriParser
     using Microsoft.OData.UriParser.Aggregation;
     using Microsoft.OData.Edm;
     using Microsoft.OData.Core;
+    using System.Runtime.CompilerServices;
     #endregion Namespaces
 
     /// <summary>
@@ -178,6 +179,14 @@ namespace Microsoft.OData.UriParser
         /// <param name="filter">The $filter expression string to parse.</param>
         /// <returns>The lexical token representing the filter.</returns>
         public QueryToken ParseFilter(string filter)
+            => ParseFilter(filter.AsMemory());
+
+        /// <summary>
+        /// Parses the $filter expression.
+        /// </summary>
+        /// <param name="filter">The $filter expression string to parse.</param>
+        /// <returns>The lexical token representing the filter.</returns>
+        public QueryToken ParseFilter(ReadOnlyMemory<char> filter)
         {
             return this.ParseExpressionText(filter);
         }
@@ -316,13 +325,12 @@ namespace Microsoft.OData.UriParser
         }
 
         // parses $compute query option.
-        internal ComputeToken ParseCompute(string compute)
+        internal ComputeToken ParseCompute(string compute) => ParseCompute(compute.AsMemory());
+
+        internal ComputeToken ParseCompute(ReadOnlyMemory<char> compute)
         {
-            Debug.Assert(compute != null, "compute != null");
-
             List<ComputeExpressionToken> transformationTokens = new List<ComputeExpressionToken>();
-
-            if (string.IsNullOrEmpty(compute))
+            if (compute.IsEmpty)
             {
                 return new ComputeToken(transformationTokens);
             }
@@ -376,7 +384,8 @@ namespace Microsoft.OData.UriParser
                 this.lexer.NextToken();
                 if (this.lexer.CurrentToken.Kind == ExpressionTokenKind.Identifier)
                 {
-                    switch (this.lexer.CurrentToken.GetIdentifier())
+                    ReadOnlySpan<char> identifier = this.lexer.CurrentToken.GetIdentifier().Span;
+                    switch (identifier)
                     {
                         case ExpressionConstants.KeywordFilter:
                             filterToken = this.ParseApplyFilter();
@@ -414,13 +423,13 @@ namespace Microsoft.OData.UriParser
             return new ExpandToken(termTokens);
         }
 
-        internal IEnumerable<QueryToken> ParseApply(string apply)
-        {
-            Debug.Assert(apply != null, "apply != null");
+        internal IEnumerable<QueryToken> ParseApply(string apply) => ParseApply(apply.AsMemory());
 
+        internal IEnumerable<QueryToken> ParseApply(ReadOnlyMemory<char> apply)
+        {
             List<QueryToken> transformationTokens = new List<QueryToken>();
 
-            if (string.IsNullOrEmpty(apply))
+            if (apply.IsEmpty)
             {
                 return transformationTokens;
             }
@@ -430,7 +439,8 @@ namespace Microsoft.OData.UriParser
 
             while (true)
             {
-                switch (this.lexer.CurrentToken.GetIdentifier())
+                ReadOnlySpan<char> identifier = this.lexer.CurrentToken.GetIdentifier().Span;
+                switch (identifier)
                 {
                     case ExpressionConstants.KeywordAggregate:
                         transformationTokens.Add(ParseAggregate());
@@ -545,9 +555,9 @@ namespace Microsoft.OData.UriParser
                 }
 
                 // "as" alias
-                StringLiteralToken alias = this.ParseAggregateAs();
+                ReadOnlyMemory<char> alias = this.ParseAggregateAs();
 
-                return new AggregateExpressionToken(expression, verb, alias.Text);
+                return new AggregateExpressionToken(expression, verb, alias.ToString());
             }
             finally
             {
@@ -655,9 +665,9 @@ namespace Microsoft.OData.UriParser
             QueryToken expression = this.ParseExpression();
 
             // "as" alias
-            StringLiteralToken alias = this.ParseAggregateAs();
+            ReadOnlyMemory<char> alias = this.ParseAggregateAs();
 
-            return new ComputeExpressionToken(expression, alias.Text);
+            return new ComputeExpressionToken(expression, alias.ToString());
         }
 
         /// <summary>
@@ -665,10 +675,10 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         /// <param name="expressionText">The expression string to Parse.</param>
         /// <returns>The lexical token representing the expression text.</returns>
-        internal QueryToken ParseExpressionText(string expressionText)
-        {
-            Debug.Assert(expressionText != null, "expressionText != null");
+        internal QueryToken ParseExpressionText(string expressionText) => ParseExpressionText(expressionText.AsMemory());
 
+        internal QueryToken ParseExpressionText(ReadOnlyMemory<char> expressionText)
+        {
             this.recursionDepth = 0;
             this.lexer = CreateLexerForFilterOrOrderByOrApplyExpression(this.model, expressionText);
             QueryToken result = this.ParseExpression();
@@ -682,9 +692,16 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         /// <param name="orderBy">The $orderby expression string to parse.</param>
         /// <returns>The enumeration of lexical tokens representing order by tokens.</returns>
-        internal IEnumerable<OrderByToken> ParseOrderBy(string orderBy)
+        internal IEnumerable<OrderByToken> ParseOrderBy(string orderBy) => ParseOrderBy(orderBy.AsMemory());
+
+        /// <summary>
+        /// Parses the $orderby expression.
+        /// </summary>
+        /// <param name="orderBy">The $orderby expression string to parse.</param>
+        /// <returns>The enumeration of lexical tokens representing order by tokens.</returns>
+        internal IEnumerable<OrderByToken> ParseOrderBy(ReadOnlyMemory<char> orderBy)
         {
-            Debug.Assert(orderBy != null, "orderBy != null");
+            Debug.Assert(!orderBy.IsEmpty, "orderBy is empty.");
 
             this.recursionDepth = 0;
             this.lexer = CreateLexerForFilterOrOrderByOrApplyExpression(this.model, orderBy);
@@ -737,6 +754,9 @@ namespace Microsoft.OData.UriParser
         /// <param name="expression">The expression.</param>
         /// <returns>The lexer for the expression, which will have already moved to the first token.</returns>
         private static ExpressionLexer CreateLexerForFilterOrOrderByOrApplyExpression(IEdmModel edmModel, string expression)
+            => CreateLexerForFilterOrOrderByOrApplyExpression(edmModel, expression.AsMemory());
+
+        private static ExpressionLexer CreateLexerForFilterOrOrderByOrApplyExpression(IEdmModel edmModel, ReadOnlyMemory<char> expression)
         {
             return new ExpressionLexer(edmModel, expression, moveToFirstToken: true, useSemicolonDelimiter: true, parsingFunctionParameters: true);
         }
@@ -1003,7 +1023,7 @@ namespace Microsoft.OData.UriParser
                 if (operatorToken.Kind == ExpressionTokenKind.Minus && (ExpressionLexerUtils.IsNumeric(this.lexer.CurrentToken.Kind)))
                 {
                     ExpressionToken numberLiteral = this.lexer.CurrentToken;
-                    numberLiteral.Text = this.Lexer.ExpressionText.AsMemory(operatorToken.Position, 1 + this.lexer.CurrentToken.Length);
+                    numberLiteral.Text = this.Lexer.ExpressionText.Slice(operatorToken.Position, 1 + this.lexer.CurrentToken.Length);
                     numberLiteral.Position = operatorToken.Position;
                     this.lexer.CurrentToken = numberLiteral;
                     this.RecurseLeave();
@@ -1167,16 +1187,16 @@ namespace Microsoft.OData.UriParser
 
                 // a function call or an entity with key value is treated same as function call.
                 bool identifierIsFunction = this.lexer.ExpandIdentifierAsFunction();
-                if (identifierIsFunction && TryParseIdentifierAsFunction(lexer, out string result))
+                if (identifierIsFunction && TryParseIdentifierAsFunction(lexer, out ReadOnlyMemory<char> result))
                 {
-                    rootPathToken.Segments.Add(result);
+                    rootPathToken.Segments.Add(result.ToString());
                     this.lexer.NextToken();
                     continue;
                 }
 
                 if (this.lexer.PeekNextToken().Kind == ExpressionTokenKind.Dot)
                 {
-                    ReadOnlySpan<char> dotIdentifier = this.lexer.ReadDottedIdentifier(false);
+                    ReadOnlyMemory<char> dotIdentifier = this.lexer.ReadDottedIdentifier(false);
                     rootPathToken.Segments.Add(dotIdentifier.ToString());
                     continue;
                 }
@@ -1190,13 +1210,14 @@ namespace Microsoft.OData.UriParser
             return rootPathToken;
         }
 
-        private static bool TryParseIdentifierAsFunction(ExpressionLexer lexer, out string result)
+        private static bool TryParseIdentifierAsFunction(ExpressionLexer lexer, out ReadOnlyMemory<char> result)
         {
             result = null;
-            ReadOnlySpan<char> functionName;
+            ReadOnlyMemory<char> functionName;
 
+            int startPosition = lexer.CurrentToken.Position;
             ExpressionLexer.ExpressionLexerPosition position = lexer.SnapshotPosition();
-
+            
             if (lexer.PeekNextToken().Kind == ExpressionTokenKind.Dot)
             {
                 // handle the case where we prefix a function with its namespace.
@@ -1204,7 +1225,7 @@ namespace Microsoft.OData.UriParser
             }
             else
             {
-                functionName = lexer.CurrentToken.Span;
+                functionName = lexer.CurrentToken.Text;
                 lexer.NextToken();
             }
 
@@ -1214,8 +1235,9 @@ namespace Microsoft.OData.UriParser
                 return false;
             }
 
-            string parameters = lexer.AdvanceThroughBalancedParentheticalExpression();
-            result = $"{functionName}{parameters}";
+            lexer.AdvanceThroughBalancedParentheticalExpression();
+
+            result = lexer.ExpressionText.Slice(startPosition, lexer.TextPosition - startPosition);
             return true;
         }
 
@@ -1374,7 +1396,7 @@ namespace Microsoft.OData.UriParser
 
             AggregationMethodDefinition verb;
             int identifierStartPosition = lexer.CurrentToken.Position;
-            ReadOnlySpan<char> methodLabel = lexer.ReadDottedIdentifier(false /* acceptStar */);
+            ReadOnlySpan<char> methodLabel = lexer.ReadDottedIdentifier(false /* acceptStar */).Span;
 
             switch (methodLabel)
             {
@@ -1394,7 +1416,7 @@ namespace Microsoft.OData.UriParser
                     verb = AggregationMethodDefinition.Sum;
                     break;
                 default:
-                    if (!methodLabel.Contains(OData.ExpressionConstants.SymbolDot, StringComparison.Ordinal))
+                    if (!methodLabel.Contains(ExpressionConstants.SymbolDot, StringComparison.Ordinal))
                     {
                         throw ParseError(
                             Error.Format(SRResources.UriQueryExpressionParser_UnrecognizedWithMethod,
@@ -1410,7 +1432,7 @@ namespace Microsoft.OData.UriParser
             return verb;
         }
 
-        private StringLiteralToken ParseAggregateAs()
+        private ReadOnlyMemory<char> ParseAggregateAs()
         {
             if (!TokenIdentifierIs(ExpressionConstants.KeywordAs))
             {
@@ -1419,7 +1441,7 @@ namespace Microsoft.OData.UriParser
 
             lexer.NextToken();
 
-            var alias = new StringLiteralToken(lexer.CurrentToken.Text.ToString());
+            var alias = lexer.CurrentToken.Text;
 
             lexer.NextToken();
 

--- a/src/Microsoft.OData.Core/UriParser/SearchLexer.cs
+++ b/src/Microsoft.OData.Core/UriParser/SearchLexer.cs
@@ -56,6 +56,11 @@ namespace Microsoft.OData.UriParser
         /// <param name="model">The Edm model associated with this lexer, used when resolving custom URI literal prefixes.</param>
         /// <param name="expression">Expression to parse.</param>
         internal SearchLexer(IEdmModel model, string expression)
+            : this(model, expression.AsMemory())
+        {
+        }
+
+        internal SearchLexer(IEdmModel model, ReadOnlyMemory<char> expression)
             : base(model, expression, moveToFirstToken: true, useSemicolonDelimiter: false)
         {
         }
@@ -114,7 +119,7 @@ namespace Microsoft.OData.UriParser
             }
 
             this.token.Kind = t;
-            this.token.Text = this.Text.AsMemory(tokenPos, this.textPos - tokenPos);
+            this.token.Text = this.Text.Slice(tokenPos, this.textPos - tokenPos);
             this.token.Position = tokenPos;
 
             if (this.token.Kind == ExpressionTokenKind.StringLiteral)

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
@@ -867,8 +867,8 @@ namespace Microsoft.OData.Tests.UriParser
         public void AdvanceThroughExpandOptionStopsAtSemi()
         {
             var lexer = CreateLexerForAdvanceThroughExpandOptionTest(this.model, "abc;def");
-            string result = lexer.AdvanceThroughExpandOption();
-            Assert.Equal("abc", result);
+            ReadOnlyMemory<char> result = lexer.AdvanceThroughExpandOption();
+            Assert.Equal("abc", result.Span);
             Assert.Equal(3, lexer.Position);
             Assert.Equal(ExpressionTokenKind.SemiColon, lexer.CurrentToken.Kind);
         }
@@ -877,8 +877,8 @@ namespace Microsoft.OData.Tests.UriParser
         public void AdvanceThroughExpandOptionStopsAtCloseParen()
         {
             var lexer = CreateLexerForAdvanceThroughExpandOptionTest(this.model, "abc)def");
-            string result = lexer.AdvanceThroughExpandOption();
-            Assert.Equal("abc", result);
+            ReadOnlyMemory<char> result = lexer.AdvanceThroughExpandOption();
+            Assert.Equal("abc", result.Span);
             Assert.Equal(3, lexer.Position);
             Assert.Equal(ExpressionTokenKind.CloseParen, lexer.CurrentToken.Kind);
         }
@@ -887,8 +887,8 @@ namespace Microsoft.OData.Tests.UriParser
         public void AdvanceThroughExpandOptionWillReadUntilEnd()
         {
             var lexer = CreateLexerForAdvanceThroughExpandOptionTest(this.model, "entirestring");
-            string result = lexer.AdvanceThroughExpandOption();
-            Assert.Equal("entirestring", result);
+            ReadOnlyMemory<char> result = lexer.AdvanceThroughExpandOption();
+            Assert.Equal("entirestring", result.Span);
             Assert.Equal(ExpressionTokenKind.End, lexer.CurrentToken.Kind);
         }
 
@@ -896,8 +896,8 @@ namespace Microsoft.OData.Tests.UriParser
         public void AdvanceThroughExpandOptionWorksWhenDelimiterIsAtEnd()
         {
             var lexer = CreateLexerForAdvanceThroughExpandOptionTest(this.model, "foo;");
-            string result = lexer.AdvanceThroughExpandOption();
-            Assert.Equal("foo", result);
+            ReadOnlyMemory<char> result = lexer.AdvanceThroughExpandOption();
+            Assert.Equal("foo", result.Span);
             Assert.Equal(ExpressionTokenKind.SemiColon, lexer.CurrentToken.Kind);
         }
 
@@ -905,8 +905,8 @@ namespace Microsoft.OData.Tests.UriParser
         public void AdvanceThroughExpandOptionSkipsBalancedParens()
         {
             var lexer = CreateLexerForAdvanceThroughExpandOptionTest(this.model, "abc()def;");
-            string result = lexer.AdvanceThroughExpandOption();
-            Assert.Equal("abc()def", result);
+            ReadOnlyMemory<char> result = lexer.AdvanceThroughExpandOption();
+            Assert.Equal("abc()def", result.Span);
             Assert.Equal(8, lexer.Position);
             Assert.Equal(ExpressionTokenKind.SemiColon, lexer.CurrentToken.Kind);
         }
@@ -915,8 +915,8 @@ namespace Microsoft.OData.Tests.UriParser
         public void AdvanceThroughExpandOptionHandlesNestedParensRightNextToCheckOther()
         {
             var lexer = CreateLexerForAdvanceThroughExpandOptionTest(this.model, "abc(())def;");
-            string result = lexer.AdvanceThroughExpandOption();
-            Assert.Equal("abc(())def", result);
+            ReadOnlyMemory<char> result = lexer.AdvanceThroughExpandOption();
+            Assert.Equal("abc(())def", result.Span);
             Assert.Equal(10, lexer.Position);
             Assert.Equal(ExpressionTokenKind.SemiColon, lexer.CurrentToken.Kind);
         }
@@ -925,8 +925,8 @@ namespace Microsoft.OData.Tests.UriParser
         public void AdvanceThroughExpandOptionHandlesNestedParensRightNextToFinalClosingParen()
         {
             var lexer = CreateLexerForAdvanceThroughExpandOptionTest(this.model, "abc(()))");
-            string result = lexer.AdvanceThroughExpandOption();
-            Assert.Equal("abc(())", result);
+            ReadOnlyMemory<char> result = lexer.AdvanceThroughExpandOption();
+            Assert.Equal("abc(())", result.Span);
             Assert.Equal(7, lexer.Position);
             Assert.Equal(ExpressionTokenKind.CloseParen, lexer.CurrentToken.Kind);
         }
@@ -935,8 +935,8 @@ namespace Microsoft.OData.Tests.UriParser
         public void AdvanceThroughExpandOptionSkipsSemisInParenthesis()
         {
             var lexer = CreateLexerForAdvanceThroughExpandOptionTest(this.model, "abc(;;;)def;next");
-            string result = lexer.AdvanceThroughExpandOption();
-            Assert.Equal("abc(;;;)def", result);
+            ReadOnlyMemory<char> result = lexer.AdvanceThroughExpandOption();
+            Assert.Equal("abc(;;;)def", result.Span);
             Assert.Equal(11, lexer.Position);
             Assert.Equal(ExpressionTokenKind.SemiColon, lexer.CurrentToken.Kind);
         }
@@ -945,8 +945,8 @@ namespace Microsoft.OData.Tests.UriParser
         public void AdvanceThroughExpandOptionSkipsOverInnerOptionsSuccessfully()
         {
             var lexer = CreateLexerForAdvanceThroughExpandOptionTest(this.model, "prop(inner(a=b;c=d(e=deep)))");
-            string result = lexer.AdvanceThroughExpandOption();
-            Assert.Equal("prop(inner(a=b;c=d(e=deep)))", result);
+            ReadOnlyMemory<char> result = lexer.AdvanceThroughExpandOption();
+            Assert.Equal("prop(inner(a=b;c=d(e=deep)))", result.Span);
             Assert.Equal(ExpressionTokenKind.End, lexer.CurrentToken.Kind);
         }
 
@@ -962,8 +962,8 @@ namespace Microsoft.OData.Tests.UriParser
         public void AdvanceUntilRecognizesSkipsStringLiterals()
         {
             var lexer = CreateLexerForAdvanceThroughExpandOptionTest(this.model, "'str with ; and () in it' eq StringProperty)");
-            string result = lexer.AdvanceThroughExpandOption();
-            Assert.Equal("'str with ; and () in it' eq StringProperty", result);
+            ReadOnlyMemory<char> result = lexer.AdvanceThroughExpandOption();
+            Assert.Equal("'str with ; and () in it' eq StringProperty", result.Span);
             Assert.Equal(43, lexer.Position);
             Assert.StartsWith(")", lexer.CurrentToken.Span.ToString());
         }
@@ -973,8 +973,8 @@ namespace Microsoft.OData.Tests.UriParser
         public void AdvanceThroughBalancedParentheticalExpressionWorks()
         {
             ExpressionLexer lexer = new ExpressionLexer(this.model, "(expression)next", moveToFirstToken: true, useSemicolonDelimiter: true, parsingFunctionParameters: false);
-            string result = lexer.AdvanceThroughBalancedParentheticalExpression();
-            Assert.Equal("(expression)", result);
+            ReadOnlyMemory<char> result = lexer.AdvanceThroughBalancedParentheticalExpression();
+            Assert.Equal("(expression)", result.Span);
             // TODO: the state of the lexer is weird right now, see note in AdvanceThroughBalancedParentheticalExpression.
 
             Assert.Equal("next", lexer.NextToken().Span.ToString());

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SelectExpandParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SelectExpandParserTests.cs
@@ -489,8 +489,8 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             bool enableNoDollarQueryOptions = false)
         {
             SelectExpandSyntacticParser.Parse(
-                select,
-                expand,
+                select.AsMemory(),
+                expand.AsMemory(),
                 parentStructuredType: null,
                 new ODataUriParserConfiguration(EdmCoreModel.Instance)
                 {
@@ -805,7 +805,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
                 Settings = { PathLimit = 2, FilterLimit = 8, OrderByLimit = 8, SearchLimit = 7, SelectExpandLimit = 5 }
             };
 
-            SelectExpandSyntacticParser.Parse(select, expand, null , configuration, out expandTree, out selectTree);
+            SelectExpandSyntacticParser.Parse(select.AsMemory(), expand.AsMemory(), null , configuration, out expandTree, out selectTree);
         }
         #endregion
     }


### PR DESCRIPTION
… URI parsers and lexers

- Updated ExpressionLexer.AdvanceThroughExpandOption() to return ReadOnlyMemory<char>
- Updated ExpressionLexer.AdvanceThroughBalancedParentheticalExpression() to return ReadOnlyMemory<char>
- Updated SelectExpandSyntacticParser.Parse() to accept ReadOnlyMemory<char> parameters
- Updated various parser methods to use ReadOnlyMemory<char> instead of string
- Updated test files to handle ReadOnlyMemory<char> types
- Updated PublicAPI.Shipped.txt to reflect API changes

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
