### PR TITLE
Fix StringAsEnumResolver and add tests for issue #3524

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Resolver/StringAsEnumResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/StringAsEnumResolver.cs
@@ -35,26 +35,26 @@ namespace Microsoft.OData.UriParser
 
             if (leftNode.TypeReference != null && rightNode.TypeReference != null)
             {
-                if ((leftNode.TypeReference.IsEnum()) && (rightNode.TypeReference.IsString()) && rightNode is ConstantNode)
+                if ((leftNode.TypeReference.IsEnum()) && (rightNode.TypeReference.IsString()) && rightNode is ConstantNode rightConstantNode)
                 {
-                    string text = ((ConstantNode)rightNode).Value as string;
+                    string text = rightConstantNode.Value as string;
                     ODataEnumValue val;
                     IEdmTypeReference typeRef = leftNode.TypeReference;
 
                     if (TryParseEnum(typeRef.Definition as IEdmEnumType, text, out val))
                     {
-                        rightNode = new ConstantNode(val, text, typeRef);
+                        rightNode = new ConstantNode(val, ODataUriUtils.ConvertToUriLiteral(text, ODataVersion.V4), typeRef);
                         return;
                     }
                 }
-                else if ((rightNode.TypeReference.IsEnum()) && (leftNode.TypeReference.IsString()) && leftNode is ConstantNode)
+                else if ((rightNode.TypeReference.IsEnum()) && (leftNode.TypeReference.IsString()) && leftNode is ConstantNode leftConstantNode)
                 {
-                    string text = ((ConstantNode)leftNode).Value as string;
+                    string text = leftConstantNode.Value as string;
                     ODataEnumValue val;
                     IEdmTypeReference typeRef = rightNode.TypeReference;
                     if (TryParseEnum(typeRef.Definition as IEdmEnumType, text, out val))
                     {
-                        leftNode = new ConstantNode(val, text, typeRef);
+                        leftNode = new ConstantNode(val, ODataUriUtils.ConvertToUriLiteral(text, ODataVersion.V4), typeRef);
                         return;
                     }
                 }
@@ -104,7 +104,7 @@ namespace Microsoft.OData.UriParser
 
                     if (TryParseEnum(typeRef.Definition as IEdmEnumType, text, out val))
                     {
-                        newVal = new ConstantNode(val, text, typeRef);
+                        newVal = new ConstantNode(val, ODataUriUtils.ConvertToUriLiteral(text, ODataVersion.V4), typeRef);
                     }
                 }
 

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/UriBuilderTests/UriBuilderTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/UriBuilderTests/UriBuilderTests.cs
@@ -6,6 +6,7 @@
 
 using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
+using System.Net;
 
 namespace Microsoft.OData.Core.E2E.Tests.UriBuilderTests;
 
@@ -453,15 +454,46 @@ public class UriBuilderTests
         Assert.Equal(queryUri, actualUri);
     }
 
+    [Theory]
+    [InlineData("?$filter=Status eq 'Deleted'", true)]
+    [InlineData("?$filter=Status eq 'Deleted'", false)]
+    [InlineData("?$filter='Deleted' eq Status", true)]
+    [InlineData("?$filter='Deleted' eq Status", false)]
+    public void BuildUriWithStringAsEnumResolverBuildsEnumLiteralCorrectly(string queryUriString, bool useStringAsEnumResolver)
+    {
+        var queryUri = new Uri($"http://localhost/People{queryUriString}");
+
+        var odataUriParser = new ODataUriParser(this.GetModel(), _baseUri, queryUri);
+        if (useStringAsEnumResolver)
+        {
+            odataUriParser.Resolver = new StringAsEnumResolver();
+        }
+
+        // Act
+        ODataUri odataUri = odataUriParser.ParseUri();
+        var actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Slash);
+
+        // Assert
+        Assert.Equal(Uri.UnescapeDataString(queryUri.ToString()), Uri.UnescapeDataString(actualUri.ToString()));
+        Assert.Equal(queryUriString, Uri.UnescapeDataString(actualUri.Query));
+    }
+
     #region Private
 
     private EdmModel GetModel()
     {
         EdmModel model = new EdmModel();
+
+        EdmEnumType edmEnumType = new EdmEnumType("NS", "ItemStatus");
+        edmEnumType.AddMember("Active", new EdmEnumMemberValue(0));
+        edmEnumType.AddMember("Deleted", new EdmEnumMemberValue(1));
+        model.AddElement(edmEnumType);
+
         EdmEntityType edmEntityType = new EdmEntityType("NS", "Person");
         edmEntityType.AddKeys(edmEntityType.AddStructuralProperty("ID", EdmPrimitiveTypeKind.Int32));
         edmEntityType.AddStructuralProperty("Color", EdmPrimitiveTypeKind.String);
         edmEntityType.AddStructuralProperty("FA", EdmPrimitiveTypeKind.String);
+        edmEntityType.AddStructuralProperty("Status", new EdmEnumTypeReference(edmEnumType, false));
         edmEntityType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "MyDog", TargetMultiplicity = EdmMultiplicity.ZeroOrOne, Target = edmEntityType });
         edmEntityType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "MyCat", TargetMultiplicity = EdmMultiplicity.ZeroOrOne, Target = edmEntityType });
         model.AddElement(edmEntityType);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Metadata/ODataUriResolverTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Metadata/ODataUriResolverTests.cs
@@ -4,14 +4,13 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OData.Core;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OData.UriParser;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
 using Xunit;
 
 namespace Microsoft.OData.Tests.UriParser.Metadata

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Metadata/ODataUriResolverTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Metadata/ODataUriResolverTests.cs
@@ -4,14 +4,15 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using Microsoft.OData.Core;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
+using Microsoft.OData.UriParser;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.OData.UriParser;
-using Microsoft.OData.Edm;
-using Microsoft.OData.Edm.Vocabularies;
+using System.Net;
 using Xunit;
-using Microsoft.OData.Core;
 
 namespace Microsoft.OData.Tests.UriParser.Metadata
 {
@@ -86,6 +87,25 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
             var bin = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
             bin.Right.ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPet2PetColorPatternProperty());
             bin.Left.ShouldBeEnumNode(enumtypeRef.EnumDefinition(), "2");
+        }
+
+        // Regression test for https://github.com/OData/odata.net/issues/3524
+        // StringAsEnumResolver must preserve the original single-quoted LiteralText so that
+        // BuildUri round-trips the filter without dropping the quotes.
+        [Theory]
+        [InlineData("http://host/Pet2Set?$filter=PetColorPattern eq 'Blue'")] // left=enum, right=string
+        [InlineData("http://host/Pet2Set?$filter='Blue' eq PetColorPattern")]  // left=string, right=enum
+        public void StringAsEnumResolver_BuildUri_PreservesQuotedEnumLiteralText(string uriString)
+        {
+            var uri = new Uri(uriString);
+            var parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, uri)
+            {
+                Resolver = new StringAsEnumResolver()
+            };
+
+            Uri rebuiltUri = parser.ParseUri().BuildUri(ODataUrlKeyDelimiter.Parentheses);
+
+            Assert.Equal(Uri.UnescapeDataString(uri.Query), Uri.UnescapeDataString(rebuiltUri.Query));
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -4,13 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Xml;
 using Microsoft.OData.Core;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
@@ -20,6 +13,14 @@ using Microsoft.OData.Metadata;
 using Microsoft.OData.UriParser;
 using Microsoft.OData.UriParser.Aggregation;
 using Microsoft.OData.UriParser.Validation;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Xml;
 using Xunit;
 
 namespace Microsoft.OData.Tests.UriParser
@@ -1439,7 +1440,32 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.Equal(fullUriString, Uri.UnescapeDataString(resultUri.OriginalString));
         }
 
-#region Escape Function Parse
+        [Theory]
+        [InlineData("?$filter=Shape eq 'Rectangle'", true)]
+        [InlineData("?$filter=Shape eq 'Rectangle'", false)]
+        [InlineData("?$filter='Rectangle' eq Shape", true)]
+        [InlineData("?$filter='Rectangle' eq Shape", false)]
+        public void ParseEnumAsStringInFilterClauseWithOrWithoutStringAsEnumResolver(string queryUriString, bool useStringAsEnumResolver)
+        {
+            var queryUri = new Uri($"{ServiceRoot}Pet2Set{queryUriString}");
+
+            var odataUriParser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, queryUri);
+            if (useStringAsEnumResolver)
+            {
+                odataUriParser.Resolver = new StringAsEnumResolver();
+            }
+
+            // Act
+            ODataUri odataUri = odataUriParser.ParseUri();
+            var actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Slash);
+
+            // Assert
+            Assert.Equal(Uri.UnescapeDataString(queryUri.ToString()), Uri.UnescapeDataString(actualUri.ToString()));
+
+            Assert.Equal(queryUriString, Uri.UnescapeDataString(actualUri.Query));
+        }
+
+        #region Escape Function Parse
         [Theory]
         [InlineData("/root:/", "/root/NS.NormalFunction(path='')")]
         [InlineData("/root:/abc", "/root/NS.NormalFunction(path='abc')")]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataUriParserTests.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Text;
 using System.Xml;
 using Xunit;
@@ -1465,7 +1464,7 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.Equal(queryUriString, Uri.UnescapeDataString(actualUri.Query));
         }
 
-        #region Escape Function Parse
+#region Escape Function Parse
         [Theory]
         [InlineData("/root:/", "/root/NS.NormalFunction(path='')")]
         [InlineData("/root:/abc", "/root/NS.NormalFunction(path='abc')")]


### PR DESCRIPTION
Fix StringAsEnumResolver and add tests for issue #3524

- Updated StringAsEnumResolver to handle edge cases in enum resolution
- Added tests in ODataUriResolverTests for StringAsEnumResolver behavior
- Added tests in ODataUriParserTests to verify enum parsing scenarios
- Added UriBuilderTests for round-trip URI building with enum values