### PR TITLE
Add support for hassubset and hassubsequence built-in functions

### DIFF
--- a/src/Microsoft.OData.Core/Uri/ExpressionConstants.cs
+++ b/src/Microsoft.OData.Core/Uri/ExpressionConstants.cs
@@ -123,6 +123,12 @@ namespace Microsoft.OData
         /// <summary> "isof function </summary>
         internal const string UnboundFunctionIsOf = "isof";
 
+        /// <summary> "hassubset" function </summary>
+        internal const string UnboundFunctionHassubset = "hassubset";
+
+        /// <summary> "hassubset" function </summary>
+        internal const string UnboundFunctionHassubsequence = "hassubsequence";
+
         /// <summary> Spatial length function </summary>
         internal const string UnboundFunctionLength = "geo.length";
 

--- a/src/Microsoft.OData.Core/Uri/ExpressionConstants.cs
+++ b/src/Microsoft.OData.Core/Uri/ExpressionConstants.cs
@@ -126,7 +126,7 @@ namespace Microsoft.OData
         /// <summary> "hassubset" function </summary>
         internal const string UnboundFunctionHassubset = "hassubset";
 
-        /// <summary> "hassubset" function </summary>
+        /// <summary> "hassubsequence" function </summary>
         internal const string UnboundFunctionHassubsequence = "hassubsequence";
 
         /// <summary> Spatial length function </summary>

--- a/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
@@ -722,7 +722,7 @@ namespace Microsoft.OData.UriParser
                 case ExpressionConstants.UnboundFunctionHassubsequence:
                     {
                         ValidateArgsForCollection(functionCallTokenName, args);
-                        returnType = EdmCoreModel.Instance.GetBoolean(false); // why 'false'? Because these functions return non-nullable boolean, and GetBoolean is designed to return nullable boolean by default, we need to specify false here to get the non-nullable boolean type reference.
+                        returnType = EdmCoreModel.Instance.GetBoolean(false); // non-nullable boolean
                         break;
                     }
 

--- a/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
@@ -29,6 +29,8 @@ namespace Microsoft.OData.UriParser
         {
             ExpressionConstants.UnboundFunctionCast,
             ExpressionConstants.UnboundFunctionIsOf,
+            ExpressionConstants.UnboundFunctionHassubset,
+            ExpressionConstants.UnboundFunctionHassubsequence
         };
 
         /// <summary>
@@ -716,6 +718,15 @@ namespace Microsoft.OData.UriParser
                         break;
                     }
 
+                case ExpressionConstants.UnboundFunctionHassubset:
+                case ExpressionConstants.UnboundFunctionHassubsequence:
+                    {
+                        ValidateArgsForCollection(functionCallTokenName, args);
+                        returnType = EdmCoreModel.Instance.GetBoolean(false); // why 'false'? Because these functions return non-nullable boolean, and GetBoolean is designed to return nullable boolean by default, we need to specify false here to get the non-nullable boolean type reference.
+                        break;
+                    }
+
+
                 default:
                     {
                         break;
@@ -845,6 +856,22 @@ namespace Microsoft.OData.UriParser
             else
             {
                 return EdmCoreModel.Instance.GetBoolean(true);
+            }
+        }
+
+        private static void ValidateArgsForCollection(string functionName, List<QueryNode> args)
+        {
+            if (args.Count != 2)
+            {
+                throw new ODataErrorException(Error.Format(SRResources.MetadataBinder_FunctionWithWrongNumberOfOperands, functionName, args.Count, "2"));
+            }
+
+            for (int i = 0; i < args.Count; i++)
+            {
+                if (!(args[i] is CollectionNode))
+                {
+                    throw new ODataErrorException(Error.Format(SRResources.MetadataBinder_FunctionArgumentNotCollectionValue, i + 1, functionName));
+                }
             }
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -3866,7 +3866,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Fact]
         public void CaseFunctionInOrderBy()
         {
-            OrderByClause orderBy = ParseOrderBy("case(ID gt 0 :1, true:-1)", // be noted: "ID gt 0:1, true:-1" is confusing that "0:1" could be parsed as TimeOfDay. Add a white space can avoid this issue.
+            OrderByClause orderBy = ParseOrderBy("case(ID gt 0 :1, true:-1)", // Note: "ID gt 0:1, true:-1" is confusing because "0:1" could be parsed as a TimeOfDay. Adding a whitespace avoids this issue.
                 HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
 
             orderBy.Expression.ShouldBeSingleValueFunctionCallQueryNode("case");

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2707,6 +2707,54 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void HassubsetInFilterWithBooleanComparison()
+        {
+            // Arrange & Act - Use hassubset in boolean expression
+            IEdmEntityType personType = HardCodedTestModel.GetPersonType();
+            IEdmProperty relatedIdsProp = personType.FindProperty("RelatedIDs");
+            Assert.NotNull(relatedIdsProp);
+
+            var filterClause = ParseFilter("hassubset(RelatedIDs, [0,9]) eq true", HardCodedTestModel.TestModel, personType, HardCodedTestModel.GetPeopleSet());
+
+            // Assert
+            var binaryOp = filterClause.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
+            SingleValueFunctionCallNode hassubsetCall = binaryOp.Left.ShouldBeSingleValueFunctionCallQueryNode("hassubset");
+            Assert.Equal(2, hassubsetCall.Parameters.Count());
+
+            hassubsetCall.Parameters.ElementAt(0).ShouldBeCollectionPropertyAccessQueryNode(relatedIdsProp);
+            CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(hassubsetCall.Parameters.ElementAt(1));
+            Assert.Equal(2, collectionNode.Items.Count);
+
+            collectionNode.Items.ElementAt(0).ShouldBeConstantQueryNode(0);
+            collectionNode.Items.ElementAt(1).ShouldBeConstantQueryNode(9);
+            binaryOp.Right.ShouldBeConstantQueryNode(true);
+        }
+
+        [Fact]
+        public void HassubsequenceInFilterWithBooleanComparison()
+        {
+            // Arrange & Act - Use hassubsequence in boolean expression
+            IEdmEntityType personType = HardCodedTestModel.GetPersonType();
+            IEdmProperty relatedIdsProp = personType.FindProperty("RelatedIDs");
+            Assert.NotNull(relatedIdsProp);
+
+            var filterClause = ParseFilter("hassubsequence(RelatedIDs, [0,9]) eq true", HardCodedTestModel.TestModel, personType, HardCodedTestModel.GetPeopleSet());
+
+            // Assert
+            var binaryOp = filterClause.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
+            SingleValueFunctionCallNode hassubsequenceCall = binaryOp.Left.ShouldBeSingleValueFunctionCallQueryNode("hassubsequence");
+            Assert.Equal(2, hassubsequenceCall.Parameters.Count());
+
+            hassubsequenceCall.Parameters.ElementAt(0).ShouldBeCollectionPropertyAccessQueryNode(relatedIdsProp);
+            CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(hassubsequenceCall.Parameters.ElementAt(1));
+            Assert.Equal(2, collectionNode.Items.Count);
+
+            collectionNode.Items.ElementAt(0).ShouldBeConstantQueryNode(0);
+            collectionNode.Items.ElementAt(1).ShouldBeConstantQueryNode(9);
+            binaryOp.Right.ShouldBeConstantQueryNode(true);
+        }
+
+        [Fact]
         public void FilterWithInOperationWithAny()
         {
             // https://github.com/OData/odata.net/issues/1447
@@ -3765,9 +3813,69 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
         #endregion
 
-        private static FilterClause ParseFilter(string text, IEdmModel edmModel, IEdmType edmType, IEdmNavigationSource edmEntitySet = null)
+        #region case function in filter
+
+        [Fact]
+        public void CaseFunctionWithBooleanConditionsInFilter()
         {
-            return new ODataQueryOptionParser(edmModel, edmType, edmEntitySet, new Dictionary<string, string>() { { "$filter", text } }) { Resolver = new ODataUriResolver() { EnableCaseInsensitive = false } }.ParseFilter();
+            FilterClause filter = ParseFilter("case(ID gt 0:true, ID eq 0:false) eq true",
+                HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            BinaryOperatorNode binaryNode = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
+            SingleValueFunctionCallNode caseNode = binaryNode.Left.ShouldBeSingleValueFunctionCallQueryNode("case");
+            Assert.Equal(4, caseNode.Parameters.Count());
+        }
+
+        [Fact]
+        public void CaseFunctionWithStringResultInFilter()
+        {
+            FilterClause filter = ParseFilter("case(ID gt 0:'positive', ID lt 0:'negative', true:'zero') eq 'positive'",
+                HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            BinaryOperatorNode binaryNode = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
+            SingleValueFunctionCallNode caseNode = binaryNode.Left.ShouldBeSingleValueFunctionCallQueryNode("case");
+            Assert.Equal(6, caseNode.Parameters.Count());
+            Assert.Collection(caseNode.Parameters,
+                e => e.ShouldBeBinaryOperatorNode(BinaryOperatorKind.GreaterThan),
+                e => e.ShouldBeConstantQueryNode("positive"),
+                e => e.ShouldBeBinaryOperatorNode(BinaryOperatorKind.LessThan),
+                e => e.ShouldBeConstantQueryNode("negative"),
+                e => e.ShouldBeConstantQueryNode(true),
+                e => e.ShouldBeConstantQueryNode("zero"));
+        }
+
+        [Fact]
+        public void CaseFunctionMissingColonThrows()
+        {
+            string filterText = "case(ID gt 0 1, true:0) eq 0";
+            Action parse = () => ParseFilter(filterText, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            parse.Throws<ODataException>(Error.Format(SRResources.UriQueryExpressionParser_ColonExpectedForCaseFunctionCall, 13, filterText));
+        }
+
+        [Fact]
+        public void CaseFunctionCaseInsensitiveNameWorks()
+        {
+            FilterClause filter = ParseFilter("CASE(ID gt 0 :1, true:-1) eq 1",
+                HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet(),
+                caseInsensitive: true);
+
+            BinaryOperatorNode binaryNode = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
+            binaryNode.Left.ShouldBeSingleValueFunctionCallQueryNode("case");
+        }
+
+        [Fact]
+        public void CaseFunctionInOrderBy()
+        {
+            OrderByClause orderBy = ParseOrderBy("case(ID gt 0 :1, true:-1)", // be noted: "ID gt 0:1, true:-1" is confusing that "0:1" could be parsed as TimeOfDay. Add a white space can avoid this issue.
+                HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            orderBy.Expression.ShouldBeSingleValueFunctionCallQueryNode("case");
+        }
+        #endregion
+
+        private static FilterClause ParseFilter(string text, IEdmModel edmModel, IEdmType edmType, IEdmNavigationSource edmEntitySet = null, bool caseInsensitive = false)
+        {
+            return new ODataQueryOptionParser(edmModel, edmType, edmEntitySet, new Dictionary<string, string>() { { "$filter", text } }) { Resolver = new ODataUriResolver() { EnableCaseInsensitive = caseInsensitive } }.ParseFilter();
         }
 
         private static OrderByClause ParseOrderBy(string text, IEdmModel edmModel, IEdmType edmType, IEdmNavigationSource edmEntitySet = null)

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Binders/FunctionCallBinderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Binders/FunctionCallBinderTests.cs
@@ -608,7 +608,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         }
 
         [Fact]
-        public void HassubsequenceFunctionBindReturnsWorksWithTwoCollectionArguments()
+        public void HassubsequenceFunctionBindWorksWithTwoCollectionArguments()
         {
             CollectionLiteralToken leftCol = new CollectionLiteralToken();
             leftCol.Items.Add(new LiteralToken(1));

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Binders/FunctionCallBinderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Binders/FunctionCallBinderTests.cs
@@ -608,6 +608,222 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         }
 
         [Fact]
+        public void HassubsequenceFunctionBindReturnsWorksWithTwoCollectionArguments()
+        {
+            CollectionLiteralToken leftCol = new CollectionLiteralToken();
+            leftCol.Items.Add(new LiteralToken(1));
+            leftCol.Items.Add(new LiteralToken(2));
+            leftCol.Items.Add(new LiteralToken(3));
+
+            CollectionLiteralToken rightCol = new CollectionLiteralToken();
+            rightCol.Items.Add(new LiteralToken(2));
+            rightCol.Items.Add(new LiteralToken(3));
+
+            QueryToken[] args = [leftCol, rightCol];
+
+            FunctionCallToken functionToken = new FunctionCallToken("hassubsequence", args);
+            QueryNode node = this.functionCallBinder.BindFunctionCall(functionToken);
+            var functionCallNode = node.ShouldBeSingleValueFunctionCallQueryNode("hassubsequence");
+            CollectionConstantNode leftNode = Assert.IsType<CollectionConstantNode>(functionCallNode.Parameters.ElementAt(0));
+            Assert.Equal(3, leftNode.Items.Count);
+
+            CollectionConstantNode rightNode = Assert.IsType<CollectionConstantNode>(functionCallNode.Parameters.ElementAt(1));
+            Assert.Equal(2, rightNode.Items.Count);
+        }
+
+        [Fact]
+        public void HassubsetFunctionBindWorksWithTwoCollectionArguments()
+        {
+            CollectionLiteralToken leftCol = new CollectionLiteralToken();
+            leftCol.Items.Add(new LiteralToken(1));
+            leftCol.Items.Add(new LiteralToken(2));
+            leftCol.Items.Add(new LiteralToken(3));
+
+            CollectionLiteralToken rightCol = new CollectionLiteralToken();
+            rightCol.Items.Add(new LiteralToken(1));
+            rightCol.Items.Add(new LiteralToken(3));
+
+            QueryToken[] args = [leftCol, rightCol];
+
+            FunctionCallToken functionToken = new FunctionCallToken("hassubset", args);
+            QueryNode node = this.functionCallBinder.BindFunctionCall(functionToken);
+            var functionCallNode = node.ShouldBeSingleValueFunctionCallQueryNode("hassubset");
+            Assert.True(functionCallNode.TypeReference.IsEquivalentTo(EdmCoreModel.Instance.GetBoolean(false)));
+
+            CollectionConstantNode leftNode = Assert.IsType<CollectionConstantNode>(functionCallNode.Parameters.ElementAt(0));
+            Assert.Equal(3, leftNode.Items.Count);
+
+            CollectionConstantNode rightNode = Assert.IsType<CollectionConstantNode>(functionCallNode.Parameters.ElementAt(1));
+            Assert.Equal(2, rightNode.Items.Count);
+        }
+
+        [Fact]
+        public void HassubsetFunctionReturnsNonNullableBoolean()
+        {
+            CollectionLiteralToken col1 = new CollectionLiteralToken();
+            col1.Items.Add(new LiteralToken("a"));
+
+            CollectionLiteralToken col2 = new CollectionLiteralToken();
+            col2.Items.Add(new LiteralToken("a"));
+
+            QueryToken[] args = [col1, col2];
+            FunctionCallToken functionToken = new FunctionCallToken("hassubset", args);
+            QueryNode node = this.functionCallBinder.BindFunctionCall(functionToken);
+            var functionCallNode = node.ShouldBeSingleValueFunctionCallQueryNode("hassubset");
+            Assert.False(functionCallNode.TypeReference.IsNullable);
+            Assert.Equal("Edm.Boolean", functionCallNode.TypeReference.FullName());
+        }
+
+        [Fact]
+        public void HassubsequenceFunctionReturnsNonNullableBoolean()
+        {
+            CollectionLiteralToken col1 = new CollectionLiteralToken();
+            col1.Items.Add(new LiteralToken(1));
+
+            CollectionLiteralToken col2 = new CollectionLiteralToken();
+            col2.Items.Add(new LiteralToken(1));
+
+            QueryToken[] args = [col1, col2];
+            FunctionCallToken functionToken = new FunctionCallToken("hassubsequence", args);
+            QueryNode node = this.functionCallBinder.BindFunctionCall(functionToken);
+            var functionCallNode = node.ShouldBeSingleValueFunctionCallQueryNode("hassubsequence");
+            Assert.False(functionCallNode.TypeReference.IsNullable);
+            Assert.Equal("Edm.Boolean", functionCallNode.TypeReference.FullName());
+        }
+
+        [Fact]
+        public void HassubsetFunctionWithEmptySubsetArgument()
+        {
+            CollectionLiteralToken superSet = new CollectionLiteralToken();
+            superSet.Items.Add(new LiteralToken(1));
+            superSet.Items.Add(new LiteralToken(2));
+
+            CollectionLiteralToken emptySubset = new CollectionLiteralToken();
+
+            QueryToken[] args = [superSet, emptySubset];
+            FunctionCallToken functionToken = new FunctionCallToken("hassubset", args);
+            QueryNode node = this.functionCallBinder.BindFunctionCall(functionToken);
+            var functionCallNode = node.ShouldBeSingleValueFunctionCallQueryNode("hassubset");
+            Assert.Equal(2, functionCallNode.Parameters.Count());
+
+            CollectionConstantNode subsetNode = Assert.IsType<CollectionConstantNode>(functionCallNode.Parameters.ElementAt(1));
+            Assert.Empty(subsetNode.Items);
+        }
+
+        [Fact]
+        public void HassubsequenceFunctionWithEmptySubsequenceArgument()
+        {
+            CollectionLiteralToken superSeq = new CollectionLiteralToken();
+            superSeq.Items.Add(new LiteralToken(1));
+            superSeq.Items.Add(new LiteralToken(2));
+
+            CollectionLiteralToken emptySubseq = new CollectionLiteralToken();
+
+            QueryToken[] args = [superSeq, emptySubseq];
+            FunctionCallToken functionToken = new FunctionCallToken("hassubsequence", args);
+            QueryNode node = this.functionCallBinder.BindFunctionCall(functionToken);
+            var functionCallNode = node.ShouldBeSingleValueFunctionCallQueryNode("hassubsequence");
+            Assert.Equal(2, functionCallNode.Parameters.Count());
+
+            CollectionConstantNode emptyNode = Assert.IsType<CollectionConstantNode>(functionCallNode.Parameters.ElementAt(1));
+            Assert.Empty(emptyNode.Items);
+        }
+
+        [Theory]
+        [InlineData("hassubset")]
+        [InlineData("hassubsequence")]
+        public void HassubsetAndHassubsequenceWithOneArgumentThrows(string functionName)
+        {
+            CollectionLiteralToken col = new CollectionLiteralToken();
+            col.Items.Add(new LiteralToken(1));
+
+            QueryToken[] args = [col];
+            FunctionCallToken functionToken = new FunctionCallToken(functionName, args);
+            Action bind = () => this.functionCallBinder.BindFunctionCall(functionToken);
+            bind.Throws<ODataErrorException>(Error.Format(SRResources.MetadataBinder_FunctionWithWrongNumberOfOperands, functionName, 1, "2"));
+        }
+
+        [Theory]
+        [InlineData("hassubset")]
+        [InlineData("hassubsequence")]
+        public void HassubsetAndHassubsequenceWithThreeArgumentsThrows(string functionName)
+        {
+            CollectionLiteralToken col = new CollectionLiteralToken();
+            col.Items.Add(new LiteralToken(1));
+
+            QueryToken[] args = [col, col, col];
+            FunctionCallToken functionToken = new FunctionCallToken(functionName, args);
+            Action bind = () => this.functionCallBinder.BindFunctionCall(functionToken);
+            bind.Throws<ODataErrorException>(Error.Format(SRResources.MetadataBinder_FunctionWithWrongNumberOfOperands, functionName, 3, "2"));
+        }
+
+        [Theory]
+        [InlineData("hassubset")]
+        [InlineData("hassubsequence")]
+        public void HassubsetAndHassubsequenceWithNonCollectionFirstArgThrows(string functionName)
+        {
+            CollectionLiteralToken col = new CollectionLiteralToken();
+            col.Items.Add(new LiteralToken(1));
+
+            QueryToken[] args = [new LiteralToken(42), col];
+            FunctionCallToken functionToken = new FunctionCallToken(functionName, args);
+            Action bind = () => this.functionCallBinder.BindFunctionCall(functionToken);
+            bind.Throws<ODataErrorException>(Error.Format(SRResources.MetadataBinder_FunctionArgumentNotCollectionValue, 1, functionName));
+        }
+
+        [Theory]
+        [InlineData("hassubset")]
+        [InlineData("hassubsequence")]
+        public void HassubsetAndHassubsequenceWithNonCollectionSecondArgThrows(string functionName)
+        {
+            CollectionLiteralToken col = new CollectionLiteralToken();
+            col.Items.Add(new LiteralToken(1));
+
+            QueryToken[] args = [col, new LiteralToken(42)];
+            FunctionCallToken functionToken = new FunctionCallToken(functionName, args);
+            Action bind = () => this.functionCallBinder.BindFunctionCall(functionToken);
+            bind.Throws<ODataErrorException>(Error.Format(SRResources.MetadataBinder_FunctionArgumentNotCollectionValue, 2, functionName));
+        }
+
+        [Fact]
+        public void HassubsetFunctionWithStringCollections()
+        {
+            CollectionLiteralToken superSet = new CollectionLiteralToken();
+            superSet.Items.Add(new LiteralToken("apple"));
+            superSet.Items.Add(new LiteralToken("banana"));
+            superSet.Items.Add(new LiteralToken("cherry"));
+
+            CollectionLiteralToken subSet = new CollectionLiteralToken();
+            subSet.Items.Add(new LiteralToken("banana"));
+
+            QueryToken[] args = [superSet, subSet];
+            FunctionCallToken functionToken = new FunctionCallToken("hassubset", args);
+            QueryNode node = this.functionCallBinder.BindFunctionCall(functionToken);
+            var functionCallNode = node.ShouldBeSingleValueFunctionCallQueryNode("hassubset");
+            Assert.Equal("Edm.Boolean", functionCallNode.TypeReference.FullName());
+            Assert.Equal(2, functionCallNode.Parameters.Count());
+        }
+
+        [Fact]
+        public void HassubsequenceFunctionWithStringCollections()
+        {
+            CollectionLiteralToken superSeq = new CollectionLiteralToken();
+            superSeq.Items.Add(new LiteralToken("a"));
+            superSeq.Items.Add(new LiteralToken("b"));
+            superSeq.Items.Add(new LiteralToken("c"));
+
+            CollectionLiteralToken subSeq = new CollectionLiteralToken();
+            subSeq.Items.Add(new LiteralToken("b"));
+            subSeq.Items.Add(new LiteralToken("c"));
+
+            QueryToken[] args = [superSeq, subSeq];
+            FunctionCallToken functionToken = new FunctionCallToken("hassubsequence", args);
+            QueryNode node = this.functionCallBinder.BindFunctionCall(functionToken);
+            var functionCallNode = node.ShouldBeSingleValueFunctionCallQueryNode("hassubsequence");
+            Assert.Equal("Edm.Boolean", functionCallNode.TypeReference.FullName());
+            Assert.Equal(2, functionCallNode.Parameters.Count());
+        }
+        [Fact]
         public void TypeMustBeLastArgumentToIsOf()
         {
             QueryToken[] args = new QueryToken[]


### PR DESCRIPTION
Add support for hassubset and hassubsequence built-in functions

- Add UnboundFunctionHassubset and UnboundFunctionHassubsequence constants to ExpressionConstants
- Register both functions in UnboundFunctionNames to bypass standard built-in function lookup
- Implement ValidateArgsForCollection to enforce exactly two collection-valued arguments
- Return non-nullable Edm.Boolean as the result type for both functions
- Add functional tests in FilterAndOrderByFunctionalTests for filter expressions using hassubset and hassubsequence with collection properties and bracket collection literals
- Add binder unit tests in FunctionCallBinderTests covering happy paths, return type, empty collections, wrong argument count, and non-collection argument errors