### PR TITLE
Add SearchTermToken and update search parser

### DIFF
--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -95,7 +95,8 @@
     <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\SelectToken.cs" Link="ALinq\UriParser\SyntacticAst\SelectToken.cs" />
     <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\StarToken.cs" Link="ALinq\UriParser\SyntacticAst\StarToken.cs" />
     <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\SystemToken.cs" Link="ALinq\UriParser\SyntacticAst\SystemToken.cs" />
-    <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\RootPathToken.cs" Link="ALinq\UriParser\SyntacticAst\RootPathToken.cs" />
+		<Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\SearchTermToken.cs" Link="ALinq\UriParser\SyntacticAst\SearchTermToken.cs" />
+		<Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\RootPathToken.cs" Link="ALinq\UriParser\SyntacticAst\RootPathToken.cs" />
     <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\UnaryOperatorToken.cs" Link="ALinq\UriParser\SyntacticAst\UnaryOperatorToken.cs" />
     <Compile Include="..\Microsoft.OData.Core\UriParser\Aggregation\ApplyTransformationToken.cs" Link="ALinq\UriParser\Aggregation\ApplyTransformationToken.cs" />
     <Compile Include="..\Microsoft.OData.Core\UriParser\Aggregation\EntitySetAggregateToken.cs" Link="ALinq\UriParser\Aggregation\EntitySetAggregateToken.cs" />

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -95,8 +95,8 @@
     <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\SelectToken.cs" Link="ALinq\UriParser\SyntacticAst\SelectToken.cs" />
     <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\StarToken.cs" Link="ALinq\UriParser\SyntacticAst\StarToken.cs" />
     <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\SystemToken.cs" Link="ALinq\UriParser\SyntacticAst\SystemToken.cs" />
-		<Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\SearchTermToken.cs" Link="ALinq\UriParser\SyntacticAst\SearchTermToken.cs" />
-		<Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\RootPathToken.cs" Link="ALinq\UriParser\SyntacticAst\RootPathToken.cs" />
+    <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\SearchTermToken.cs" Link="ALinq\UriParser\SyntacticAst\SearchTermToken.cs" />
+    <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\RootPathToken.cs" Link="ALinq\UriParser\SyntacticAst\RootPathToken.cs" />
     <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\UnaryOperatorToken.cs" Link="ALinq\UriParser\SyntacticAst\UnaryOperatorToken.cs" />
     <Compile Include="..\Microsoft.OData.Core\UriParser\Aggregation\ApplyTransformationToken.cs" Link="ALinq\UriParser\Aggregation\ApplyTransformationToken.cs" />
     <Compile Include="..\Microsoft.OData.Core\UriParser\Aggregation\EntitySetAggregateToken.cs" Link="ALinq\UriParser\Aggregation\EntitySetAggregateToken.cs" />

--- a/src/Microsoft.OData.Client/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind.SearchTerm = 34 -> Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind

--- a/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 Microsoft.OData.UriParser.IndexSegment
 Microsoft.OData.UriParser.IndexSegment.Index.get -> long
 Microsoft.OData.UriParser.IndexSegment.IndexSegment(long index, Microsoft.OData.Edm.IEdmType targetEdmType) -> void
+Microsoft.OData.UriParser.QueryTokenKind.SearchTerm = 34 -> Microsoft.OData.UriParser.QueryTokenKind
 override Microsoft.OData.UriParser.IndexSegment.EdmType.get -> Microsoft.OData.Edm.IEdmType
 override Microsoft.OData.UriParser.IndexSegment.HandleWith(Microsoft.OData.UriParser.PathSegmentHandler handler) -> void
 override Microsoft.OData.UriParser.IndexSegment.TranslateWith<T>(Microsoft.OData.UriParser.PathSegmentTranslator<T> translator) -> T

--- a/src/Microsoft.OData.Core/UriParser/Binders/MetadataBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/MetadataBinder.cs
@@ -173,6 +173,9 @@ namespace Microsoft.OData.UriParser
                 case QueryTokenKind.StringLiteral:
                     result = this.BindStringLiteral((StringLiteralToken)token);
                     break;
+                case QueryTokenKind.SearchTerm:
+                    result = this.BindSearchTerm((SearchTermToken)token);
+                    break;
                 case QueryTokenKind.BinaryOperator:
                     result = this.BindBinaryOperator((BinaryOperatorToken)token);
                     break;
@@ -352,9 +355,15 @@ namespace Microsoft.OData.UriParser
         /// <param name="stringLiteralToken">The StringLiteral token to bind.</param>
         /// <returns>The bound StringLiteral token.</returns>
         protected virtual QueryNode BindStringLiteral(StringLiteralToken stringLiteralToken)
-        {
-            return new SearchTermNode(stringLiteralToken.Text);
-        }
+            => new ConstantNode(stringLiteralToken.Text);
+
+        /// <summary>
+        /// Binds a SearchTerm token.
+        /// </summary>
+        /// <param name="searchTermToken">The SearchTerm token to bind.</param>
+        /// <returns>The bound SearchTerm token.</returns>
+        protected virtual QueryNode BindSearchTerm(SearchTermToken searchTermToken)
+            => new SearchTermNode(searchTermToken.Text);
 
         /// <summary>
         /// Binds an In token.

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SearchParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SearchParser.cs
@@ -172,7 +172,7 @@ namespace Microsoft.OData.UriParser
                     expr = this.ParseParenExpression();
                     break;
                 case ExpressionTokenKind.StringLiteral:
-                    expr = new StringLiteralToken(this.lexer.CurrentToken.Text.ToString());
+                    expr = new SearchTermToken(this.lexer.CurrentToken.Text);
                     this.lexer.NextToken();
                     break;
                 default:

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/QueryTokenKind.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/QueryTokenKind.cs
@@ -164,6 +164,11 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// $root path
         /// </summary>
-        RootPath = 33
+        RootPath = 33,
+
+        /// <summary>
+        /// The search literal for search query
+        /// </summary>
+        SearchTerm = 34
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/SearchTermToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/SearchTermToken.cs
@@ -1,0 +1,85 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="SearchTermToken.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+#if ODATA_CLIENT
+namespace Microsoft.OData.Client.ALinq.UriParser
+#else
+namespace Microsoft.OData.UriParser
+#endif
+{
+    using System;
+    using System.Diagnostics;
+
+    /// <summary>
+    /// Lexical token representing a search term value.
+    /// </summary>
+    [DebuggerDisplay("SearchTermToken ({text})")]
+    internal sealed class SearchTermToken : QueryToken
+    {
+        /// <summary>
+        /// Raw text value for this token.
+        /// </summary>
+        private readonly ReadOnlyMemory<char> originalText;
+        private string text;
+
+        /// <summary>
+        /// Constructor for the SearchTermToken
+        /// </summary>
+        /// <param name="text">The text value for this token</param>
+        internal SearchTermToken(string text)
+            : this(text.AsMemory())
+        {
+            this.text = text;
+        }
+
+        /// <summary>
+        /// Constructor for the SearchTermToken
+        /// </summary>
+        /// <param name="text">The text value for this token</param>
+        internal SearchTermToken(ReadOnlyMemory<char> text)
+        {
+            this.originalText = text;
+        }
+
+        /// <summary>
+        /// The kind of the query token.
+        /// </summary>
+        public override QueryTokenKind Kind => QueryTokenKind.SearchTerm;
+
+        /// <summary>
+        /// Gets the original text for this search term.
+        /// </summary>
+        public ReadOnlyMemory<char> OriginalText => this.originalText;
+
+        /// <summary>
+        /// Gets an original string text value of the literal.
+        /// Avoid creating the string multiple times.
+        /// </summary>
+        internal string Text
+        {
+            get
+            {
+                if (this.text == null)
+                {
+                    this.text = this.originalText.ToString();
+                }
+
+                return this.text;
+            }
+        }
+
+        /// <summary>
+        /// Accept a <see cref="ISyntacticTreeVisitor{T}"/> to walk a tree of <see cref="QueryToken"/>s.
+        /// </summary>
+        /// <typeparam name="T">Type that the visitor will return after visiting this token.</typeparam>
+        /// <param name="visitor">An implementation of the visitor interface.</param>
+        /// <returns>An object whose type is determined by the type parameter of the visitor.</returns>
+        public override T Accept<T>(ISyntacticTreeVisitor<T> visitor)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/SearchTermToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/SearchTermToken.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing a search term value.
     /// </summary>
-    [DebuggerDisplay("SearchTermToken ({text})")]
+    [DebuggerDisplay("SearchTermToken ({Text})")]
     internal sealed class SearchTermToken : QueryToken
     {
         /// <summary>

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SearchParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SearchParserTests.cs
@@ -20,14 +20,14 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         public void SearchWordTest()
         {
             QueryToken token = searchParser.ParseSearch("zlexico");
-            token.ShouldBeStringLiteralToken("zlexico");
+            token.ShouldBeSearchTermToken("zlexico");
         }
 
         [Fact]
         public void SearchPhraseTest()
         {
             QueryToken token = searchParser.ParseSearch("\"A AND BC AND DEF\"");
-            token.ShouldBeStringLiteralToken("A AND BC AND DEF");
+            token.ShouldBeSearchTermToken("A AND BC AND DEF");
         }
 
         [Fact]
@@ -36,9 +36,9 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             QueryToken token = searchParser.ParseSearch("A AND BC AND DEF");
             var binaryToken1 = token.ShouldBeBinaryOperatorQueryToken(BinaryOperatorKind.And);
             var binaryToken11 = binaryToken1.Left.ShouldBeBinaryOperatorQueryToken(BinaryOperatorKind.And);
-            binaryToken11.Left.ShouldBeStringLiteralToken("A");
-            binaryToken11.Right.ShouldBeStringLiteralToken("BC");
-            binaryToken1.Right.ShouldBeStringLiteralToken("DEF");
+            binaryToken11.Left.ShouldBeSearchTermToken("A");
+            binaryToken11.Right.ShouldBeSearchTermToken("BC");
+            binaryToken1.Right.ShouldBeSearchTermToken("DEF");
         }
 
         [Fact]
@@ -47,9 +47,9 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             QueryToken token = searchParser.ParseSearch("A BC DEF");
             var binaryToken1 = token.ShouldBeBinaryOperatorQueryToken(BinaryOperatorKind.And);
             var binaryToken11 = binaryToken1.Left.ShouldBeBinaryOperatorQueryToken(BinaryOperatorKind.And);
-            binaryToken11.Left.ShouldBeStringLiteralToken("A");
-            binaryToken11.Right.ShouldBeStringLiteralToken("BC");
-            binaryToken1.Right.ShouldBeStringLiteralToken("DEF");
+            binaryToken11.Left.ShouldBeSearchTermToken("A");
+            binaryToken11.Right.ShouldBeSearchTermToken("BC");
+            binaryToken1.Right.ShouldBeSearchTermToken("DEF");
         }
 
         [Fact]
@@ -57,8 +57,8 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         {
             QueryToken token = searchParser.ParseSearch("foo OR bar");
             var binaryToken = token.ShouldBeBinaryOperatorQueryToken(BinaryOperatorKind.Or);
-            binaryToken.Left.ShouldBeStringLiteralToken("foo");
-            binaryToken.Right.ShouldBeStringLiteralToken("bar");
+            binaryToken.Left.ShouldBeSearchTermToken("foo");
+            binaryToken.Right.ShouldBeSearchTermToken("bar");
         }
 
         [Fact]
@@ -67,9 +67,9 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             QueryToken token = searchParser.ParseSearch("(A  OR BC) AND DEF");
             var binaryToken1 = token.ShouldBeBinaryOperatorQueryToken(BinaryOperatorKind.And);
             var binaryToken11 = binaryToken1.Left.ShouldBeBinaryOperatorQueryToken(BinaryOperatorKind.Or);
-            binaryToken11.Left.ShouldBeStringLiteralToken("A");
-            binaryToken11.Right.ShouldBeStringLiteralToken("BC");
-            binaryToken1.Right.ShouldBeStringLiteralToken("DEF");
+            binaryToken11.Left.ShouldBeSearchTermToken("A");
+            binaryToken11.Right.ShouldBeSearchTermToken("BC");
+            binaryToken1.Right.ShouldBeSearchTermToken("DEF");
         }
 
         [Fact]
@@ -78,9 +78,9 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             QueryToken token = searchParser.ParseSearch("(A BC) DEF");
             var binaryToken1 = token.ShouldBeBinaryOperatorQueryToken(BinaryOperatorKind.And);
             var binaryToken11 = binaryToken1.Left.ShouldBeBinaryOperatorQueryToken(BinaryOperatorKind.And);
-            binaryToken11.Left.ShouldBeStringLiteralToken("A");
-            binaryToken11.Right.ShouldBeStringLiteralToken("BC");
-            binaryToken1.Right.ShouldBeStringLiteralToken("DEF");
+            binaryToken11.Left.ShouldBeSearchTermToken("A");
+            binaryToken11.Right.ShouldBeSearchTermToken("BC");
+            binaryToken1.Right.ShouldBeSearchTermToken("DEF");
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         {
             QueryToken token = searchParser.ParseSearch("NOT foo");
             var unaryToken = token.ShouldBeUnaryOperatorQueryToken(UnaryOperatorKind.Not);
-            unaryToken.Operand.ShouldBeStringLiteralToken("foo");
+            unaryToken.Operand.ShouldBeSearchTermToken("foo");
         }
 
 
@@ -99,15 +99,15 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             var binaryToken1 = token.ShouldBeBinaryOperatorQueryToken(BinaryOperatorKind.Or);
             var binaryToken21 = binaryToken1.Left.ShouldBeBinaryOperatorQueryToken(BinaryOperatorKind.And);
             var binaryToken22 = binaryToken1.Right.ShouldBeBinaryOperatorQueryToken(BinaryOperatorKind.And);
-            binaryToken21.Left.ShouldBeStringLiteralToken("a");
-            binaryToken21.Right.ShouldBeStringLiteralToken("bc");
-            binaryToken22.Left.ShouldBeStringLiteralToken("def");
+            binaryToken21.Left.ShouldBeSearchTermToken("a");
+            binaryToken21.Right.ShouldBeSearchTermToken("bc");
+            binaryToken22.Left.ShouldBeSearchTermToken("def");
             var unaryToken222 = binaryToken22.Right.ShouldBeUnaryOperatorQueryToken(UnaryOperatorKind.Not);
             var binaryToken222 = unaryToken222.Operand.ShouldBeBinaryOperatorQueryToken(BinaryOperatorKind.And);
             var binaryToken2221 = binaryToken222.Left.ShouldBeBinaryOperatorQueryToken(BinaryOperatorKind.And);
-            binaryToken2221.Left.ShouldBeStringLiteralToken("ghij");
-            binaryToken2221.Right.ShouldBeStringLiteralToken("klmno");
-            binaryToken222.Right.ShouldBeStringLiteralToken("pqrstu");
+            binaryToken2221.Left.ShouldBeSearchTermToken("ghij");
+            binaryToken2221.Right.ShouldBeSearchTermToken("klmno");
+            binaryToken222.Right.ShouldBeSearchTermToken("pqrstu");
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SelectExpandOptionParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SelectExpandOptionParserTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
 
             // Assert
             Assert.NotNull(selectTerm.SearchOption);
-            selectTerm.SearchOption.ShouldBeStringLiteralToken("Searchme");
+            selectTerm.SearchOption.ShouldBeSearchTermToken("Searchme");
         }
 
         [Theory]
@@ -484,7 +484,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             // Assert
             Assert.NotNull(expandTerm);
             Assert.NotNull(expandTerm.SearchOption);
-            expandTerm.SearchOption.ShouldBeStringLiteralToken("Searchme");
+            expandTerm.SearchOption.ShouldBeSearchTermToken("Searchme");
         }
 
         [Theory]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SelectExpandParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SelectExpandParserTests.cs
@@ -302,7 +302,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             orderBy.Expression.ShouldBeEndPathToken("abc");
 
             Assert.NotNull(selectTermToken.SearchOption);
-            selectTermToken.SearchOption.ShouldBeStringLiteralToken("xyz");
+            selectTermToken.SearchOption.ShouldBeSearchTermToken("xyz");
         }
 
         [Theory]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/TokenAssertions.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/TokenAssertions.cs
@@ -183,5 +183,13 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.Equal(text, stringLiteralToken.Text);
             return stringLiteralToken;
         }
+
+        public static SearchTermToken ShouldBeSearchTermToken(this QueryToken token, string text)
+        {
+            Assert.NotNull(token);
+            SearchTermToken searchTermToken = Assert.IsType<SearchTermToken>(token);
+            Assert.Equal(text, searchTermToken.Text);
+            return searchTermToken;
+        }
     }
 }


### PR DESCRIPTION
Add SearchTermToken and update search parser

- Added new SearchTermToken class for representing search terms
- Added SearchTerm query token kind to QueryTokenKind enum
- Updated SearchParser to use SearchTermToken
- Updated MetadataBinder to handle SearchTermToken
- Updated test files to work with new token types
- Added TokenAssertions helper for SearchTermToken
- Fixed SelectExpandOptionParserTests and SelectExpandParserTests