### PR TITLE
Fix #3524: StringAsEnumResolver preserves quoted LiteralText for enum ConstantNode

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Resolver/StringAsEnumResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/StringAsEnumResolver.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="StringAsEnumResolver.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -8,8 +8,8 @@ namespace Microsoft.OData.UriParser
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
+    using Microsoft.OData;
     using Microsoft.OData.Core;
     using Microsoft.OData.Edm;
 
@@ -35,26 +35,26 @@ namespace Microsoft.OData.UriParser
 
             if (leftNode.TypeReference != null && rightNode.TypeReference != null)
             {
-                if ((leftNode.TypeReference.IsEnum()) && (rightNode.TypeReference.IsString()) && rightNode is ConstantNode)
+                if ((leftNode.TypeReference.IsEnum()) && (rightNode.TypeReference.IsString()) && rightNode is ConstantNode rightConstantNode)
                 {
-                    string text = ((ConstantNode)rightNode).Value as string;
+                    string text = rightConstantNode.Value as string;
                     ODataEnumValue val;
                     IEdmTypeReference typeRef = leftNode.TypeReference;
 
                     if (TryParseEnum(typeRef.Definition as IEdmEnumType, text, out val))
                     {
-                        rightNode = new ConstantNode(val, text, typeRef);
+                        rightNode = new ConstantNode(val, rightConstantNode.LiteralText, typeRef);
                         return;
                     }
                 }
-                else if ((rightNode.TypeReference.IsEnum()) && (leftNode.TypeReference.IsString()) && leftNode is ConstantNode)
+                else if ((rightNode.TypeReference.IsEnum()) && (leftNode.TypeReference.IsString()) && leftNode is ConstantNode leftConstantNode)
                 {
-                    string text = ((ConstantNode)leftNode).Value as string;
+                    string text = leftConstantNode.Value as string;
                     ODataEnumValue val;
                     IEdmTypeReference typeRef = rightNode.TypeReference;
                     if (TryParseEnum(typeRef.Definition as IEdmEnumType, text, out val))
                     {
-                        leftNode = new ConstantNode(val, text, typeRef);
+                        leftNode = new ConstantNode(val, leftConstantNode.LiteralText, typeRef);
                         return;
                     }
                 }
@@ -104,7 +104,7 @@ namespace Microsoft.OData.UriParser
 
                     if (TryParseEnum(typeRef.Definition as IEdmEnumType, text, out val))
                     {
-                        newVal = new ConstantNode(val, text, typeRef);
+                        newVal = new ConstantNode(val, constNode.LiteralText, typeRef);
                     }
                 }
 

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/UriBuilderTests/UriBuilderTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/UriBuilderTests/UriBuilderTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using System.Net;
 using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
 
@@ -453,18 +454,51 @@ public class UriBuilderTests
         Assert.Equal(queryUri, actualUri);
     }
 
+    [Theory]
+    [InlineData("?$filter=Status eq 'Deleted'", true)]
+    [InlineData("?$filter=Status eq 'Deleted'", false)]
+    [InlineData("?$filter='Deleted' eq Status", true)]
+    [InlineData("?$filter='Deleted' eq Status", false)]
+    public void BuildUriWithStringAsEnumResolverBuildsEnumLiteralCorrectly(string queryUriString, bool useStringAsEnumResolver)
+    {
+        var queryUri = new Uri($"http://localhost/People{queryUriString}");
+
+        var odataUriParser = new ODataUriParser(this.GetModel(), _baseUri, queryUri);
+        if (useStringAsEnumResolver)
+        {
+            odataUriParser.Resolver = new StringAsEnumResolver();
+        }
+
+        // Act
+        ODataUri odataUri = odataUriParser.ParseUri();
+        var actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Slash);
+
+        // Assert
+        Assert.Equal(WebUtility.UrlDecode(queryUri.ToString()), WebUtility.UrlDecode(actualUri.ToString()));
+
+        Assert.Equal(queryUriString, WebUtility.UrlDecode(actualUri.Query));
+    }
+
     #region Private
 
     private EdmModel GetModel()
     {
         EdmModel model = new EdmModel();
+
+        EdmEnumType edmEnumType = new EdmEnumType("NS", "ItemStatus");
+        edmEnumType.AddMember("Active", new EdmEnumMemberValue(0));
+        edmEnumType.AddMember("Deleted", new EdmEnumMemberValue(1));
+        model.AddElement(edmEnumType);
+
         EdmEntityType edmEntityType = new EdmEntityType("NS", "Person");
         edmEntityType.AddKeys(edmEntityType.AddStructuralProperty("ID", EdmPrimitiveTypeKind.Int32));
         edmEntityType.AddStructuralProperty("Color", EdmPrimitiveTypeKind.String);
         edmEntityType.AddStructuralProperty("FA", EdmPrimitiveTypeKind.String);
+        edmEntityType.AddStructuralProperty("Status", new EdmEnumTypeReference(edmEnumType, false));
         edmEntityType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "MyDog", TargetMultiplicity = EdmMultiplicity.ZeroOrOne, Target = edmEntityType });
         edmEntityType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "MyCat", TargetMultiplicity = EdmMultiplicity.ZeroOrOne, Target = edmEntityType });
         model.AddElement(edmEntityType);
+
         EdmEntityContainer container = new EdmEntityContainer("NS", "EntityContainer");
         model.AddElement(container);
         container.AddEntitySet("People", edmEntityType);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Metadata/ODataUriResolverTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Metadata/ODataUriResolverTests.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataUriResolverTests.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -86,6 +86,25 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
             var bin = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
             bin.Right.ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPet2PetColorPatternProperty());
             bin.Left.ShouldBeEnumNode(enumtypeRef.EnumDefinition(), "2");
+        }
+
+        // Regression test for https://github.com/OData/odata.net/issues/3524
+        // StringAsEnumResolver must preserve the original single-quoted LiteralText so that
+        // BuildUri round-trips the filter without dropping the quotes.
+        [Theory]
+        [InlineData("http://host/Pet2Set?$filter=PetColorPattern eq 'Blue'")] // left=enum, right=string
+        [InlineData("http://host/Pet2Set?$filter='Blue' eq PetColorPattern")]  // left=string, right=enum
+        public void StringAsEnumResolver_BuildUri_PreservesQuotedEnumLiteralText(string uriString)
+        {
+            var uri = new Uri(uriString);
+            var parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, uri)
+            {
+                Resolver = new StringAsEnumResolver()
+            };
+
+            Uri rebuiltUri = parser.ParseUri().BuildUri(ODataUrlKeyDelimiter.Parentheses);
+
+            Assert.Equal(Uri.UnescapeDataString(uri.Query), Uri.UnescapeDataString(rebuiltUri.Query));
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Xml;
 using Microsoft.OData.Core;
@@ -16,12 +17,12 @@ using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OData.Edm.Vocabularies.Community.V1;
+using Microsoft.OData.Edm.Vocabularies.V1;
+using Microsoft.OData.Metadata;
 using Microsoft.OData.UriParser;
 using Microsoft.OData.UriParser.Aggregation;
 using Microsoft.OData.UriParser.Validation;
 using Xunit;
-using Microsoft.OData.Metadata;
-using Microsoft.OData.Edm.Vocabularies.V1;
 
 namespace Microsoft.OData.Tests.UriParser
 {
@@ -1447,6 +1448,31 @@ namespace Microsoft.OData.Tests.UriParser
 
             Uri resultUri = uri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
             Assert.Equal(fullUriString, Uri.UnescapeDataString(resultUri.OriginalString));
+        }
+
+        [Theory]
+        [InlineData("?$filter=Shape eq 'Rectangle'", true)]
+        [InlineData("?$filter=Shape eq 'Rectangle'", false)]
+        [InlineData("?$filter='Rectangle' eq Shape", true)]
+        [InlineData("?$filter='Rectangle' eq Shape", false)]
+        public void ParseEnumAsStringInFilterClauseWithOrWithoutStringAsEnumResolver(string queryUriString, bool useStringAsEnumResolver)
+        {
+            var queryUri = new Uri($"{ServiceRoot}Pet2Set{queryUriString}");
+
+            var odataUriParser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, queryUri);
+            if (useStringAsEnumResolver)
+            {
+                odataUriParser.Resolver = new StringAsEnumResolver();
+            }
+
+            // Act
+            ODataUri odataUri = odataUriParser.ParseUri();
+            var actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Slash);
+
+            // Assert
+            Assert.Equal(WebUtility.UrlDecode(queryUri.ToString()), WebUtility.UrlDecode(actualUri.ToString()));
+
+            Assert.Equal(queryUriString, WebUtility.UrlDecode(actualUri.Query));
         }
 
         // use static to make sure one model used in all tests


### PR DESCRIPTION

StringAsEnumResolver.PromoteBinaryOperandTypes and ResolveOperationParameters were constructing ConstantNode with the raw unquoted string value as LiteralText (e.g. 'Deleted' stored as Deleted). BuildUri emits LiteralText verbatim, so the round-tripped URL produced unquoted enum values which are invalid per the OData URL conventions ABNF (enum values MUST be single-quoted).

The standard binder path (MetadataBindingUtils.ConvertToTypeIfNeeded) was fixed by PR #1391 to use ODataUriUtils.ConvertToUriLiteral. This commit applies the equivalent fix to the resolver path: use the original LiteralText from the string ConstantNode (which already contains the single-quoted form from the expression lexer) instead of the raw Value string.

Fixes: https://github.com/OData/odata.net/issues/3524

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
