### PR TITLE
# OData.NET - Performance Improvements (ported to dev-9.x)

### DIFF
--- a/src/Microsoft.OData.Client/BatchSaveResult.cs
+++ b/src/Microsoft.OData.Client/BatchSaveResult.cs
@@ -279,7 +279,7 @@ namespace Microsoft.OData.Client
         /// <returns>A multipart mime header with a generated batch boundary</returns>
         private static string CreateMultiPartMimeContentType()
         {
-            return string.Format(CultureInfo.InvariantCulture, "{0}; {1}={2}_{3}", XmlConstants.MimeMultiPartMixed, XmlConstants.HttpMultipartBoundary, XmlConstants.HttpMultipartBoundaryBatch, Guid.NewGuid());
+            return $"{XmlConstants.MimeMultiPartMixed}; {XmlConstants.HttpMultipartBoundary}={XmlConstants.HttpMultipartBoundaryBatch}_{Guid.NewGuid()}";
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/CommonUtil.cs
+++ b/src/Microsoft.OData.Client/CommonUtil.cs
@@ -37,7 +37,7 @@ namespace Microsoft.OData.Service
             Debug.Assert(rawValue != null && rawValue.Length > 0 && rawValue.IndexOf('{', StringComparison.Ordinal) != 0 && rawValue.IndexOf('[', StringComparison.Ordinal) != 0,
                   "rawValue != null && rawValue.Length > 0 && rawValue.IndexOf('{') != 0 && rawValue.IndexOf('[') != 0");
             ODataCollectionValue collectionValue = (ODataCollectionValue)
-                ODataUriUtils.ConvertFromUriLiteral(string.Format(CultureInfo.InvariantCulture, "[{0}]", rawValue), ODataVersion.V4);
+                ODataUriUtils.ConvertFromUriLiteral($"[{rawValue}]", ODataVersion.V4);
             foreach (object item in collectionValue.Items)
             {
                 return item;

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -3667,7 +3667,7 @@ namespace Microsoft.OData.Client
 
                 string contentType = buildingRequestEventArgs.HeaderCollection.GetHeader(ContentType);
 
-                if (!string.IsNullOrEmpty(contentType) && contentType.ToUpperInvariant().Contains(MimeIeee754CompatibleHeaderTrue.ToUpperInvariant(), StringComparison.Ordinal))
+                if (!string.IsNullOrEmpty(contentType) && contentType.IndexOf(MimeIeee754CompatibleHeaderTrue, StringComparison.OrdinalIgnoreCase) >= 0)
                 {
                     this.IsIeee754Compatible = true;
                 }

--- a/src/Microsoft.OData.Client/EntityTracker.cs
+++ b/src/Microsoft.OData.Client/EntityTracker.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="EntityTracker.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -150,13 +150,24 @@ namespace Microsoft.OData.Client
         {
             this.EnsureLinkBindings();
 
-            // Since we are changing the list on the fly, we need to convert it into a list first
-            // so that enumeration won't get effected.
-            foreach (LinkDescriptor end in this.bindings.Values.Where(resource.IsRelatedEntity).ToList())
+            // Materialize matches first since DetachExistingLink mutates this.bindings.
+            List<LinkDescriptor> related = null;
+            foreach (LinkDescriptor end in this.bindings.Values)
             {
-                this.DetachExistingLink(
-                        end,
-                        end.Target == resource.Entity && resource.State == EntityStates.Added);
+                if (resource.IsRelatedEntity(end))
+                {
+                    (related ??= new List<LinkDescriptor>()).Add(end);
+                }
+            }
+
+            if (related != null)
+            {
+                foreach (LinkDescriptor end in related)
+                {
+                    this.DetachExistingLink(
+                            end,
+                            end.Target == resource.Entity && resource.State == EntityStates.Added);
+                }
             }
 
             resource.ChangeOrder = UInt32.MaxValue;

--- a/src/Microsoft.OData.Client/HeaderCollection.cs
+++ b/src/Microsoft.OData.Client/HeaderCollection.cs
@@ -232,7 +232,7 @@ namespace Microsoft.OData.Client
         {
             // Add User-Agent header to every request - Since UserAgent field is not supported in silverlight,
             // doing this non-silverlight stacks only
-            this.SetHeader(XmlConstants.HttpUserAgent, string.Format(CultureInfo.InvariantCulture, "Microsoft.OData.Client/{0}.{1}.{2}", assemblyVersion.Major, assemblyVersion.Minor, assemblyVersion.Build));
+            this.SetHeader(XmlConstants.HttpUserAgent, FormattableString.Invariant($"Microsoft.OData.Client/{assemblyVersion.Major}.{assemblyVersion.Minor}.{assemblyVersion.Build}"));
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/Materialization/EntryValueMaterializationPolicy.cs
+++ b/src/Microsoft.OData.Client/Materialization/EntryValueMaterializationPolicy.cs
@@ -313,9 +313,9 @@ namespace Microsoft.OData.Client.Materialization
         /// <param name="collection">Collection to add link to.</param>
         internal void FoundNextLinkForUnmodifiedCollection(IEnumerable collection)
         {
-            if (collection != null && !this.nextLinkTable.ContainsKey(collection))
+            if (collection != null)
             {
-                this.nextLinkTable.Add(collection, null);
+                this.nextLinkTable.TryAdd(collection, null);
             }
         }
 

--- a/src/Microsoft.OData.Client/Materialization/ODataEntityMaterializer.cs
+++ b/src/Microsoft.OData.Client/Materialization/ODataEntityMaterializer.cs
@@ -477,8 +477,8 @@ namespace Microsoft.OData.Client.Materialization
                 // Take the example Select(p => new MyEmployee { Manager = (p as Employee).Manager }), if p is of Person type, the Manager navigation property would not
                 // be on its payload from the server. Thus we don't need to set the MyEmployee.Manager link.
                 StreamDescriptor streamInfo;
-                var odataProperty = entry.Entry.Properties.Where(p => p.Name == propertyName).FirstOrDefault();
-                var link = odataProperty == null && entry.NestedResourceInfos != null ? entry.NestedResourceInfos.Where(l => l.Name == propertyName).FirstOrDefault() : null;
+                var odataProperty = entry.Entry.Properties.FirstOrDefault(p => p.Name == propertyName);
+                var link = odataProperty == null && entry.NestedResourceInfos != null ? entry.NestedResourceInfos.FirstOrDefault(l => l.Name == propertyName) : null;
 
                 if (link == null && odataProperty == null && !entry.EntityDescriptor.TryGetNamedStreamInfo(propertyName, out streamInfo))
                 {
@@ -640,7 +640,7 @@ namespace Microsoft.OData.Client.Materialization
                     // projecting a DataServiceStreamLink property
                     // the stream link does not come inside <Properties>
                     // instead, it's materialized and attached to the entity descriptor on the MaterializerEntry struct
-                    var streamDescriptor = entry.EntityDescriptor.StreamDescriptors.Where(sd => sd.Name == propertyName).SingleOrDefault();
+                    var streamDescriptor = entry.EntityDescriptor.StreamDescriptors.SingleOrDefault(sd => sd.Name == propertyName);
                     if (streamDescriptor == null)
                     {
                         // We are projecting a named stream on a derived type and entry is of a base type which the named stream is not defined on. Return null.
@@ -671,7 +671,7 @@ namespace Microsoft.OData.Client.Materialization
                     }
 
                     odataProperty = properties?.FirstOrDefault(p => p.Name == propertyName);
-                    link = odataProperty == null && links != null ? links.Where(p => p.Name == propertyName).FirstOrDefault() : null;
+                    link = odataProperty == null && links != null ? links.FirstOrDefault(p => p.Name == propertyName) : null;
                     if (link == null && odataProperty == null)
                     {
                         throw new InvalidOperationException(Error.Format(SRResources.Materializer_PropertyMissing, propertyName));
@@ -1045,7 +1045,7 @@ namespace Microsoft.OData.Client.Materialization
             ODataNestedResourceInfo link = null;
             if (links != null)
             {
-                link = links.Where(p => p.Name == propertyName).FirstOrDefault();
+                link = links.FirstOrDefault(p => p.Name == propertyName);
             }
 
             if (link == null)

--- a/src/Microsoft.OData.Client/Materialization/StructuralValueMaterializationPolicy.cs
+++ b/src/Microsoft.OData.Client/Materialization/StructuralValueMaterializationPolicy.cs
@@ -308,7 +308,7 @@ namespace Microsoft.OData.Client.Materialization
             if (lastIndexOf > 0)
             {
                 string unqualifiedTypeName = serverTypeName.Substring(serverTypeName.LastIndexOf('.') + 1);
-                clientType = assembly.GetType(string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}.{1}", containingTypeNamespace, unqualifiedTypeName));
+                clientType = assembly.GetType($"{containingTypeNamespace}.{unqualifiedTypeName}");
                 if (clientType != null)
                 {
                     return clientType;

--- a/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
+++ b/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
@@ -446,7 +446,7 @@ namespace Microsoft.OData.Client
 
                     Debug.Assert(
                         header.Value == this.cachedRequestHeaders.GetHeader(header.Key),
-                        String.Format(CultureInfo.InvariantCulture, "The header '{0}' has a different value. Old Value: '{1}', Current Value: '{2}' Please make sure to set the header before SendingRequest event is fired", header.Key, header.Value, this.cachedRequestHeaders.GetHeader(header.Key)));
+                        Error.Format(SRResources.ODataRequestMessageWrapper_HeaderValueChanged, header.Key, header.Value, this.cachedRequestHeaders.GetHeader(header.Key)));
                 }
 
                 this.cachedRequestHeaders = null;

--- a/src/Microsoft.OData.Client/SRResources.Designer.cs
+++ b/src/Microsoft.OData.Client/SRResources.Designer.cs
@@ -1141,6 +1141,15 @@ namespace Microsoft.OData.Client {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The header &apos;{0}&apos; has a different value. Old Value: &apos;{1}&apos;, Current Value: &apos;{2}&apos;. Please make sure to set the header before the SendingRequest event is fired..
+        /// </summary>
+        internal static string ODataRequestMessageWrapper_HeaderValueChanged {
+            get {
+                return ResourceManager.GetString("ODataRequestMessageWrapper_HeaderValueChanged", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The context is currently in no tracking mode, in order to use streams make sure your entities extend BaseEntityType and query the Item again from the server to populate the read link or enable tracking..
         /// </summary>
         internal static string Context_EntityMediaLinksNotTrackedInEntity {

--- a/src/Microsoft.OData.Client/SRResources.resx
+++ b/src/Microsoft.OData.Client/SRResources.resx
@@ -887,5 +887,8 @@
   <data name="Context_EntityInNonTrackedContextLacksMediaLinks" xml:space="preserve">
     <value>The context is in non tracking mode, The entity does not seem to have the media links populated properly. Please verify server response is correct and that the entity extends BaseEntityType.</value>
   </data>
+  <data name="ODataRequestMessageWrapper_HeaderValueChanged" xml:space="preserve">
+    <value>The header '{0}' has a different value. Old Value: '{1}', Current Value: '{2}'. Please make sure to set the header before the SendingRequest event is fired.</value>
+  </data>
 </root>
 

--- a/src/Microsoft.OData.Client/SaveResult.cs
+++ b/src/Microsoft.OData.Client/SaveResult.cs
@@ -738,7 +738,7 @@ namespace Microsoft.OData.Client
         /// <param name="response">response object</param>
         private void HandleOperationException(InvalidOperationException e, IODataResponseMessage response)
         {
-            Debug.Assert(this.entryIndex >= 0 && this.entryIndex < this.ChangedEntries.Count, string.Format(System.Globalization.CultureInfo.InvariantCulture, "this.entryIndex = '{0}', this.ChangedEntries.Count = '{1}'", this.entryIndex, this.ChangedEntries.Count));
+            Debug.Assert(this.entryIndex >= 0 && this.entryIndex < this.ChangedEntries.Count, $"this.entryIndex = '{this.entryIndex}', this.ChangedEntries.Count = '{this.ChangedEntries.Count}'");
 
             Descriptor current = this.ChangedEntries[this.entryIndex];
             HeaderCollection headers = null;
@@ -839,7 +839,7 @@ namespace Microsoft.OData.Client
         /// <param name="responseStream">stream containing the response payload.</param>
         private void HandleOperationResponseData(IODataResponseMessage responseMsg, Stream responseStream)
         {
-            Debug.Assert(this.entryIndex >= 0 && this.entryIndex < this.ChangedEntries.Count, string.Format(System.Globalization.CultureInfo.InvariantCulture, "this.entryIndex = '{0}', this.ChangedEntries.Count() = '{1}'", this.entryIndex, this.ChangedEntries.Count));
+            Debug.Assert(this.entryIndex >= 0 && this.entryIndex < this.ChangedEntries.Count, $"this.entryIndex = '{this.entryIndex}', this.ChangedEntries.Count() = '{this.ChangedEntries.Count}'");
 
             // Parse the response
             Descriptor current = this.ChangedEntries[this.entryIndex];

--- a/src/Microsoft.OData.Core/Buffers/StringBuilderPool.cs
+++ b/src/Microsoft.OData.Core/Buffers/StringBuilderPool.cs
@@ -1,0 +1,33 @@
+//---------------------------------------------------------------------
+// <copyright file="StringBuilderPool.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData
+{
+    using System.Text;
+    using Microsoft.Extensions.ObjectPool;
+
+    /// <summary>Shared pool of <see cref="StringBuilder"/> for hot serialization paths.</summary>
+    internal static class StringBuilderPool
+    {
+        public static readonly ObjectPool<StringBuilder> Shared =
+            new DefaultObjectPoolProvider { MaximumRetained = 16 }
+                .CreateStringBuilderPool(initialCapacity: 64, maximumRetainedCapacity: 4 * 1024);
+
+        public static string Build(System.Action<StringBuilder> build)
+        {
+            StringBuilder sb = Shared.Get();
+            try
+            {
+                build(sb);
+                return sb.ToString();
+            }
+            finally
+            {
+                Shared.Return(sb);
+            }
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/Evaluation/LiteralFormatter.cs
+++ b/src/Microsoft.OData.Core/Evaluation/LiteralFormatter.cs
@@ -343,21 +343,29 @@ namespace Microsoft.OData.Evaluation
                 // DEVNOTE: for some reason, the client adds .0 to doubles where the server does not.
                 // Unfortunately, it would be a breaking change to alter this behavior now.
 #if ODATA_CLIENT || ODATA_CORE
-                IEnumerable<char> characters = input.ToCharArray();
-
+                int start = 0;
 #if ODATA_CORE
                 // negative numbers can also be 'whole', but the client did not take that into account.
-                if (input[0] == '-')
+                if (input.Length > 0 && input[0] == '-')
                 {
-                    characters = characters.Skip(1);
+                    start = 1;
                 }
 #endif
-                // a whole number should be all digits.
-                if (characters.All(char.IsDigit))
+                // a whole number should be all digits. Inspect in-place to avoid ToCharArray + LINQ allocation.
+                bool allDigits = input.Length > start;
+                for (int i = start; i < input.Length; i++)
+                {
+                    if (!char.IsDigit(input[i]))
+                    {
+                        allDigits = false;
+                        break;
+                    }
+                }
+
+                if (allDigits)
                 {
                     return string.Concat(input, ".0");
                 }
-
 #endif
                 // the server never appended anything, so it will fall through to here.
                 return input;

--- a/src/Microsoft.OData.Core/Evaluation/ODataMissingOperationGenerator.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataMissingOperationGenerator.cs
@@ -49,7 +49,7 @@ namespace Microsoft.OData.Evaluation
         /// Gets the computed missing Actions from the generator.
         /// </summary>
         /// <returns>The computed missing Actions.</returns>
-        internal IEnumerable<ODataAction> GetComputedActions()
+        internal IReadOnlyList<ODataAction> GetComputedActions()
         {
             this.ComputeMissingOperationsToResource();
             return this.computedActions;
@@ -59,7 +59,7 @@ namespace Microsoft.OData.Evaluation
         /// Gets the computed missing Functions from the generator.
         /// </summary>
         /// <returns>The computed missing Functions.</returns>
-        internal IEnumerable<ODataFunction> GetComputedFunctions()
+        internal IReadOnlyList<ODataFunction> GetComputedFunctions()
         {
             this.ComputeMissingOperationsToResource();
             return this.computedFunctions;

--- a/src/Microsoft.OData.Core/Json/JsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/JsonReader.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="JsonReader.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -3267,7 +3267,9 @@ namespace Microsoft.OData.Json
             int characterValue = ParseFourHexDigits(hexChar1, hexChar2, hexChar3, hexChar4);
             if (characterValue < 0)
             {
-                throw JsonReaderExtensions.CreateException(Error.Format(SRResources.JsonReader_UnrecognizedEscapeSequence, "\\u" + new string(new char[] {hexChar1, hexChar2, hexChar3, hexChar4})));
+                throw JsonReaderExtensions.CreateException(Error.Format(
+                    SRResources.JsonReader_UnrecognizedEscapeSequence,
+                    new string(this.characterBuffer, this.tokenStartIndex - 6, 6)));
             }
 
             return characterValue;

--- a/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="JsonValueUtils.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -8,6 +8,7 @@ namespace Microsoft.OData.Json
 {
     #region Namespaces
     using System;
+    using System.Buffers;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
@@ -48,6 +49,10 @@ namespace Microsoft.OData.Json
         /// Characters which, if found inside a number, indicate that the number is a double when no other type information is available.
         /// </summary>
         internal static readonly char[] DoubleIndicatingCharacters = new char[] { '.', 'e', 'E' };
+
+        /// <summary>
+        /// </summary>
+        internal static readonly SearchValues<char> DoubleIndicatingCharactersSearchValues = SearchValues.Create(DoubleIndicatingCharacters);
 
         /// <summary>
         /// Map of special characters to strings.
@@ -168,7 +173,7 @@ namespace Microsoft.OData.Json
                 string valueToWrite = XmlConvert.ToString(value);
 
                 writer.Write(valueToWrite);
-                if (valueToWrite.IndexOfAny(JsonValueUtils.DoubleIndicatingCharacters) < 0)
+                if (valueToWrite.AsSpan().IndexOfAny(JsonValueUtils.DoubleIndicatingCharactersSearchValues) < 0)
                 {
                     writer.Write(".0");
                 }
@@ -532,39 +537,46 @@ namespace Microsoft.OData.Json
         {
             Debug.Assert(inputString != null, "The string value must not be null.");
 
-            StringBuilder builder = new StringBuilder();
-            int startIndex = 0;
-            int inputStringLength = inputString.Length;
-            int subStrLength;
-            for (int currentIndex = 0; currentIndex < inputStringLength; currentIndex++)
+            StringBuilder builder = StringBuilderPool.Shared.Get();
+            try
             {
-                char c = inputString[currentIndex];
-
-                // Append the un-handled characters (that do not require special treatment)
-                // to the string builder when special characters are detected.
-                if (JsonValueUtils.SpecialCharToEscapedStringMap[c] == null)
+                int startIndex = 0;
+                int inputStringLength = inputString.Length;
+                int subStrLength;
+                for (int currentIndex = 0; currentIndex < inputStringLength; currentIndex++)
                 {
-                    continue;
+                    char c = inputString[currentIndex];
+
+                    // Append the un-handled characters (that do not require special treatment)
+                    // to the string builder when special characters are detected.
+                    if (JsonValueUtils.SpecialCharToEscapedStringMap[c] == null)
+                    {
+                        continue;
+                    }
+
+                    // Flush out the un-escaped characters we've built so far via AsSpan to avoid Substring allocation.
+                    subStrLength = currentIndex - startIndex;
+                    if (subStrLength > 0)
+                    {
+                        builder.Append(inputString.AsSpan(startIndex, subStrLength));
+                    }
+
+                    builder.Append(JsonValueUtils.SpecialCharToEscapedStringMap[c]);
+                    startIndex = currentIndex + 1;
                 }
 
-                // Flush out the un-escaped characters we've built so far.
-                subStrLength = currentIndex - startIndex;
+                subStrLength = inputStringLength - startIndex;
                 if (subStrLength > 0)
                 {
-                    builder.Append(inputString.Substring(startIndex, subStrLength));
+                    builder.Append(inputString.AsSpan(startIndex, subStrLength));
                 }
 
-                builder.Append(JsonValueUtils.SpecialCharToEscapedStringMap[c]);
-                startIndex = currentIndex + 1;
+                return builder.ToString();
             }
-
-            subStrLength = inputStringLength - startIndex;
-            if (subStrLength > 0)
+            finally
             {
-                builder.Append(inputString.Substring(startIndex, subStrLength));
+                StringBuilderPool.Shared.Return(builder);
             }
-
-            return builder.ToString();
         }
 
         /// <summary>
@@ -710,7 +722,7 @@ namespace Microsoft.OData.Json
                 if ((c < ' ') || (c > 0x7F))
                 {
                     // We only need to populate for characters < ' ' and > 0x7F.
-                    specialCharToEscapedStringMap[c] = string.Format(CultureInfo.InvariantCulture, "\\u{0:x4}", c);
+                    specialCharToEscapedStringMap[c] = string.Create(CultureInfo.InvariantCulture, $"\\u{c:x4}");
                 }
                 else
                 {
@@ -737,13 +749,8 @@ namespace Microsoft.OData.Json
         private static string FormatDateTimeAsJsonTicksString(DateTimeOffset value)
         {
             Int32 offsetMinutes = (Int32)value.Offset.TotalMinutes;
-
-            return String.Format(
-                CultureInfo.InvariantCulture,
-                JsonConstants.ODataDateTimeOffsetFormat,
-                DateTimeTicksToJsonTicks(value.Ticks),
-                offsetMinutes >= 0 ? JsonConstants.ODataDateTimeOffsetPlusSign : string.Empty,
-                offsetMinutes);
+            string sign = offsetMinutes >= 0 ? JsonConstants.ODataDateTimeOffsetPlusSign : string.Empty;
+            return string.Create(CultureInfo.InvariantCulture, $"\\/Date({DateTimeTicksToJsonTicks(value.Ticks)}{sign}{offsetMinutes:D4})\\/");
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="JsonValueUtils.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -134,9 +134,17 @@ namespace Microsoft.OData.Json
             // to use XmlConvert in all other cases, except infinity
             string valueToWrite = XmlConvert.ToString(value);
 
-            if (valueToWrite.IndexOfAny(DoubleIndicatingCharacters) < 0)
+            if (valueToWrite.AsSpan().IndexOfAny(DoubleIndicatingCharactersSearchValues) < 0)
             {
-                valueToWrite += ".0";
+                // Append ".0" via string.Create (single allocation) then a single WriteAsync, instead
+                // of two WriteAsync calls (which would create an async state machine for the continuation).
+                string withSuffix = string.Create(valueToWrite.Length + 2, valueToWrite, static (span, source) =>
+                {
+                    source.AsSpan().CopyTo(span);
+                    span[source.Length] = '.';
+                    span[source.Length + 1] = '0';
+                });
+                return writer.WriteAsync(withSuffix);
             }
 
             return writer.WriteAsync(valueToWrite);

--- a/src/Microsoft.OData.Core/Json/ODataAnnotationNames.cs
+++ b/src/Microsoft.OData.Core/Json/ODataAnnotationNames.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataAnnotationNames.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -8,6 +8,7 @@ namespace Microsoft.OData.Json
 {
     #region Namespaces
     using System;
+    using System.Collections.Frozen;
     using System.Collections.Generic;
     using System.Diagnostics;
     using Microsoft.OData.Core;
@@ -19,9 +20,9 @@ namespace Microsoft.OData.Json
     internal static class ODataAnnotationNames
     {
         /// <summary>
-        /// Hash set of known odata annotation names that have special meanings to OData Lib.
+        /// Frozen set of known odata annotation names that have special meanings to OData Lib.
         /// </summary>
-        internal static readonly HashSet<string> KnownODataAnnotationNames =
+        internal static readonly FrozenSet<string> KnownODataAnnotationNames =
             new HashSet<string>(
                 new[]
                 {
@@ -45,7 +46,7 @@ namespace Microsoft.OData.Json
                     ODataDelta,
                     ODataNull,
                 },
-                StringComparer.Ordinal);
+                StringComparer.Ordinal).ToFrozenSet(StringComparer.Ordinal);
 
         /// <summary>The OData Context annotation name.</summary>
         internal const string ODataContext = "odata.context";

--- a/src/Microsoft.OData.Core/Json/ODataJsonBatchBodyContentReaderStream.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonBatchBodyContentReaderStream.cs
@@ -94,8 +94,7 @@ namespace Microsoft.OData.Json
 
                     case BatchPayloadBodyContentType.Textual:
                     {
-                        string bodyContent = string.Format(CultureInfo.InvariantCulture,
-                            "\"{0}\"", jsonReader.ReadStringValue());
+                        string bodyContent = $"\"{jsonReader.ReadStringValue()}\"";
                         WriteBytes(Encoding.UTF8.GetBytes(bodyContent));
                     }
 
@@ -135,8 +134,7 @@ namespace Microsoft.OData.Json
             if (mediaType != null && mediaType.Type.Equals(MimeConstants.MimeTextType, StringComparison.Ordinal))
             {
                 // Explicit check for matching of textual content-type.
-                string bodyContent = string.Format(CultureInfo.InvariantCulture,
-                    "\"{0}\"", this.cachedBodyContent);
+                string bodyContent = $"\"{this.cachedBodyContent}\"";
                 WriteBytes(Encoding.UTF8.GetBytes(bodyContent));
             }
             else
@@ -185,8 +183,7 @@ namespace Microsoft.OData.Json
                         break;
 
                     case BatchPayloadBodyContentType.Textual:
-                        string bodyContent = string.Format(CultureInfo.InvariantCulture,
-                            "\"{0}\"", jsonReader.ReadStringValue());
+                        string bodyContent = $"\"{jsonReader.ReadStringValue()}\"";
                         await WriteBytesAsync(Encoding.UTF8.GetBytes(bodyContent))
                             .ConfigureAwait(false);
 
@@ -227,8 +224,7 @@ namespace Microsoft.OData.Json
             if (mediaType != null && mediaType.Type.Equals(MimeConstants.MimeTextType, StringComparison.Ordinal))
             {
                 // Explicit check for matching of textual content-type.
-                string bodyContent = string.Format(CultureInfo.InvariantCulture,
-                    "\"{0}\"", this.cachedBodyContent);
+                string bodyContent = $"\"{this.cachedBodyContent}\"";
                 await WriteBytesAsync(Encoding.UTF8.GetBytes(bodyContent))
                     .ConfigureAwait(false);
             }

--- a/src/Microsoft.OData.Core/Json/ODataJsonBatchPayloadItemPropertiesCache.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonBatchPayloadItemPropertiesCache.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataJsonBatchPayloadItemPropertiesCache.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -344,7 +344,7 @@ namespace Microsoft.OData.Json
         /// Wrapper method with validation to asynchronously scan the JSON object for known properties.
         /// </summary>
         /// <returns>A task that represents the asynchronous read operation.</returns>
-        private async Task ScanJsonPropertiesAsync()
+        private async ValueTask ScanJsonPropertiesAsync()
         {
             Debug.Assert(this.jsonReader != null, $"{nameof(this.jsonReader)} != null");
             Debug.Assert(this.jsonProperties == null, $"{nameof(this.jsonProperties)} == null");

--- a/src/Microsoft.OData.Core/Json/ODataJsonBatchReader.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonBatchReader.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataJsonBatchReader.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -616,7 +616,7 @@ namespace Microsoft.OData.Json
         /// Asynchronously verify the first JSON property of the batch payload to detect the reader's mode.
         /// </summary>
         /// <returns>A task that represents the asynchronous read operation.</returns>
-        private async Task DetectReaderModeAsync()
+        private async ValueTask DetectReaderModeAsync()
         {
             await this.batchStream.JsonReader.ReadNextAsync()
                 .ConfigureAwait(false);

--- a/src/Microsoft.OData.Core/Json/ODataJsonBatchWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonBatchWriter.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataJsonBatchWriter.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -278,9 +278,9 @@ namespace Microsoft.OData.Json
             List<string> dependsOnRequestIds = new List<string>();
             foreach (string id in dependsOnIds)
             {
-                if (this.atomicityGroupIdToRequestId.ContainsKey(id))
+                if (this.atomicityGroupIdToRequestId.TryGetValue(id, out IList<string> groupRequests))
                 {
-                    dependsOnRequestIds.AddRange(this.atomicityGroupIdToRequestId[id]);
+                    dependsOnRequestIds.AddRange(groupRequests);
                 }
                 else
                 {
@@ -739,11 +739,8 @@ namespace Microsoft.OData.Json
             // write the pending headers (if any)
             this.WritePendingMessageData(false);
 
-            this.jsonWriter.WriteRawValue(string.Format(CultureInfo.InvariantCulture,
-                "{0} \"{1}\" {2}",
-                JsonConstants.ArrayElementSeparator,
-                PropertyBody,
-                JsonConstants.NameValueSeparator));
+            this.jsonWriter.WriteRawValue(
+                $"{JsonConstants.ArrayElementSeparator} \"{PropertyBody}\" {JsonConstants.NameValueSeparator}");
 
             // flush the text writer to make sure all buffers of the text writer
             // are flushed to the underlying async stream
@@ -887,7 +884,7 @@ namespace Microsoft.OData.Json
                     case BatchPayloadUriOption.AbsoluteUriUsingHostHeader:
                         string absoluteResourcePath = ExtractAbsoluteResourcePath(absoluteUriString);
                         this.jsonWriter.WriteValue(absoluteResourcePath);
-                        this.CurrentOperationRequestMessage.SetHeader("host", string.Format(CultureInfo.InvariantCulture, "{0}:{1}", uri.Host, uri.Port));
+                        this.CurrentOperationRequestMessage.SetHeader("host", FormattableString.Invariant($"{uri.Host}:{uri.Port}"));
                         break;
 
                     case BatchPayloadUriOption.RelativeUri:
@@ -919,7 +916,7 @@ namespace Microsoft.OData.Json
         /// Asynchronously writes all the pending headers and prepares the writer to write a content of the operation.
         /// </summary>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task StartBatchOperationContentAsync()
+        private async ValueTask StartBatchOperationContentAsync()
         {
             Debug.Assert(this.CurrentOperationMessage != null, "Expected non-null operation message!");
             Debug.Assert(this.jsonWriter != null, "Must have a Json writer!");
@@ -928,11 +925,8 @@ namespace Microsoft.OData.Json
             await this.WritePendingMessageDataAsync(false)
                 .ConfigureAwait(false);
 
-            await this.jsonWriter.WriteRawValueAsync(string.Format(CultureInfo.InvariantCulture,
-                "{0} \"{1}\" {2}",
-                JsonConstants.ArrayElementSeparator,
-                PropertyBody,
-                JsonConstants.NameValueSeparator)).ConfigureAwait(false);
+            await this.jsonWriter.WriteRawValueAsync(
+                $"{JsonConstants.ArrayElementSeparator} \"{PropertyBody}\" {JsonConstants.NameValueSeparator}").ConfigureAwait(false);
 
             // flush the text writer to make sure all buffers of the text writer
             // are flushed to the underlying async stream
@@ -947,7 +941,7 @@ namespace Microsoft.OData.Json
         /// A flag to control whether after writing the pending data we report writing the message to be completed or not.
         /// </param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WritePendingMessageDataAsync(bool reportMessageCompleted)
+        private async ValueTask WritePendingMessageDataAsync(bool reportMessageCompleted)
         {
             if (this.CurrentOperationMessage != null)
             {
@@ -993,7 +987,7 @@ namespace Microsoft.OData.Json
         /// Always sets the isBatchEnvelopeWritten flag to true before return.
         /// </summary>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteBatchEnvelopeAsync()
+        private async ValueTask WriteBatchEnvelopeAsync()
         {
             // Start the top level scope
             await this.jsonWriter.StartObjectScopeAsync()
@@ -1010,7 +1004,7 @@ namespace Microsoft.OData.Json
         /// Asynchronously writes pending data for the current request message.
         /// </summary>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WritePendingRequestMessageDataAsync()
+        private async ValueTask WritePendingRequestMessageDataAsync()
         {
             Debug.Assert(this.CurrentOperationRequestMessage != null, "this.CurrentOperationRequestMessage != null");
 
@@ -1039,7 +1033,7 @@ namespace Microsoft.OData.Json
         /// Asynchronously writes pending data for the current response message.
         /// </summary>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WritePendingResponseMessageDataAsync()
+        private async ValueTask WritePendingResponseMessageDataAsync()
         {
             Debug.Assert(this.JsonOutputContext.WritingResponse, "If the response message is available we must be writing response.");
             Debug.Assert(this.CurrentOperationResponseMessage != null, "this.CurrentOperationResponseMessage != null");
@@ -1094,7 +1088,7 @@ namespace Microsoft.OData.Json
         /// The format of operation Request-URI, which could be AbsoluteUri, AbsoluteResourcePathAndHost, or RelativeResourcePath.
         /// </param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteRequestUriAsync(Uri uri, BatchPayloadUriOption payloadUriOption)
+        private async ValueTask WriteRequestUriAsync(Uri uri, BatchPayloadUriOption payloadUriOption)
         {
             await this.jsonWriter.WriteNameAsync(PropertyUrl)
                 .ConfigureAwait(false);
@@ -1116,7 +1110,7 @@ namespace Microsoft.OData.Json
                         await this.jsonWriter.WriteValueAsync(absoluteResourcePath)
                             .ConfigureAwait(false);
                         this.CurrentOperationRequestMessage.SetHeader("host",
-                            string.Format(CultureInfo.InvariantCulture, "{0}:{1}", uri.Host, uri.Port));
+                            FormattableString.Invariant($"{uri.Host}:{uri.Port}"));
                         break;
 
                     case BatchPayloadUriOption.RelativeUri:

--- a/src/Microsoft.OData.Core/Json/ODataJsonContextUriParseResult.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonContextUriParseResult.cs
@@ -70,7 +70,7 @@ namespace Microsoft.OData.Json
         /// <summary>
         /// The detected payload kinds from parsing the context URI.
         /// </summary>
-        internal IEnumerable<ODataPayloadKind> DetectedPayloadKinds { get; set; }
+        internal IReadOnlyList<ODataPayloadKind> DetectedPayloadKinds { get; set; }
 
         /// <summary>
         /// ODataPath parsed from context Url

--- a/src/Microsoft.OData.Core/Json/ODataJsonContextUriParser.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonContextUriParser.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OData.Json
     /// <summary>
     /// Parser for odata context URIs used in JSON.
     /// </summary>
-    internal sealed class ODataJsonContextUriParser
+    internal sealed partial class ODataJsonContextUriParser
     {
         /// <summary>
         /// Pattern for key segments, Examples:
@@ -29,7 +29,10 @@ namespace Microsoft.OData.Json
         /// Customer(baf04077-a3c0-454b-ac6f-9fec00b8e170), Message(FromUsername='1',MessageId=-10)
         /// Message(geography'SRID=0;Collection(LineString(142.1 64.1,3.14 2.78))'),Message(duration'P6DT23H59M59.9999S')
         /// </summary>
-        private static readonly Regex KeyPattern = new Regex(@"^(?:-{0,1}\d+?|\w*'.+?'|[A-F0-9]{8}(?:-[A-F0-9]{4}){3}-[A-F0-9]{12}|.+?=.+?)$", RegexOptions.IgnoreCase);
+        [GeneratedRegex(@"^(?:-{0,1}\d+?|\w*'.+?'|[A-F0-9]{8}(?:-[A-F0-9]{4}){3}-[A-F0-9]{12}|.+?=.+?)$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+        private static partial Regex KeyPatternRegex();
+
+        private static readonly Regex KeyPattern = KeyPatternRegex();
 
         /// <summary>The model to use when resolving the target of the URI.</summary>
         private readonly IEdmModel model;

--- a/src/Microsoft.OData.Core/Json/ODataJsonDeserializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonDeserializer.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataJsonDeserializer.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -547,12 +547,11 @@ namespace Microsoft.OData.Json
                 return;
             }
 
-            string message = string.Format(
-                CultureInfo.InvariantCulture,
-                "JSON condition failed: the JsonReader is on node {0} (Value: {1}) but it was expected be on {2}.",
-                this.JsonReader.NodeType.ToString(),
+            string message = Error.Format(
+                SRResources.ODataJsonDeserializer_AssertJsonConditionFailed,
+                this.JsonReader.NodeType,
                 this.JsonReader.GetValue(),
-                string.Join(",", allowedNodeTypes.Select(n => n.ToString()).ToArray()));
+                string.Join(',', allowedNodeTypes.Select(n => n.ToString())));
             Debug.Assert(false, message);
 #endif
         }

--- a/src/Microsoft.OData.Core/Json/ODataJsonEntityReferenceLinkDeserializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonEntityReferenceLinkDeserializer.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataJsonEntityReferenceLinkDeserializer.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -539,7 +539,7 @@ namespace Microsoft.OData.Json
         /// Post-Condition: JsonNodeType.EndObject              When the end of the entity reference links object is reached
         ///                 Any                                 The first node of the value of the 'url' property (if found)
         /// </remarks>
-        private async Task ReadEntityReferenceLinksAnnotationsAsync(
+        private async ValueTask ReadEntityReferenceLinksAnnotationsAsync(
             ODataEntityReferenceLinks links,
             PropertyAndAnnotationCollector propertyAndAnnotationCollector,
             bool forLinksStart)

--- a/src/Microsoft.OData.Core/Json/ODataJsonOutputContext.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonOutputContext.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataJsonOutputContext.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -1045,7 +1045,7 @@ namespace Microsoft.OData.Json
         /// be included in the payload. This should only be used in debug scenarios.
         /// </param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteInStreamErrorImplementationAsync(ODataError error, bool includeDebugInformation)
+        private async ValueTask WriteInStreamErrorImplementationAsync(ODataError error, bool includeDebugInformation)
         {
             if (this.outputInStreamErrorListener != null)
             {
@@ -1077,7 +1077,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="property">The property to write.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WritePropertyImplementationAsync(ODataProperty property)
+        private async ValueTask WritePropertyImplementationAsync(ODataProperty property)
         {
             ODataJsonPropertySerializer jsonPropertySerializer = new ODataJsonPropertySerializer(this, /*initContextUriBuilder*/ true);
             await jsonPropertySerializer.WriteTopLevelPropertyAsync(property)
@@ -1101,7 +1101,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="serviceDocument">The service document to write.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteServiceDocumentImplementationAsync(ODataServiceDocument serviceDocument)
+        private async ValueTask WriteServiceDocumentImplementationAsync(ODataServiceDocument serviceDocument)
         {
             ODataJsonServiceDocumentSerializer jsonServiceDocumentSerializer = new ODataJsonServiceDocumentSerializer(this);
             await jsonServiceDocumentSerializer.WriteServiceDocumentAsync(serviceDocument)
@@ -1131,7 +1131,7 @@ namespace Microsoft.OData.Json
         /// be included in the payload. This should only be used in debug scenarios.
         /// </param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteErrorImplementationAsync(ODataError error, bool includeDebugInformation)
+        private async ValueTask WriteErrorImplementationAsync(ODataError error, bool includeDebugInformation)
         {
             ODataJsonSerializer jsonSerializer = new ODataJsonSerializer(this, false);
             await jsonSerializer.WriteTopLevelErrorAsync(error, includeDebugInformation)
@@ -1153,7 +1153,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="links">The entity reference links to write as message payload.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteEntityReferenceLinksImplementationAsync(ODataEntityReferenceLinks links)
+        private async ValueTask WriteEntityReferenceLinksImplementationAsync(ODataEntityReferenceLinks links)
         {
             ODataJsonEntityReferenceLinkSerializer jsonEntityReferenceLinkSerializer = new ODataJsonEntityReferenceLinkSerializer(this);
             await jsonEntityReferenceLinkSerializer.WriteEntityReferenceLinksAsync(links)
@@ -1175,7 +1175,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="link">The entity reference link to write as message payload.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteEntityReferenceLinkImplementationAsync(ODataEntityReferenceLink link)
+        private async ValueTask WriteEntityReferenceLinkImplementationAsync(ODataEntityReferenceLink link)
         {
             ODataJsonEntityReferenceLinkSerializer jsonEntityReferenceLinkSerializer = new ODataJsonEntityReferenceLinkSerializer(this);
             await jsonEntityReferenceLinkSerializer.WriteEntityReferenceLinkAsync(link)

--- a/src/Microsoft.OData.Core/Json/ODataJsonPropertyAndValueDeserializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonPropertyAndValueDeserializer.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataJsonPropertyAndValueDeserializer.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -3618,7 +3618,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="propertyAndAnnotationCollector">The duplicate property names checker to use.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        private async Task ValidateNoPropertyInNullPayloadAsync(PropertyAndAnnotationCollector propertyAndAnnotationCollector)
+        private async ValueTask ValidateNoPropertyInNullPayloadAsync(PropertyAndAnnotationCollector propertyAndAnnotationCollector)
         {
             Debug.Assert(propertyAndAnnotationCollector != null, "propertyAndAnnotationCollector != null");
 

--- a/src/Microsoft.OData.Core/Json/ODataJsonPropertySerializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonPropertySerializer.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataJsonPropertySerializer.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -926,7 +926,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="untypedValue">The untyped value to write.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteUntypedValueAsync(ODataUntypedValue untypedValue)
+        private async ValueTask WriteUntypedValueAsync(ODataUntypedValue untypedValue)
         {
             await this.JsonWriter.WriteNameAsync(this.currentPropertyInfo.WireName)
                 .ConfigureAwait(false);
@@ -938,7 +938,7 @@ namespace Microsoft.OData.Json
         /// Asynchronously writes an <see cref="System.Text.Json.JsonElement"/> value.
         /// </summary>
         /// <param name="jsonElementValue">The value to be written.</param>
-        private async Task WriteJsonElementPropertyAsync(ODataJsonElementValue jsonElementValue)
+        private async ValueTask WriteJsonElementPropertyAsync(ODataJsonElementValue jsonElementValue)
         {
             await this.JsonWriter.WriteNameAsync(this.currentPropertyInfo.WireName)
                 .ConfigureAwait(false);
@@ -953,7 +953,7 @@ namespace Microsoft.OData.Json
         /// <param name="propertyName">The property name.</param>
         /// <param name="metadataBuilder">The metadata builder for the resource.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteStreamValueAsync(
+        private async ValueTask WriteStreamValueAsync(
             IODataStreamReferenceInfo streamInfo,
             string propertyName,
             ODataResourceMetadataBuilder metadataBuilder)
@@ -974,21 +974,21 @@ namespace Microsoft.OData.Json
         /// <param name="isTopLevel">If writing top level property.</param>
         /// <param name="isUndeclaredProperty">If writing an undeclared property.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private Task WriteInstanceAnnotationAsync(ODataPropertyInfo property, bool isTopLevel, bool isUndeclaredProperty)
+        private ValueTask WriteInstanceAnnotationAsync(ODataPropertyInfo property, bool isTopLevel, bool isUndeclaredProperty)
         {
             if (property.InstanceAnnotations.Count != 0)
             {
                 if (isTopLevel)
                 {
-                    return this.InstanceAnnotationWriter.WriteInstanceAnnotationsAsync(property.InstanceAnnotations);
+                    return new ValueTask(this.InstanceAnnotationWriter.WriteInstanceAnnotationsAsync(property.InstanceAnnotations));
                 }
                 else
                 {
-                    return this.InstanceAnnotationWriter.WriteInstanceAnnotationsAsync(property.InstanceAnnotations, property.Name, isUndeclaredProperty);
+                    return new ValueTask(this.InstanceAnnotationWriter.WriteInstanceAnnotationsAsync(property.InstanceAnnotations, property.Name, isUndeclaredProperty));
                 }
             }
 
-            return Task.CompletedTask;
+            return default;
         }
 
         /// <summary>
@@ -997,7 +997,7 @@ namespace Microsoft.OData.Json
         /// <param name="property">The property to handle.</param>
         /// <param name="isTopLevel">If writing top level property.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private Task WriteODataTypeAnnotationAsync(ODataPropertyInfo property, bool isTopLevel)
+        private ValueTask WriteODataTypeAnnotationAsync(ODataPropertyInfo property, bool isTopLevel)
         {
             if (property.TypeAnnotation != null && property.TypeAnnotation.TypeName != null)
             {
@@ -1010,17 +1010,17 @@ namespace Microsoft.OData.Json
                 {
                     if (isTopLevel)
                     {
-                        return this.ODataAnnotationWriter.WriteODataTypeInstanceAnnotationAsync(typeName);
+                        return new ValueTask(this.ODataAnnotationWriter.WriteODataTypeInstanceAnnotationAsync(typeName));
                     }
                     else
                     {
-                        return this.ODataAnnotationWriter.WriteODataTypePropertyAnnotationAsync(property.Name, typeName);
+                        return new ValueTask(this.ODataAnnotationWriter.WriteODataTypePropertyAnnotationAsync(property.Name, typeName));
 
                     }
                 }
             }
 
-            return Task.CompletedTask;
+            return default;
         }
 
         /// <summary>
@@ -1029,7 +1029,7 @@ namespace Microsoft.OData.Json
         /// <param name="propertyName">The name of the stream property to write.</param>
         /// <param name="streamInfo">The stream reference value to be written</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteStreamInfoAsync(string propertyName, IODataStreamReferenceInfo streamInfo)
+        private async ValueTask WriteStreamInfoAsync(string propertyName, IODataStreamReferenceInfo streamInfo)
         {
             Debug.Assert(!string.IsNullOrEmpty(propertyName), "!string.IsNullOrEmpty(propertyName)");
             Debug.Assert(streamInfo != null, "streamReferenceValue != null");
@@ -1076,7 +1076,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="property">The property to write out.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteNullPropertyAsync(
+        private async ValueTask WriteNullPropertyAsync(
             ODataPropertyInfo property)
         {
             this.WriterValidator.ValidateNullPropertyValue(
@@ -1120,7 +1120,7 @@ namespace Microsoft.OData.Json
         /// <param name="resourceValue">The resource value to be written</param>
         /// <param name="isOpenPropertyType">If the property is open.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteResourcePropertyAsync(
+        private async ValueTask WriteResourcePropertyAsync(
             ODataProperty property,
             ODataResourceValue resourceValue,
             bool isOpenPropertyType)
@@ -1146,7 +1146,7 @@ namespace Microsoft.OData.Json
         /// <param name="enumValue">The enum value to be written.</param>
         /// <param name="isOpenPropertyType">If the property is open.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteEnumPropertyAsync(
+        private async ValueTask WriteEnumPropertyAsync(
             ODataEnumValue enumValue,
             bool isOpenPropertyType)
         {
@@ -1165,7 +1165,7 @@ namespace Microsoft.OData.Json
         /// <param name="collectionValue">The collection value to be written</param>
         /// <param name="isOpenPropertyType">If the property is open.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteCollectionPropertyAsync(
+        private async ValueTask WriteCollectionPropertyAsync(
             ODataCollectionValue collectionValue,
             bool isOpenPropertyType)
         {
@@ -1192,7 +1192,7 @@ namespace Microsoft.OData.Json
         /// <param name="streamValue">The stream value to be written</param>
         /// <param name="isOpenPropertyType">If the property is open.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteStreamPropertyAsync(ODataBinaryStreamValue streamValue, bool isOpenPropertyType)
+        private async ValueTask WriteStreamPropertyAsync(ODataBinaryStreamValue streamValue, bool isOpenPropertyType)
         {
             await this.JsonWriter.WriteNameAsync(this.currentPropertyInfo.WireName)
                 .ConfigureAwait(false);
@@ -1206,7 +1206,7 @@ namespace Microsoft.OData.Json
         /// <param name="primitiveValue">The primitive value to be written</param>
         /// <param name="isOpenPropertyType">If the property is open.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WritePrimitivePropertyAsync(
+        private async ValueTask WritePrimitivePropertyAsync(
             ODataPrimitiveValue primitiveValue,
             bool isOpenPropertyType)
         {
@@ -1225,7 +1225,7 @@ namespace Microsoft.OData.Json
         /// Asynchronously writes the type name on the wire.
         /// </summary>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private Task WritePropertyTypeNameAsync()
+        private ValueTask WritePropertyTypeNameAsync()
         {
             string typeNameToWrite = this.currentPropertyInfo.TypeNameToWrite;
             if (typeNameToWrite != null)
@@ -1233,15 +1233,15 @@ namespace Microsoft.OData.Json
                 // We write the type name as an instance annotation (named "odata.type") for top-level properties, but as a property annotation (e.g., "...@odata.type") if not top level.
                 if (this.currentPropertyInfo.IsTopLevel)
                 {
-                    return this.ODataAnnotationWriter.WriteODataTypeInstanceAnnotationAsync(typeNameToWrite);
+                    return new ValueTask(this.ODataAnnotationWriter.WriteODataTypeInstanceAnnotationAsync(typeNameToWrite));
                 }
                 else
                 {
-                    return this.ODataAnnotationWriter.WriteODataTypePropertyAnnotationAsync(this.currentPropertyInfo.PropertyName, typeNameToWrite);
+                    return new ValueTask(this.ODataAnnotationWriter.WriteODataTypePropertyAnnotationAsync(this.currentPropertyInfo.PropertyName, typeNameToWrite));
                 }
             }
 
-            return Task.CompletedTask;
+            return default;
         }
     }
 }

--- a/src/Microsoft.OData.Core/Json/ODataJsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonReader.cs
@@ -3165,7 +3165,7 @@ namespace Microsoft.OData.Json
         /// Asynchronously reads the next item in a nested resource info content in a request payload.
         /// </summary>
         /// <returns>A task that represents the asynchronous read operation.</returns>
-        private async Task ReadNextNestedResourceInfoContentItemInRequestAsync()
+        private async ValueTask ReadNextNestedResourceInfoContentItemInRequestAsync()
         {
             Debug.Assert(
                 this.CurrentScope.State == ODataReaderState.NestedResourceInfoStart,
@@ -3214,7 +3214,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="state">The reader state to switch to.</param>
         /// <returns>A task that represents the asynchronous read operation.</returns>
-        private async Task StartDeltaLinkAsync(ODataReaderState state)
+        private async ValueTask StartDeltaLinkAsync(ODataReaderState state)
         {
             Debug.Assert(
                 state == ODataReaderState.DeltaLink || state == ODataReaderState.DeltaDeletedLink,
@@ -3266,7 +3266,7 @@ namespace Microsoft.OData.Json
         ///                 JsonNodeType.StartArray
         /// Post-Condition: The reader is positioned on the first item in the resource set, or on the end array of the resource set.
         /// </remarks>
-        private async Task ReadResourceSetStartAsync(ODataResourceSet resourceSet, SelectedPropertiesNode selectedProperties)
+        private async ValueTask ReadResourceSetStartAsync(ODataResourceSet resourceSet, SelectedPropertiesNode selectedProperties)
         {
             Debug.Assert(resourceSet != null, "resourceSet != null");
 
@@ -3294,7 +3294,7 @@ namespace Microsoft.OData.Json
         /// Asynchronously reads the end of the current resource set.
         /// </summary>
         /// <returns>A task that represents the asynchronous read operation.</returns>
-        private async Task ReadResourceSetEndAsync()
+        private async ValueTask ReadResourceSetEndAsync()
         {
             Debug.Assert(
                 this.State == ODataReaderState.ResourceSetStart || this.State == ODataReaderState.DeltaResourceSetStart,
@@ -3338,7 +3338,7 @@ namespace Microsoft.OData.Json
         ///                 JsonNodeType.Property               Property after deferred link or expanded entity reference
         ///                 JsonNodeType.EndObject              If no (more) properties exist in the resource's content
         /// </remarks>
-        private async Task ReadExpandedNestedResourceInfoStartAsync(ODataNestedResourceInfo nestedResourceInfo)
+        private async ValueTask ReadExpandedNestedResourceInfoStartAsync(ODataNestedResourceInfo nestedResourceInfo)
         {
             Debug.Assert(nestedResourceInfo != null, "nestedResourceInfo != null");
 
@@ -3408,7 +3408,7 @@ namespace Microsoft.OData.Json
         ///                 JsonNodeType.Property               Property after deferred link or expanded entity reference
         ///                 JsonNodeType.EndObject              If no (more) properties exist in the resource's content
         /// </remarks>
-        private async Task ReadResourceSetItemStartAsync(PropertyAndAnnotationCollector propertyAndAnnotationCollector,
+        private async ValueTask ReadResourceSetItemStartAsync(PropertyAndAnnotationCollector propertyAndAnnotationCollector,
             SelectedPropertiesNode selectedProperties)
         {
             IEdmNavigationSource source = this.CurrentNavigationSource;
@@ -3598,7 +3598,7 @@ namespace Microsoft.OData.Json
         /// Asynchronously reads the next entity or complex value (or primitive or collection value for an untyped collection) in a resource set.
         /// </summary>
         /// <returns>A task that represents the asynchronous read operation.</returns>
-        private async Task ReadNextResourceSetItemAsync()
+        private async ValueTask ReadNextResourceSetItemAsync()
         {
             Debug.Assert(this.State == ODataReaderState.ResourceSetStart ||
                 this.State == ODataReaderState.DeltaResourceSetStart,
@@ -3690,7 +3690,7 @@ namespace Microsoft.OData.Json
         ///                 JsonNodeType.StartArray
         /// Post-Condition: The reader is positioned on the first item in the resource set, or on the end array of the resource set.
         /// </remarks>
-        private async Task ReadDeltaResourceSetStartAsync(ODataDeltaResourceSet deltaResourceSet, SelectedPropertiesNode selectedProperties)
+        private async ValueTask ReadDeltaResourceSetStartAsync(ODataDeltaResourceSet deltaResourceSet, SelectedPropertiesNode selectedProperties)
         {
             Debug.Assert(deltaResourceSet != null, "resourceSet != null");
 
@@ -3717,7 +3717,7 @@ namespace Microsoft.OData.Json
         /// Asynchronously read the resource up to the first nested resource info.
         /// </summary>
         /// <returns>A task that represents the asynchronous read operation.</returns>
-        private async Task StartReadingResourceAsync()
+        private async ValueTask StartReadingResourceAsync()
         {
             ODataResourceBase currentResource = this.Item as ODataResourceBase;
 

--- a/src/Microsoft.OData.Core/Json/ODataJsonResourceSerializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonResourceSerializer.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataJsonResourceSerializer.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -862,7 +862,7 @@ namespace Microsoft.OData.Json
         /// <param name="propertyName">The name of the navigation property for which to write the association link.</param>
         /// <param name="associationLinkUrl">The association link URL to write.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteAssociationLinkAsync(string propertyName, Uri associationLinkUrl)
+        private async ValueTask WriteAssociationLinkAsync(string propertyName, Uri associationLinkUrl)
         {
             Debug.Assert(!String.IsNullOrEmpty(propertyName), "!string.IsNullOrEmpty(propertyName)");
             Debug.Assert(associationLinkUrl != null, "associationLinkUrl != null");
@@ -882,7 +882,7 @@ namespace Microsoft.OData.Json
         /// </remarks>
         /// <param name="operations">A grouping of operations that are all actions or all functions and share the same "metadata".</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteOperationMetadataGroupAsync(IGrouping<string, ODataOperation> operations)
+        private async ValueTask WriteOperationMetadataGroupAsync(IGrouping<string, ODataOperation> operations)
         {
             this.ValidateOperationMetadataGroup(operations);
             await this.JsonOutputContext.JsonWriter.WriteNameAsync(operations.Key)
@@ -915,7 +915,7 @@ namespace Microsoft.OData.Json
         /// Expects the write to already have written the "rel value" and opened an array.
         /// </remarks>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteOperationAsync(ODataOperation operation)
+        private async ValueTask WriteOperationAsync(ODataOperation operation)
         {
             Debug.Assert(operation != null, "operation must not be null.");
             Debug.Assert(operation.Metadata != null, "operation.Metadata != null");

--- a/src/Microsoft.OData.Core/Json/ODataJsonServiceDocumentSerializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonServiceDocumentSerializer.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataJsonServiceDocumentSerializer.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -217,7 +217,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="serviceDocumentElement">The element in service document to write.</param>
         /// <param name="kind">Kind of the service document element, optional for entitysets must for FunctionImport and Singleton.</param>
-        private async Task WriteServiceDocumentElementAsync(ODataServiceDocumentElement serviceDocumentElement, string kind)
+        private async ValueTask WriteServiceDocumentElementAsync(ODataServiceDocumentElement serviceDocumentElement, string kind)
         {
             // validate that the resource has a non-null url.
             ValidationUtils.ValidateServiceDocumentElement(serviceDocumentElement, ODataFormat.Json);

--- a/src/Microsoft.OData.Core/Json/ODataJsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonWriter.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataJsonWriter.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -526,14 +526,14 @@ namespace Microsoft.OData.Json
                 {
                     // write "odata.actions" metadata
                     IEnumerable<ODataAction> actions = resourceSet.Actions;
-                    if (actions != null && actions.Any())
+                    if (actions != null && Utils.HasAny(actions))
                     {
                         this.jsonResourceSerializer.WriteOperations(actions.Cast<ODataOperation>(), /*isAction*/ true);
                     }
 
                     // write "odata.functions" metadata
                     IEnumerable<ODataFunction> functions = resourceSet.Functions;
-                    if (functions != null && functions.Any())
+                    if (functions != null && Utils.HasAny(functions))
                     {
                         this.jsonResourceSerializer.WriteOperations(functions.Cast<ODataOperation>(), /*isAction*/ false);
                     }
@@ -1482,7 +1482,7 @@ namespace Microsoft.OData.Json
                 {
                     // Write "odata.actions" metadata
                     IEnumerable<ODataAction> actions = resourceSet.Actions;
-                    if (actions != null && actions.Any())
+                    if (actions != null && Utils.HasAny(actions))
                     {
                         await this.jsonResourceSerializer.WriteOperationsAsync(actions.Cast<ODataOperation>(), /*isAction*/ true)
                             .ConfigureAwait(false);
@@ -1490,7 +1490,7 @@ namespace Microsoft.OData.Json
 
                     // Write "odata.functions" metadata
                     IEnumerable<ODataFunction> functions = resourceSet.Functions;
-                    if (functions != null && functions.Any())
+                    if (functions != null && Utils.HasAny(functions))
                     {
                         await this.jsonResourceSerializer.WriteOperationsAsync(functions.Cast<ODataOperation>(), /*isAction*/ false)
                             .ConfigureAwait(false);
@@ -2619,7 +2619,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="entityReferenceLink">The OData entity reference link.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteEntityReferenceLinkImplementationAsync(ODataEntityReferenceLink entityReferenceLink)
+        private async ValueTask WriteEntityReferenceLinkImplementationAsync(ODataEntityReferenceLink entityReferenceLink)
         {
             Debug.Assert(entityReferenceLink != null, "entityReferenceLink != null");
 
@@ -2775,7 +2775,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="resource">The deleted resource to write deleted entry contents for</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteV4DeletedEntryContentsAsync(ODataDeletedResource resource)
+        private async ValueTask WriteV4DeletedEntryContentsAsync(ODataDeletedResource resource)
         {
             await this.WriteDeletedResourceIdAsync(resource)
                 .ConfigureAwait(false);
@@ -2788,7 +2788,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="resource">The deleted resource to write deleted entry contents for</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteDeletedEntryContentsAsync(ODataDeletedResource resource)
+        private async ValueTask WriteDeletedEntryContentsAsync(ODataDeletedResource resource)
         {
             await this.odataAnnotationWriter.WriteInstanceAnnotationNameAsync(
                 ODataAnnotationNames.ODataRemoved).ConfigureAwait(false);
@@ -2825,7 +2825,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="resource">The resource to write the id for.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteDeletedResourceIdAsync(ODataDeletedResource resource)
+        private async ValueTask WriteDeletedResourceIdAsync(ODataDeletedResource resource)
         {
             Debug.Assert(resource != null, "resource != null");
             if (this.Version == null || this.Version < ODataVersion.V401)
@@ -2879,7 +2879,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="resource">The resource to write the reason for.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteDeltaResourceReasonAsync(ODataDeletedResource resource)
+        private async ValueTask WriteDeltaResourceReasonAsync(ODataDeletedResource resource)
         {
             Debug.Assert(resource != null, "resource != null");
 
@@ -2925,7 +2925,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="link">The link to write source for.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteDeltaLinkSourceAsync(ODataDeltaLinkBase link)
+        private async ValueTask WriteDeltaLinkSourceAsync(ODataDeltaLinkBase link)
         {
             Debug.Assert(link != null, "link != null");
             Debug.Assert(link is ODataDeltaLink || link is ODataDeltaDeletedLink,
@@ -2942,7 +2942,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="link">The link to write relationship for.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteDeltaLinkRelationshipAsync(ODataDeltaLinkBase link)
+        private async ValueTask WriteDeltaLinkRelationshipAsync(ODataDeltaLinkBase link)
         {
             Debug.Assert(link != null, "link != null");
             Debug.Assert(link is ODataDeltaLink || link is ODataDeltaDeletedLink,
@@ -2959,7 +2959,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="link">The link to write target for.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteDeltaLinkTargetAsync(ODataDeltaLinkBase link)
+        private async ValueTask WriteDeltaLinkTargetAsync(ODataDeltaLinkBase link)
         {
             Debug.Assert(link != null, "link != null");
             Debug.Assert(link is ODataDeltaLink || link is ODataDeltaDeletedLink,

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataUtf8JsonWriter.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -197,8 +197,16 @@ namespace Microsoft.OData.Json
         public void WritePaddingFunctionName(string functionName)
         {
             this.CommitUtf8JsonWriterContentsToBuffer();
-            this.bufferWriter.Write(Encoding.UTF8.GetBytes(functionName));
+            this.WritePaddingFunctionNameCore(functionName);
             this.DrainBufferIfThresholdReached();
+        }
+
+        private void WritePaddingFunctionNameCore(string functionName)
+        {
+            int byteCount = Encoding.UTF8.GetByteCount(functionName);
+            Span<byte> destination = this.bufferWriter.GetSpan(byteCount);
+            int written = Encoding.UTF8.GetBytes(functionName.AsSpan(), destination);
+            this.bufferWriter.Advance(written);
         }
 
         public void EndPaddingFunctionScope()
@@ -307,6 +315,13 @@ namespace Microsoft.OData.Json
         public void WriteValue(double value)
         {
             this.WriteSeparatorIfNecessary();
+            this.WriteFiniteOrSpecialDoubleValue(value);
+            this.DrainBufferIfThresholdReached();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteFiniteOrSpecialDoubleValue(double value)
+        {
             if (double.IsNaN(value))
             {
                 this.utf8JsonWriter.WriteStringValue(nanValue.Span);
@@ -321,21 +336,26 @@ namespace Microsoft.OData.Json
             }
             else
             {
-                // whereas double.MinValue and double.MaxValue have 16 digits scale. Hence we need
-                // to use XmlConvert in all other cases, except infinity
-                string valueToWrite = XmlConvert.ToString(value);
+                // "R" round-trip format matches XmlConvert.ToString(double) for finite values.
+                Span<char> buffer = stackalloc char[32];
+                int written;
+                if (!value.TryFormat(buffer, out written, "R", CultureInfo.InvariantCulture))
+                {
+                    string s = XmlConvert.ToString(value);
+                    s.AsSpan().CopyTo(buffer);
+                    written = s.Length;
+                }
 
-                // We write doubles like 100 as 100.0 (with .0 decimal point).
-                // We do this to retain consistency with the legacy JsonWriter and with older
-                // versions. However, it's not a hard requirement. Clients should not rely on the .0
-                // to decide whether a value is an integer or double. We should consider
-                // dropping this in the future (potentially behind a compatibility flag) to avoid
-                // the cost of converting to a string and checking whether a decimal point is needed.
-                bool needsFractionalPart = valueToWrite.IndexOfAny(JsonValueUtils.DoubleIndicatingCharacters) == -1;
-                this.utf8JsonWriter.WriteRawValue(needsFractionalPart ? $"{valueToWrite}.0" : valueToWrite, skipInputValidation: true);
+                bool needsFractionalPart = buffer.Slice(0, written).IndexOfAny(JsonValueUtils.DoubleIndicatingCharactersSearchValues) == -1;
+                if (needsFractionalPart && written + 2 <= buffer.Length)
+                {
+                    buffer[written] = '.';
+                    buffer[written + 1] = '0';
+                    written += 2;
+                }
+
+                this.utf8JsonWriter.WriteRawValue(buffer.Slice(0, written), skipInputValidation: true);
             }
-
-            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(Guid value)
@@ -719,7 +739,10 @@ namespace Microsoft.OData.Json
                 this.bufferWriter.Write(itemSeparator.Slice(0, 1).Span);
             }
 
-            this.bufferWriter.Write(Encoding.UTF8.GetBytes(rawValue));
+            int byteCount = Encoding.UTF8.GetByteCount(rawValue);
+            Span<byte> destination = this.bufferWriter.GetSpan(byteCount);
+            int written = Encoding.UTF8.GetBytes(rawValue.AsSpan(), destination);
+            this.bufferWriter.Advance(written);
 
             // since we bypass the Utf8JsonWriter, we need to signal to other
             // Write methods that a separator should be written first
@@ -908,7 +931,7 @@ namespace Microsoft.OData.Json
         public async Task WritePaddingFunctionNameAsync(string functionName)
         {
             this.CommitUtf8JsonWriterContentsToBuffer();
-            this.bufferWriter.Write(Encoding.UTF8.GetBytes(functionName));
+            this.WritePaddingFunctionNameCore(functionName);
             await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
@@ -1018,34 +1041,7 @@ namespace Microsoft.OData.Json
         public async Task WriteValueAsync(double value)
         {
             this.WriteSeparatorIfNecessary();
-            if (double.IsNaN(value))
-            {
-                this.utf8JsonWriter.WriteStringValue(nanValue.Span);
-            }
-            else if (double.IsPositiveInfinity(value))
-            {
-                this.utf8JsonWriter.WriteStringValue(positiveInfinityValue.Span);
-            }
-            else if (double.IsNegativeInfinity(value))
-            {
-                this.utf8JsonWriter.WriteStringValue(negativeInfinityValue.Span);
-            }
-            else
-            {
-                // whereas double.MinValue and double.MaxValue have 16 digits scale. Hence we need
-                // to use XmlConvert in all other cases, except infinity
-                string valueToWrite = XmlConvert.ToString(value);
-
-                // We write doubles like 100 as 100.0 (with .0 decimal point).
-                // We do this to retain consistency with the legacy JsonWriter and with older
-                // versions. However, it's not a hard requirement. Clients should not rely on the .0
-                // to decide whether a value is an integer or double. We should consider
-                // dropping this in the future (potentially behind a compatibility flag) to avoid
-                // the cost of converting to a string and checking whether a decimal point is needed.
-                bool needsFractionalPart = valueToWrite.IndexOfAny(JsonValueUtils.DoubleIndicatingCharacters) == -1;
-                this.utf8JsonWriter.WriteRawValue(needsFractionalPart ? $"{valueToWrite}.0" : valueToWrite, skipInputValidation: true);
-            }
-
+            this.WriteFiniteOrSpecialDoubleValue(value);
             await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 

--- a/src/Microsoft.OData.Core/Json/ReorderingJsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/ReorderingJsonReader.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ReorderingJsonReader.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -756,10 +756,14 @@ namespace Microsoft.OData.Json
             {
                 // Instance-level annotation for the instance itself; not property name.
                 propertyName = null;
-                annotationName = jsonPropertyName.Substring(1);
-                if (annotationName.IndexOf('.', StringComparison.Ordinal) == -1)
+                ReadOnlySpan<char> tail = jsonPropertyName.AsSpan(1);
+                if (tail.IndexOf('.') == -1)
                 {
-                    annotationName = ODataJsonConstants.ODataAnnotationNamespacePrefix + annotationName;
+                    annotationName = string.Concat(ODataJsonConstants.ODataAnnotationNamespacePrefix.AsSpan(), tail);
+                }
+                else
+                {
+                    annotationName = jsonPropertyName.Substring(1);
                 }
             }
             else

--- a/src/Microsoft.OData.Core/MediaTypeUtils.cs
+++ b/src/Microsoft.OData.Core/MediaTypeUtils.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="MediaTypeUtils.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -915,7 +915,14 @@ namespace Microsoft.OData
                 this.MediaTypeResolver = resolver;
                 this.PayloadKind = payloadKind;
                 this.ContentTypeName = RemoveBoundary(contentTypeName);
+
+                int result = (resolver?.GetHashCode() ?? 0) ^ payloadKind.GetHashCode();
+                this.hashCode = this.ContentTypeName != null
+                    ? result ^ this.ContentTypeName.GetHashCode(StringComparison.Ordinal)
+                    : result;
             }
+
+            private readonly int hashCode;
 
             /// <summary>
             /// Type of the mediaTypeResolver.
@@ -970,8 +977,7 @@ namespace Microsoft.OData
             /// <returns>A 32-bit signed integer hash code.</returns>
             public override int GetHashCode()
             {
-                int result = this.MediaTypeResolver.GetHashCode() ^ this.PayloadKind.GetHashCode();
-                return this.ContentTypeName != null ? result ^ this.ContentTypeName.GetHashCode(StringComparison.Ordinal) : result;
+                return this.hashCode;
             }
 
             /// <summary>

--- a/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
+++ b/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.OData.Metadata
     #region Namespaces
     using System;
     using System.Collections;
+    using System.Collections.Frozen;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
@@ -42,7 +43,9 @@ namespace Microsoft.OData.Metadata
         /// <summary>
         /// Map of CLR primitive type to EDM primitive type reference. Doesn't include spatial types since they need assignability and not equality.
         /// </summary>
-        private static readonly Dictionary<Type, IEdmPrimitiveTypeReference> PrimitiveTypeReferenceMap = new Dictionary<Type, IEdmPrimitiveTypeReference>(EqualityComparer<Type>.Default);
+        private static readonly FrozenDictionary<Type, IEdmPrimitiveTypeReference> PrimitiveTypeReferenceMap;
+
+        private static readonly Dictionary<Type, IEdmPrimitiveTypeReference> _primitiveTypeReferenceMapBuilder = new Dictionary<Type, IEdmPrimitiveTypeReference>();
 
         /// <summary>
         /// Packs the <see cref="TypeCode"/> of supported primitive types. This is used to speed up the "IsPrimitiveType(Type)" method.
@@ -85,9 +88,6 @@ namespace Microsoft.OData.Metadata
         /// <summary>The qualifier to turn a type name into a Collection type name.</summary>
         private const string CollectionTypeQualifier = "Collection";
 
-        /// <summary>Format string to describe a Collection of a given type.</summary>
-        private const string CollectionTypeFormat = CollectionTypeQualifier + "({0})";
-
         #endregion Edm Collection constants
 
         /// <summary>
@@ -96,47 +96,49 @@ namespace Microsoft.OData.Metadata
         [SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline", Justification = "Need to use the static constructor for the phone platform.")]
         static EdmLibraryExtensions()
         {
-            PrimitiveTypeReferenceMap.Add(typeof(Boolean), BooleanTypeReference);
-            PrimitiveTypeReferenceMap.Add(typeof(Byte), ByteTypeReference);
-            PrimitiveTypeReferenceMap.Add(typeof(Decimal), DecimalTypeReference);
-            PrimitiveTypeReferenceMap.Add(typeof(Double), DoubleTypeReference);
-            PrimitiveTypeReferenceMap.Add(typeof(Int16), Int16TypeReference);
-            PrimitiveTypeReferenceMap.Add(typeof(Int32), Int32TypeReference);
-            PrimitiveTypeReferenceMap.Add(typeof(Int64), Int64TypeReference);
-            PrimitiveTypeReferenceMap.Add(typeof(SByte), SByteTypeReference);
-            PrimitiveTypeReferenceMap.Add(typeof(String), StringTypeReference);
-            PrimitiveTypeReferenceMap.Add(typeof(Single), SingleTypeReference);
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Boolean), BooleanTypeReference);
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Byte), ByteTypeReference);
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Decimal), DecimalTypeReference);
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Double), DoubleTypeReference);
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Int16), Int16TypeReference);
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Int32), Int32TypeReference);
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Int64), Int64TypeReference);
+            _primitiveTypeReferenceMapBuilder.Add(typeof(SByte), SByteTypeReference);
+            _primitiveTypeReferenceMapBuilder.Add(typeof(String), StringTypeReference);
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Single), SingleTypeReference);
 
 #if ODATA_SERVICE
-            PrimitiveTypeReferenceMap.Add(typeof(DateTime), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.DateTimeOffset), false));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(DateTime), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.DateTimeOffset), false));
 #endif
-            PrimitiveTypeReferenceMap.Add(typeof(DateTimeOffset), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.DateTimeOffset), false));
-            PrimitiveTypeReferenceMap.Add(typeof(Guid), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Guid), false));
-            PrimitiveTypeReferenceMap.Add(typeof(TimeSpan), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Duration), false));
-            PrimitiveTypeReferenceMap.Add(typeof(byte[]), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Binary), true));
-            PrimitiveTypeReferenceMap.Add(typeof(Stream), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Stream), false));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(DateTimeOffset), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.DateTimeOffset), false));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Guid), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Guid), false));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(TimeSpan), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Duration), false));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(byte[]), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Binary), true));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Stream), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Stream), false));
 
-            PrimitiveTypeReferenceMap.Add(typeof(Boolean?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Boolean), true));
-            PrimitiveTypeReferenceMap.Add(typeof(Byte?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Byte), true));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Boolean?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Boolean), true));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Byte?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Byte), true));
 #if ODATA_SERVICE
-            PrimitiveTypeReferenceMap.Add(typeof(DateTime?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.DateTimeOffset), true));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(DateTime?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.DateTimeOffset), true));
 #endif
-            PrimitiveTypeReferenceMap.Add(typeof(DateTimeOffset?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.DateTimeOffset), true));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(DateTimeOffset?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.DateTimeOffset), true));
 
-            PrimitiveTypeReferenceMap.Add(typeof(Decimal?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Decimal), true));
-            PrimitiveTypeReferenceMap.Add(typeof(Double?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Double), true));
-            PrimitiveTypeReferenceMap.Add(typeof(Int16?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Int16), true));
-            PrimitiveTypeReferenceMap.Add(typeof(Int32?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Int32), true));
-            PrimitiveTypeReferenceMap.Add(typeof(Int64?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Int64), true));
-            PrimitiveTypeReferenceMap.Add(typeof(SByte?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.SByte), true));
-            PrimitiveTypeReferenceMap.Add(typeof(Single?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Single), true));
-            PrimitiveTypeReferenceMap.Add(typeof(Guid?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Guid), true));
-            PrimitiveTypeReferenceMap.Add(typeof(TimeSpan?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Duration), true));
-            
-            PrimitiveTypeReferenceMap.Add(typeof(DateOnly), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Date), false));
-            PrimitiveTypeReferenceMap.Add(typeof(DateOnly?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Date), true));
-            PrimitiveTypeReferenceMap.Add(typeof(TimeOnly), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay), false));
-            PrimitiveTypeReferenceMap.Add(typeof(TimeOnly?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay), true));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Decimal?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Decimal), true));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Double?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Double), true));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Int16?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Int16), true));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Int32?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Int32), true));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Int64?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Int64), true));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(SByte?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.SByte), true));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Single?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Single), true));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(Guid?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Guid), true));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(TimeSpan?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Duration), true));
+
+            _primitiveTypeReferenceMapBuilder.Add(typeof(DateOnly), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Date), false));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(DateOnly?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Date), true));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(TimeOnly), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay), false));
+            _primitiveTypeReferenceMapBuilder.Add(typeof(TimeOnly?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay), true));
+
+            PrimitiveTypeReferenceMap = _primitiveTypeReferenceMapBuilder.ToFrozenDictionary();
 
             // Pack type codes of supported primitive types in the bitmap
             // See the type codes here: https://learn.microsoft.com/en-us/dotnet/api/system.typecode
@@ -260,12 +262,13 @@ namespace Microsoft.OData.Metadata
                     currentClosestType = operationBindingType;
                 }
 
-                if (!sortedOperations.ContainsKey(operationBindingType))
+                if (!sortedOperations.TryGetValue(operationBindingType, out List<IEdmOperation> bucket))
                 {
-                    sortedOperations[operationBindingType] = new List<IEdmOperation>();
+                    bucket = new List<IEdmOperation>();
+                    sortedOperations[operationBindingType] = bucket;
                 }
 
-                sortedOperations[operationBindingType].Add(operation);
+                bucket.Add(operation);
             }
 
             if (currentClosestType != null)
@@ -1629,7 +1632,7 @@ namespace Microsoft.OData.Metadata
         /// <returns>Type name for a collection of the specified item type name.</returns>
         internal static string GetCollectionTypeName(string itemTypeName)
         {
-            return string.Format(CultureInfo.InvariantCulture, CollectionTypeFormat, itemTypeName);
+            return CollectionTypeQualifier + "(" + itemTypeName + ")";
         }
 
 #if !ODATA_CLIENT

--- a/src/Microsoft.OData.Core/MultipartMixed/DependsOnIdsTracker.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/DependsOnIdsTracker.cs
@@ -82,9 +82,9 @@ namespace Microsoft.OData.MultipartMixed
         /// Get the list of dependsOn ids for the current state.
         /// </summary>
         /// <returns>The read-only list of dependsOn ids for the current batch operation request.</returns>
-        internal IEnumerable<string> GetDependsOnIds()
+        internal IReadOnlyList<string> GetDependsOnIds()
         {
-            return isInChangeSet ? this.changeSetDependsOnIds : this.topLevelDependsOnIds;
+            return isInChangeSet ? (IReadOnlyList<string>)this.changeSetDependsOnIds : (IReadOnlyList<string>)this.topLevelDependsOnIds;
         }
     }
 }

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchFormat.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchFormat.cs
@@ -153,19 +153,29 @@ namespace Microsoft.OData.MultipartMixed
                 ? mediaType.Parameters
                 : new List<KeyValuePair<string, string>>();
 
-            IEnumerable<KeyValuePair<string, string>> boundaryParameters = origParameters.Where(
-                p =>
-                    string.Compare(p.Key, ODataConstants.HttpMultipartBoundary, StringComparison.OrdinalIgnoreCase) == 0);
+            int boundaryCount = 0;
+            string firstBoundaryValue = null;
+            foreach (KeyValuePair<string, string> p in origParameters)
+            {
+                if (string.Compare(p.Key, ODataConstants.HttpMultipartBoundary, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    if (boundaryCount == 0)
+                    {
+                        firstBoundaryValue = p.Value;
+                    }
+                    boundaryCount++;
+                }
+            }
 
             string batchBoundary;
-            if (boundaryParameters.Count() > 1)
+            if (boundaryCount > 1)
             {
                 throw new ODataContentTypeException(
                     Error.Format(SRResources.MediaTypeUtils_NoOrMoreThanOneContentTypeSpecified, mediaType.ToText()));
             }
-            else if (boundaryParameters.Count() == 1)
+            else if (boundaryCount == 1)
             {
-                batchBoundary = boundaryParameters.First().Value;
+                batchBoundary = firstBoundaryValue;
                 mediaTypeParameters = mediaType.Parameters;
             }
             else

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataMultipartMixedBatchWriter.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -656,7 +656,9 @@ namespace Microsoft.OData.MultipartMixed
                     {
                         string headerName = headerPair.Key;
                         string headerValue = headerPair.Value;
-                        this.RawOutputContext.TextWriter.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0}: {1}", headerName, headerValue));
+                        this.RawOutputContext.TextWriter.Write(headerName);
+                        this.RawOutputContext.TextWriter.Write(": ");
+                        this.RawOutputContext.TextWriter.WriteLine(headerValue);
                     }
                 }
 

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriterUtils.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriterUtils.cs
@@ -52,12 +52,7 @@ namespace Microsoft.OData.MultipartMixed
         /// <returns>The multipart/mixed content type with the specified boundary (if any).</returns>
         internal static string CreateMultipartMixedContentType(string boundary)
         {
-            return string.Format(
-                CultureInfo.InvariantCulture,
-                "{0}; {1}={2}",
-                MimeConstants.MimeMultipartMixed,
-                ODataConstants.HttpMultipartBoundary,
-                boundary);
+            return $"{MimeConstants.MimeMultipartMixed}; {ODataConstants.HttpMultipartBoundary}={boundary}";
         }
 
         /// <summary>
@@ -114,7 +109,8 @@ namespace Microsoft.OData.MultipartMixed
                 writer.WriteLine();
             }
 
-            writer.WriteLine("--{0}", boundary);
+            writer.Write("--");
+            writer.WriteLine(boundary);
         }
 
         /// <summary>
@@ -137,7 +133,9 @@ namespace Microsoft.OData.MultipartMixed
             }
 
             // Note that we don't write a newline AFTER the end boundary since there's no need to.
-            writer.Write("--{0}--", boundary);
+            writer.Write("--");
+            writer.Write(boundary);
+            writer.Write("--");
         }
 
         /// <summary>
@@ -200,7 +198,9 @@ namespace Microsoft.OData.MultipartMixed
             Debug.Assert(changeSetBoundary != null, "changeSetBoundary != null");
 
             string multipartContentType = CreateMultipartMixedContentType(changeSetBoundary);
-            writer.WriteLine("{0}: {1}", ODataConstants.ContentTypeHeader, multipartContentType);
+            writer.Write(ODataConstants.ContentTypeHeader);
+            writer.Write(": ");
+            writer.WriteLine(multipartContentType);
 
             // write separator line between headers and first change set operation
             writer.WriteLine();
@@ -227,8 +227,8 @@ namespace Microsoft.OData.MultipartMixed
                     .ConfigureAwait(false);
             }
 
-            await writer.WriteLineAsync(string.Concat("--", boundary))
-                .ConfigureAwait(false);
+            await writer.WriteAsync("--").ConfigureAwait(false);
+            await writer.WriteLineAsync(boundary).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -252,9 +252,9 @@ namespace Microsoft.OData.MultipartMixed
                     .ConfigureAwait(false);
             }
 
-            // Note that we don't write a newline AFTER the end boundary since there's no need to.
-            await writer.WriteAsync(string.Concat("--", boundary, "--"))
-                .ConfigureAwait(false);
+            await writer.WriteAsync("--").ConfigureAwait(false);
+            await writer.WriteAsync(boundary).ConfigureAwait(false);
+            await writer.WriteAsync("--").ConfigureAwait(false);
         }
 
         /// <summary>
@@ -341,11 +341,17 @@ namespace Microsoft.OData.MultipartMixed
         /// <param name="contentId">The Content-ID value to write in ChangeSet head.</param>
         private static void WriteHeaders(TextWriter writer, bool inChangeSetBound, string contentId)
         {
-            writer.WriteLine("{0}: {1}", ODataConstants.ContentTypeHeader, MimeConstants.MimeApplicationHttp);
-            writer.WriteLine("{0}: {1}", ODataConstants.ContentTransferEncoding, ODataConstants.BatchContentTransferEncoding);
+            writer.Write(ODataConstants.ContentTypeHeader);
+            writer.Write(": ");
+            writer.WriteLine(MimeConstants.MimeApplicationHttp);
+            writer.Write(ODataConstants.ContentTransferEncoding);
+            writer.Write(": ");
+            writer.WriteLine(ODataConstants.BatchContentTransferEncoding);
             if (inChangeSetBound && contentId != null)
             {
-                writer.WriteLine("{0}: {1}", ODataConstants.ContentIdHeader, contentId);
+                writer.Write(ODataConstants.ContentIdHeader);
+                writer.Write(": ");
+                writer.WriteLine(contentId);
             }
         }
 

--- a/src/Microsoft.OData.Core/ODataAsynchronousWriter.cs
+++ b/src/Microsoft.OData.Core/ODataAsynchronousWriter.cs
@@ -220,7 +220,9 @@ namespace Microsoft.OData
                 {
                     string headerName = headerPair.Key;
                     string headerValue = headerPair.Value;
-                    this.rawOutputContext.TextWriter.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0}: {1}", headerName, headerValue));
+                    this.rawOutputContext.TextWriter.Write(headerName);
+                    this.rawOutputContext.TextWriter.Write(": ");
+                    this.rawOutputContext.TextWriter.WriteLine(headerValue);
                 }
             }
 

--- a/src/Microsoft.OData.Core/ODataContextUriBuilder.cs
+++ b/src/Microsoft.OData.Core/ODataContextUriBuilder.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataContextUriBuilder.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -9,6 +9,7 @@ namespace Microsoft.OData
     using Microsoft.OData.Core;
     #region Namespaces
     using System;
+    using System.Collections.Frozen;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Text;
@@ -32,7 +33,7 @@ namespace Microsoft.OData
         /// <summary>
         /// Stores the validation method mapping for supported payload kind.
         /// </summary>
-        private static readonly Dictionary<ODataPayloadKind, Action<ODataContextUrlInfo>> ValidationDictionary = new Dictionary<ODataPayloadKind, Action<ODataContextUrlInfo>>(EqualityComparer<ODataPayloadKind>.Default)
+        private static readonly FrozenDictionary<ODataPayloadKind, Action<ODataContextUrlInfo>> ValidationDictionary = new Dictionary<ODataPayloadKind, Action<ODataContextUrlInfo>>(EqualityComparer<ODataPayloadKind>.Default)
         {
             { ODataPayloadKind.ServiceDocument,         null },
             { ODataPayloadKind.EntityReferenceLink,     null },
@@ -43,7 +44,7 @@ namespace Microsoft.OData
             { ODataPayloadKind.Resource,                   ValidateNavigationSource },
             { ODataPayloadKind.ResourceSet,                    ValidateNavigationSource },
             { ODataPayloadKind.Delta,                   ValidateDelta },
-        };
+        }.ToFrozenDictionary();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ODataContextUriBuilder"/> class.

--- a/src/Microsoft.OData.Core/ODataMediaTypeResolver.cs
+++ b/src/Microsoft.OData.Core/ODataMediaTypeResolver.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataMediaTypeResolver.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -8,6 +8,7 @@ namespace Microsoft.OData
 {
     #region Namespaces
     using System;
+    using System.Collections.Frozen;
     using System.Collections.Generic;
     using System.Linq;
     using Microsoft.Extensions.DependencyInjection;
@@ -21,7 +22,7 @@ namespace Microsoft.OData
         /// <summary>
         /// The set of payload kinds which are supported for the JSON formats.
         /// </summary>
-        private static readonly HashSet<ODataPayloadKind> JsonPayloadKindSet = new HashSet<ODataPayloadKind>
+        private static readonly FrozenSet<ODataPayloadKind> JsonPayloadKindSet = new HashSet<ODataPayloadKind>
         {
             ODataPayloadKind.ResourceSet,
             ODataPayloadKind.Resource,
@@ -34,7 +35,7 @@ namespace Microsoft.OData
             ODataPayloadKind.Parameter,
             ODataPayloadKind.Delta,
             ODataPayloadKind.IndividualProperty
-        };
+        }.ToFrozenSet();
 
         /// <summary>
         /// MediaTypeResolver.

--- a/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
@@ -693,7 +693,7 @@ namespace Microsoft.OData
                 IEnumerable<string> missingParameters = parameters.Where(p => !this.parameterNamesWritten.Contains(p.Name) && !this.outputContext.EdmTypeResolver.GetParameterType(p).IsNullable).Select(p => p.Name);
                 if (missingParameters.Any())
                 {
-                    missingParameters = missingParameters.Select(name => String.Format(CultureInfo.InvariantCulture, "'{0}'", name));
+                    missingParameters = missingParameters.Select(name => $"'{name}'");
 
                     // We're calling the ToArray here since not all platforms support the string.Join which takes IEnumerable.
                     throw new ODataException(Error.Format(SRResources.ODataParameterWriterCore_MissingParameterInParameterPayload, string.Join(", ", missingParameters.ToArray()), this.operation.Name));

--- a/src/Microsoft.OData.Core/ODataPayloadValueConverter.cs
+++ b/src/Microsoft.OData.Core/ODataPayloadValueConverter.cs
@@ -55,18 +55,16 @@ namespace Microsoft.OData
             {
                 Type targetType = EdmLibraryExtensions.GetPrimitiveClrType(primitiveTypeReference.PrimitiveDefinition(), false);
 
-                string stringValue = value as string;
-                if (stringValue != null)
+                if (value is string stringValue)
                 {
                     return ConvertStringValue(stringValue, targetType);
                 }
-                else if (value is Int32)
+                else if (value is int intValue)
                 {
-                    return ConvertInt32Value((int)value, targetType, primitiveTypeReference);
+                    return ConvertInt32Value(intValue, targetType, primitiveTypeReference);
                 }
-                else if (value is Decimal)
+                else if (value is decimal decimalValue)
                 {
-                    Decimal decimalValue = (Decimal)value;
                     if (targetType == typeof(Int64))
                     {
                         return Convert.ToInt64(decimalValue);
@@ -87,9 +85,9 @@ namespace Microsoft.OData
                         throw new ODataException(Error.Format(SRResources.ODataJsonReaderUtils_CannotConvertDecimal, primitiveTypeReference.FullName()));
                     }
                 }
-                else if (value is Double)
+                else if (value is double doubleValue)
                 {
-                    return ConvertDoubleValue((Double)value, targetType, primitiveTypeReference);
+                    return ConvertDoubleValue(doubleValue, targetType, primitiveTypeReference);
                 }
                 else if (value is bool)
                 {

--- a/src/Microsoft.OData.Core/ODataPreferenceHeader.cs
+++ b/src/Microsoft.OData.Core/ODataPreferenceHeader.cs
@@ -155,12 +155,12 @@ namespace Microsoft.OData
                 var returnContentPreference = this.Get(ReturnPreferenceTokenName);
                 if (returnContentPreference != null && returnContentPreference.Value != null)
                 {
-                    if (returnContentPreference.Value.ToLowerInvariant().Equals(ReturnRepresentationPreferenceTokenValue, System.StringComparison.Ordinal))
+                    if (returnContentPreference.Value.Equals(ReturnRepresentationPreferenceTokenValue, System.StringComparison.OrdinalIgnoreCase))
                     {
                         return true;
                     }
 
-                    if (returnContentPreference.Value.ToLowerInvariant().Equals(ReturnMinimalPreferenceTokenValue, System.StringComparison.Ordinal))
+                    if (returnContentPreference.Value.Equals(ReturnMinimalPreferenceTokenValue, System.StringComparison.OrdinalIgnoreCase))
                     {
                         return false;
                     }
@@ -294,9 +294,8 @@ namespace Microsoft.OData
                     }
 
                     // TODO: Fix hard code string before Loc of 6.16 release
-                    throw new ODataException(string.Format(CultureInfo.InvariantCulture,
-                        "Invalid value '{0}' for {1} preference header found. The {1} preference header requires an integer value.",
-                        wait.Value, ODataPreferenceHeader.WaitPreferenceTokenName));
+                    throw new ODataException(
+                        $"Invalid value '{wait.Value}' for {ODataPreferenceHeader.WaitPreferenceTokenName} preference header found. The {ODataPreferenceHeader.WaitPreferenceTokenName} preference header requires an integer value.");
                 }
 
                 return null;
@@ -306,7 +305,7 @@ namespace Microsoft.OData
             {
                 if (value != null)
                 {
-                    this.Set(new HttpHeaderValueElement(WaitPreferenceTokenName, string.Format(CultureInfo.InvariantCulture, "{0}", value), EmptyParameters));
+                    this.Set(new HttpHeaderValueElement(WaitPreferenceTokenName, value.Value.ToString(CultureInfo.InvariantCulture), EmptyParameters));
                 }
                 else
                 {
@@ -365,9 +364,8 @@ namespace Microsoft.OData
                     }
 
                     // TODO: Fix hard code string before Loc of 6.16 release
-                    throw new ODataException(string.Format(CultureInfo.InvariantCulture,
-                        "Invalid value '{0}' for {1} preference header found. The {1} preference header requires an integer value.",
-                        maxPageSizeHttpHeaderValueElement.Value, ODataPreferenceHeader.ODataMaxPageSizePreferenceToken));
+                    throw new ODataException(
+                        $"Invalid value '{maxPageSizeHttpHeaderValueElement.Value}' for {ODataPreferenceHeader.ODataMaxPageSizePreferenceToken} preference header found. The {ODataPreferenceHeader.ODataMaxPageSizePreferenceToken} preference header requires an integer value.");
                 }
 
                 return null;
@@ -377,7 +375,7 @@ namespace Microsoft.OData
             {
                 if (value.HasValue)
                 {
-                    this.Set(new HttpHeaderValueElement(ODataMaxPageSizePreferenceToken, string.Format(CultureInfo.InvariantCulture, "{0}", value.Value), EmptyParameters));
+                    this.Set(new HttpHeaderValueElement(ODataMaxPageSizePreferenceToken, value.Value.ToString(CultureInfo.InvariantCulture), EmptyParameters));
                 }
                 else
                 {

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -90,7 +90,34 @@ namespace Microsoft.OData
                 selectedProperties: outputContext.MessageWriterSettings.SelectedProperties,
                 odataUri: odataUri,
                 enableDelta: true));
-            this.CurrentScope.DerivedTypeConstraints = this.outputContext.Model.GetDerivedTypeConstraints(navigationSource)?.ToList();
+            this.CurrentScope.DerivedTypeConstraints = MaterializeOrNull(this.outputContext.Model.GetDerivedTypeConstraints(navigationSource));
+        }
+
+        /// <summary>
+        /// Returns <paramref name="source"/> as an <see cref="IReadOnlyList{T}"/>, materializing the
+        /// sequence to an array when it isn't already a known collection. Used to avoid re-enumerating
+        /// the LINQ iterator returned by <see cref="ExtensionMethods.GetDerivedTypeConstraints"/>.
+        /// </summary>
+        private static IReadOnlyList<string> MaterializeOrNull(IEnumerable<string> source)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            if (source is IReadOnlyList<string> readOnlyList)
+            {
+                return readOnlyList;
+            }
+
+            if (source is ICollection<string> collection)
+            {
+                var array = new string[collection.Count];
+                collection.CopyTo(array, 0);
+                return array;
+            }
+
+            return source.ToArray();
         }
 
         /// <summary>
@@ -3191,7 +3218,7 @@ namespace Microsoft.OData
                     throw new ODataException(errorMessage);
             }
 
-            scope.DerivedTypeConstraints = derivedTypeConstraints?.ToList();
+            scope.DerivedTypeConstraints = MaterializeOrNull(derivedTypeConstraints);
             this.scopeStack.Push(scope);
         }
 
@@ -4008,7 +4035,7 @@ namespace Microsoft.OData
             }
 
             /// <summary>Gets or sets the derived type constraints for the current scope.</summary>
-            internal List<string> DerivedTypeConstraints { get; set; }
+            internal IReadOnlyList<string> DerivedTypeConstraints { get; set; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/PropertyAndAnnotationCollector.cs
+++ b/src/Microsoft.OData.Core/PropertyAndAnnotationCollector.cs
@@ -289,9 +289,9 @@ namespace Microsoft.OData
         /// <remarks>
         /// Scope annotations are those that do not apply to specific properties, and start directly with "@".
         /// </remarks>
-        internal IEnumerable<Annotation> GetCustomScopeAnnotation()
+        internal IReadOnlyList<Annotation> GetCustomScopeAnnotation()
         {
-            return customScopeAnnotations;
+            return (IReadOnlyList<Annotation>)customScopeAnnotations;
         }
 
         /// <summary>
@@ -430,14 +430,14 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="propertyName">Name of the property.</param>
         /// <returns>Custom property annotation name value pairs.</returns>
-        internal IEnumerable<Annotation> GetCustomPropertyAnnotations(string propertyName)
+        internal IReadOnlyList<Annotation> GetCustomPropertyAnnotations(string propertyName)
         {
             Debug.Assert(propertyName != null);
 
             PropertyData data;
             return propertyData.TryGetValue(propertyName, out data)
-                   ? data.CustomAnnotations
-                   : Enumerable.Empty<Annotation>();
+                   ? (IReadOnlyList<Annotation>)data.CustomAnnotations
+                   : Array.Empty<Annotation>();
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/PropertyCache.cs
+++ b/src/Microsoft.OData.Core/PropertyCache.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="PropertyCache.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -19,11 +19,16 @@ namespace Microsoft.OData
 
         private struct PropertyKey : IEquatable<PropertyKey>
         {
+            private readonly int hashCode;
+
             public PropertyKey(int depth, string name, string fullTypeName)
             {
                 this.Depth = depth;
                 this.Name = name;
                 this.FullTypeName = fullTypeName;
+                this.hashCode = depth ^
+                                (name != null ? name.GetHashCode(StringComparison.Ordinal) : 0) ^
+                                (fullTypeName != null ? fullTypeName.GetHashCode(StringComparison.Ordinal) : 0);
             }
 
             public int Depth { get; private set; }
@@ -44,9 +49,7 @@ namespace Microsoft.OData
 
             public override int GetHashCode()
             {
-                return this.Depth.GetHashCode() ^
-                       this.Name.GetHashCode(StringComparison.Ordinal) ^
-                       (this.FullTypeName?.GetHashCode(StringComparison.Ordinal) ?? 0);
+                return this.hashCode;
             }
 
             public override bool Equals(object obj)

--- a/src/Microsoft.OData.Core/SRResources.Designer.cs
+++ b/src/Microsoft.OData.Core/SRResources.Designer.cs
@@ -6617,6 +6617,15 @@ namespace Microsoft.OData.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to JSON condition failed: the JsonReader is on node {0} (Value: {1}) but it was expected to be on {2}..
+        /// </summary>
+        internal static string ODataJsonDeserializer_AssertJsonConditionFailed {
+            get {
+                return ResourceManager.GetString("ODataJsonDeserializer_AssertJsonConditionFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; is not a qualified type name. A qualified type name is expected..
         /// </summary>
         internal static string TypeUtils_TypeNameIsNotQualified {

--- a/src/Microsoft.OData.Core/SRResources.resx
+++ b/src/Microsoft.OData.Core/SRResources.resx
@@ -2678,4 +2678,7 @@
   <data name="TaskUtils_NullContinuationTask" xml:space="preserve">
     <value>The continuation task returned by the operation cannot be null.</value>
   </data>
+  <data name="ODataJsonDeserializer_AssertJsonConditionFailed" xml:space="preserve">
+    <value>JSON condition failed: the JsonReader is on node {0} (Value: {1}) but it was expected to be on {2}.</value>
+  </data>
 </root>

--- a/src/Microsoft.OData.Core/Uri/ODataUri.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUri.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataUri.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -74,7 +74,9 @@ namespace Microsoft.OData
         {
             this.ParameterAliasValueAccessor = parameterAliasValueAccessor;
             this.Path = path;
-            this.CustomQueryOptions = new ReadOnlyCollection<QueryNode>(customQueryOptions.ToList());
+            this.CustomQueryOptions = customQueryOptions == null
+                ? new ReadOnlyCollection<QueryNode>(new List<QueryNode>(0))
+                : new ReadOnlyCollection<QueryNode>(new List<QueryNode>(customQueryOptions));
             this.SelectAndExpand = selectAndExpand;
             this.Filter = filter;
             this.OrderBy = orderby;

--- a/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
@@ -58,7 +58,7 @@ namespace Microsoft.OData
             ExceptionUtils.CheckArgumentNotNull(value.Value, "value.Value");
 
             // not URL-encode the resulting string:
-            return string.Format(CultureInfo.InvariantCulture, "{0}'{1}'", value.TypeName, value.Value);
+            return $"{value.TypeName}'{value.Value}'";
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Uri/ODataUriExtensions.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriExtensions.cs
@@ -69,21 +69,21 @@ namespace Microsoft.OData
             {
                 queryOptions = WriteQueryPrefixOrSeparator(writeQueryPrefix, queryOptions);
                 writeQueryPrefix = false;
-                queryOptions = string.Concat(queryOptions, "$top", ExpressionConstants.SymbolEqual, Uri.EscapeDataString(string.Format(CultureInfo.InvariantCulture, $"{odataUri.Top}")));
+                queryOptions = string.Concat(queryOptions, "$top", ExpressionConstants.SymbolEqual, Uri.EscapeDataString(odataUri.Top.Value.ToString(CultureInfo.InvariantCulture)));
             }
 
             if (odataUri.Skip != null)
             {
                 queryOptions = WriteQueryPrefixOrSeparator(writeQueryPrefix, queryOptions);
                 writeQueryPrefix = false;
-                queryOptions = string.Concat(queryOptions, "$skip", ExpressionConstants.SymbolEqual, Uri.EscapeDataString(string.Format(CultureInfo.InvariantCulture, $"{odataUri.Skip}")));
+                queryOptions = string.Concat(queryOptions, "$skip", ExpressionConstants.SymbolEqual, Uri.EscapeDataString(odataUri.Skip.Value.ToString(CultureInfo.InvariantCulture)));
             }
 
             if (odataUri.Index != null)
             {
                 queryOptions = WriteQueryPrefixOrSeparator(writeQueryPrefix, queryOptions);
                 writeQueryPrefix = false;
-                queryOptions = string.Concat(queryOptions, "$index", ExpressionConstants.SymbolEqual, Uri.EscapeDataString(string.Format(CultureInfo.InvariantCulture, $"{odataUri.Index}")));
+                queryOptions = string.Concat(queryOptions, "$index", ExpressionConstants.SymbolEqual, Uri.EscapeDataString(odataUri.Index.Value.ToString(CultureInfo.InvariantCulture)));
             }
 
             if (odataUri.QueryCount != null)

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
@@ -147,7 +147,7 @@ namespace Microsoft.OData.UriParser.Aggregation
                 result = string.Join(",", groupByPropertyArray);
                 result = aggregateExpressions == null
                     ? result
-                    : string.Format(CultureInfo.InvariantCulture, "{0},{1}", result, CreateAggregatePropertiesUriSegment(aggregateExpressions));
+                    : $"{result},{CreateAggregatePropertiesUriSegment(aggregateExpressions)}";
             }
             else
             {
@@ -161,7 +161,7 @@ namespace Microsoft.OData.UriParser.Aggregation
                 string computeProperties = string.Join(",", computeExpressions.Select(e => e.Alias).ToArray());
                 if (!string.IsNullOrEmpty(computeProperties))
                 {
-                    result = string.Format(CultureInfo.InvariantCulture, "{0},{1}", result, computeProperties);
+                    result = $"{result},{computeProperties}";
                 }
             }
 

--- a/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
@@ -482,7 +482,7 @@ namespace Microsoft.OData.UriParser
                 if (paraToken.ValueToken is EndPathToken)
                 {
                     throw new ODataException(Error.Format(SRResources.MetadataBinder_ParameterNotInScope,
-                        string.Format(CultureInfo.InvariantCulture, "{0}={1}", paraToken.ParameterName, (paraToken.ValueToken as EndPathToken).Identifier)));
+                        $"{paraToken.ParameterName}={(paraToken.ValueToken as EndPathToken).Identifier}"));
                 }
 
                 QueryNode boundNode = binder.Bind(paraToken.ValueToken);

--- a/src/Microsoft.OData.Core/UriParser/BuiltInUriFunctions.cs
+++ b/src/Microsoft.OData.Core/UriParser/BuiltInUriFunctions.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="BuiltInUriFunctions.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -8,6 +8,7 @@ namespace Microsoft.OData.UriParser
 {
     #region Namespaces
     using System;
+    using System.Collections.Frozen;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
@@ -23,12 +24,12 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// Dictionary of the name of the built-in function and all the signatures.
         /// </summary>
-        private static readonly Dictionary<string, FunctionSignatureWithReturnType[]> builtInFunctions = InitializeBuiltInFunctions();
+        private static readonly FrozenDictionary<string, FunctionSignatureWithReturnType[]> builtInFunctions = InitializeBuiltInFunctions().ToFrozenDictionary(StringComparer.Ordinal);
 
         /// <summary>
         /// Case-insensitive lookup of the name of the built-in functions to their canonical case-sensitive name
         /// </summary>
-        private static readonly Dictionary<string, string> caseInsensitiveKeys = builtInFunctions.Keys.ToDictionary(key => key, StringComparer.OrdinalIgnoreCase);
+        private static readonly FrozenDictionary<string, string> caseInsensitiveKeys = builtInFunctions.Keys.ToDictionary(key => key, StringComparer.OrdinalIgnoreCase).ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Returns a list of signatures for a function name.

--- a/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
@@ -768,10 +768,9 @@ namespace Microsoft.OData.UriParser
                         this.ParseIdentifier(true /*includingDots*/);
 
                         // Extract the identifier from expression.
-                        ReadOnlyMemory<char> leftToken = ExpressionText.Slice(start, this.textPos - start);
+                        ReadOnlySpan<char> leftToken = ExpressionText.Slice(start, this.textPos - start).Span;
 
-
-                        t = this.parsingFunctionParameters && !leftToken.Span.Contains(".", StringComparison.Ordinal)
+                        t = this.parsingFunctionParameters && leftToken.IndexOf('.') < 0
                             ? ExpressionTokenKind.ParameterAlias
                             : ExpressionTokenKind.Identifier;
                         break;

--- a/src/Microsoft.OData.Core/UriParser/ExpressionToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionToken.cs
@@ -77,7 +77,7 @@ namespace Microsoft.OData.UriParser
         /// <returns>String representation of this token.</returns>
         public override string ToString()
         {
-            return String.Format(System.Globalization.CultureInfo.InvariantCulture, $"{this.Kind} @ {this.Position}: [{this.Text}]", this.Kind, this.Position);
+            return $"{this.Kind} @ {this.Position}: [{this.Text}]";
         }
 
         /// <summary>Gets the current identifier text.</summary>

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -717,8 +717,9 @@ namespace Microsoft.OData.UriParser
                 return true;
             }
 
+            string finalName = nameWithoutDollarPrefix ?? trimmedName;
             throw new ODataException(Error.Format(SRResources.QueryOptionUtils_QueryParameterMustBeSpecifiedOnce,
-                isNoDollarQueryOptionsEnabled ? string.Format(CultureInfo.InvariantCulture, "${0}/{0}", nameWithoutDollarPrefix ?? trimmedName) : trimmedName));
+                isNoDollarQueryOptionsEnabled ? $"${finalName}/{finalName}" : trimmedName));
         }
         #endregion private methods
     }

--- a/src/Microsoft.OData.Core/UriParser/ODataUriParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataUriParser.cs
@@ -592,9 +592,10 @@ namespace Microsoft.OData.UriParser
                     {
                         if (queryOptionDic.ContainsKey(fixedQueryOptionName))
                         {
+                            string trimmed = fixedQueryOptionName.TrimStart('$');
                             throw new ODataException(Error.Format(SRResources.QueryOptionUtils_QueryParameterMustBeSpecifiedOnce,
                                 this.EnableNoDollarQueryOptions
-                                ? string.Format(CultureInfo.InvariantCulture, "${0}/{0}", fixedQueryOptionName.TrimStart('$'))
+                                ? $"${trimmed}/{trimmed}"
                                 : fixedQueryOptionName));
                         }
 
@@ -628,33 +629,31 @@ namespace Microsoft.OData.UriParser
         }
 
         /// <summary>
-        /// Judge if optionName belongs to UriQueryConstants (Case ignored).
+        /// Judge if optionName belongs to UriQueryConstants (Case ignored when configured).
         /// </summary>
         /// <param name="optionName">The name of a query option.</param>
-        /// <returns>True if optionName is OData query option, vise versa.</returns>
+        /// <returns>True if optionName is OData query option, vice versa.</returns>
         private bool IsODataQueryOption(string optionName)
         {
-            switch (this.Resolver.EnableCaseInsensitive ? optionName.ToLowerInvariant() : optionName)
-            {
-                case UriQueryConstants.FilterQueryOption:
-                case UriQueryConstants.ApplyQueryOption:
-                case UriQueryConstants.OrderByQueryOption:
-                case UriQueryConstants.SelectQueryOption:
-                case UriQueryConstants.ExpandQueryOption:
-                case UriQueryConstants.SkipQueryOption:
-                case UriQueryConstants.SkipTokenQueryOption:
-                case UriQueryConstants.DeltaTokenQueryOption:
-                case UriQueryConstants.IdQueryOption:
-                case UriQueryConstants.TopQueryOption:
-                case UriQueryConstants.IndexQueryOption:
-                case UriQueryConstants.CountQueryOption:
-                case UriQueryConstants.FormatQueryOption:
-                case UriQueryConstants.SearchQueryOption:
-                case UriQueryConstants.ComputeQueryOption:
-                    return true;
-                default:
-                    return false;
-            }
+            StringComparison comparison = this.Resolver.EnableCaseInsensitive
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            return optionName.Equals(UriQueryConstants.FilterQueryOption, comparison)
+                || optionName.Equals(UriQueryConstants.ApplyQueryOption, comparison)
+                || optionName.Equals(UriQueryConstants.OrderByQueryOption, comparison)
+                || optionName.Equals(UriQueryConstants.SelectQueryOption, comparison)
+                || optionName.Equals(UriQueryConstants.ExpandQueryOption, comparison)
+                || optionName.Equals(UriQueryConstants.SkipQueryOption, comparison)
+                || optionName.Equals(UriQueryConstants.SkipTokenQueryOption, comparison)
+                || optionName.Equals(UriQueryConstants.DeltaTokenQueryOption, comparison)
+                || optionName.Equals(UriQueryConstants.IdQueryOption, comparison)
+                || optionName.Equals(UriQueryConstants.TopQueryOption, comparison)
+                || optionName.Equals(UriQueryConstants.IndexQueryOption, comparison)
+                || optionName.Equals(UriQueryConstants.CountQueryOption, comparison)
+                || optionName.Equals(UriQueryConstants.FormatQueryOption, comparison)
+                || optionName.Equals(UriQueryConstants.SearchQueryOption, comparison)
+                || optionName.Equals(UriQueryConstants.ComputeQueryOption, comparison);
         }
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
@@ -23,12 +23,15 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Semantic parser for the path of the request URI.
     /// </summary>
-    internal sealed class ODataPathParser
+    internal sealed partial class ODataPathParser
     {
         /// <summary>
-        /// regex pattern to match a contentID
+        /// regex pattern to match a contentID.
         /// </summary>
-        internal static readonly Regex ContentIdRegex = PlatformHelper.CreateCompiled(@"^\$[0-9]+$", RegexOptions.Singleline);
+        [GeneratedRegex(@"^\$[0-9]+$", RegexOptions.Singleline)]
+        private static partial Regex ContentIdRegexFactory();
+
+        internal static readonly Regex ContentIdRegex = ContentIdRegexFactory();
 
         /// <summary>Empty list of strings.</summary>
         private static readonly IList<string> EmptyList = new List<string>();
@@ -1233,7 +1236,7 @@ namespace Microsoft.OData.UriParser
             /*
              * For Non-KeyAsSegment, try to handle it as a key property value, unless it was preceded by an escape - marker segment('$').
              * For KeyAsSegment, the following precedence rules should be supported[ODATA - 799]:
-             * Try to match an OData segment(starting with “$”).
+             * Try to match an OData segment(starting with ï¿½$ï¿½).
              *   - Note: $filter path segment is a special case that has the format "$filter(@a)", where @a represents an alias.
              * Try to match an alias - qualified bound action name, bound function overload, or type name.
              * Try to match a namespace-qualified bound action name, bound function overload, or type name.

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriParserHelper.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriParserHelper.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="UriParserHelper.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -218,12 +218,21 @@ namespace Microsoft.OData.UriParser
         /// <exception cref="ArgumentException">Literal is not valid</exception>
         internal static void ValidatePrefixLiteral(string typePrefixLiteralName)
         {
-            bool isLettersOnly = typePrefixLiteralName.ToCharArray().All(x => char.IsLetter(x) || x == '.');
+            bool isLettersOnly = true;
+            for (int i = 0; i < typePrefixLiteralName.Length; i++)
+            {
+                char c = typePrefixLiteralName[i];
+                if (!char.IsLetter(c) && c != '.')
+                {
+                    isLettersOnly = false;
+                    break;
+                }
+            }
 
             if (!isLettersOnly)
             {
                 throw new ArgumentException(
-                    string.Format(CultureInfo.InvariantCulture, Error.Format(SRResources.UriParserHelper_InvalidPrefixLiteral, typePrefixLiteralName)));
+                    Error.Format(SRResources.UriParserHelper_InvalidPrefixLiteral, typePrefixLiteralName));
             }
         }
 

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriPrimitiveTypeParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriPrimitiveTypeParser.cs
@@ -261,24 +261,24 @@ namespace Microsoft.OData.UriParser
             catch (FormatException primitiveParserException)
             {
                 exception = new UriLiteralParsingException(
-                    string.Format(CultureInfo.InvariantCulture, Error.Format(SRResources.UriPrimitiveTypeParsers_FailedToParseTextToPrimitiveValue, text.ToString(), targetType),
-                                                            primitiveParserException));
+                    Error.Format(SRResources.UriPrimitiveTypeParsers_FailedToParseTextToPrimitiveValue, text.ToString(), targetType),
+                                                            primitiveParserException);
                 targetValue = null;
                 return false;
             }
             catch (OverflowException primitiveParserException)
             {
                 exception = new UriLiteralParsingException(
-                    string.Format(CultureInfo.InvariantCulture, Error.Format(SRResources.UriPrimitiveTypeParsers_FailedToParseTextToPrimitiveValue, text.ToString(), targetType),
-                                                            primitiveParserException));
+                    Error.Format(SRResources.UriPrimitiveTypeParsers_FailedToParseTextToPrimitiveValue, text.ToString(), targetType),
+                                                            primitiveParserException);
                 targetValue = null;
                 return false;
             }
             catch (ODataException primitiveParserException)
             {
                 exception = new UriLiteralParsingException(
-                    string.Format(CultureInfo.InvariantCulture, Error.Format(SRResources.UriPrimitiveTypeParsers_FailedToParseTextToPrimitiveValue, text.ToString(), targetType),
-                                                            primitiveParserException));
+                    Error.Format(SRResources.UriPrimitiveTypeParsers_FailedToParseTextToPrimitiveValue, text.ToString(), targetType),
+                                                            primitiveParserException);
                 targetValue = null;
                 return false;
             }

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="UriQueryExpressionParser.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -367,7 +367,7 @@ namespace Microsoft.OData.UriParser
             PathSegmentToken pathToken = termParser.ParseTerm(allowRef: true);
 
             QueryToken filterToken = null;
-            ExpandToken nestedExpand = null;
+            List<ExpandTermToken> mergedExpandTerms = null;
 
             // Followed (optionally) by filter and expand
             // Syntax for expand inside $apply is different (and much simpler)  from $expand clause => had to use different parsing approach
@@ -384,15 +384,19 @@ namespace Microsoft.OData.UriParser
                             break;
                         case ExpressionConstants.KeywordExpand:
                             ExpandToken tempNestedExpand = ParseExpand();
-                            nestedExpand = nestedExpand == null
-                                ? tempNestedExpand
-                                : new ExpandToken(nestedExpand.ExpandTerms.Concat(tempNestedExpand.ExpandTerms));
+                            mergedExpandTerms ??= new List<ExpandTermToken>();
+                            foreach (ExpandTermToken term in tempNestedExpand.ExpandTerms)
+                            {
+                                mergedExpandTerms.Add(term);
+                            }
                             break;
                         default:
                             throw ParseError(Error.Format(SRResources.UriQueryExpressionParser_KeywordOrIdentifierExpected, supportedKeywords, this.lexer.CurrentToken.Position, this.lexer.ExpressionText));
                     }
                 }
             }
+
+            ExpandToken nestedExpand = mergedExpandTerms != null ? new ExpandToken(mergedExpandTerms) : null;
 
             // Leaf level expands require filter
             if (filterToken == null && nestedExpand == null)

--- a/src/Microsoft.OData.Core/UriParser/SearchLexer.cs
+++ b/src/Microsoft.OData.Core/UriParser/SearchLexer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OData.UriParser
     /// (others)            StringLiteral
     /// </summary>
     [DebuggerDisplay("SearchLexer ({text} @ {textPos} [{token}])")]
-    internal sealed class SearchLexer : ExpressionLexer
+    internal sealed partial class SearchLexer : ExpressionLexer
     {
         /// <summary>
         /// Pattern for searchWord
@@ -35,7 +35,10 @@ namespace Microsoft.OData.UriParser
         ///
         /// \p{L} means any kind of letter from any language, include [Lo] such as CJK single character.
         /// </summary>
-        internal static readonly Regex InvalidWordPattern = new Regex(@"([^\p{L}\p{Nl}])");
+        [GeneratedRegex(@"([^\p{L}\p{Nl}])", RegexOptions.CultureInvariant)]
+        private static partial Regex InvalidWordPatternRegex();
+
+        internal static readonly Regex InvalidWordPattern = InvalidWordPatternRegex();
 
         /// <summary>
         /// Escape character used in search query

--- a/src/Microsoft.OData.Core/Utils.cs
+++ b/src/Microsoft.OData.Core/Utils.cs
@@ -21,6 +21,34 @@ namespace Microsoft.OData
     /// </summary>
     internal static class Utils
     {
+        /// <summary>Allocation-free <see cref="System.Linq.Enumerable.Any{T}(IEnumerable{T})"/> for known collection types.</summary>
+        internal static bool HasAny<T>(IEnumerable<T> source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            // Fast paths for common collection shapes - avoid the GetEnumerator() allocation.
+            if (source is T[] array)
+            {
+                return array.Length > 0;
+            }
+
+            if (source is ICollection<T> collection)
+            {
+                return collection.Count > 0;
+            }
+
+            if (source is IReadOnlyCollection<T> readOnlyCollection)
+            {
+                return readOnlyCollection.Count > 0;
+            }
+
+            using IEnumerator<T> enumerator = source.GetEnumerator();
+            return enumerator.MoveNext();
+        }
+
         /// <summary>
         /// Calls IDisposable.Dispose() on the argument if it is not null
         /// and is an IDisposable.

--- a/src/Microsoft.OData.Core/ValidationUtils.cs
+++ b/src/Microsoft.OData.Core/ValidationUtils.cs
@@ -8,10 +8,12 @@ namespace Microsoft.OData
 {
     #region Namespaces
     using System;
+    using System.Buffers;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
+    using System.Text;
     using Microsoft.OData.Core;
     using Microsoft.OData.Edm;
     using Microsoft.OData.Metadata;
@@ -25,6 +27,9 @@ namespace Microsoft.OData
         /// <summary>The set of characters that are invalid in property names.</summary>
         /// <remarks>Keep this array in sync with MetadataProviderUtils.InvalidCharactersInPropertyNames in Astoria.</remarks>
         internal static readonly char[] InvalidCharactersInPropertyNames = new char[] { ':', '.', '@' };
+
+        /// <summary>SIMD-accelerated lookup for <see cref="InvalidCharactersInPropertyNames"/>.</summary>
+        private static readonly SearchValues<char> InvalidCharactersInPropertyNamesSearchValues = SearchValues.Create(InvalidCharactersInPropertyNames);
 
         /// <summary>Maximum batch boundary length supported (not including leading CRLF or '-').</summary>
         private const int MaxBoundaryLength = 70;
@@ -452,7 +457,26 @@ namespace Microsoft.OData
         {
             Debug.Assert(!string.IsNullOrEmpty(propertyName), "The JSON reader should have verified that the property name is not null or empty.");
 
-            return propertyName.IndexOfAny(ValidationUtils.InvalidCharactersInPropertyNames) < 0;
+            return propertyName.AsSpan().IndexOfAny(InvalidCharactersInPropertyNamesSearchValues) < 0;
+        }
+
+        /// <summary>Pre-built description of invalid property-name characters; computed once.</summary>
+        private static readonly string InvalidCharactersInPropertyNamesAsErrorString = BuildInvalidCharactersErrorString();
+
+        private static string BuildInvalidCharactersErrorString()
+        {
+            char[] chars = ValidationUtils.InvalidCharactersInPropertyNames;
+            // Each entry contributes 3 chars ('X') + ", " between each.  Pre-size accordingly.
+            StringBuilder sb = new StringBuilder(chars.Length * 5);
+            for (int i = 0; i < chars.Length; i++)
+            {
+                if (i > 0)
+                {
+                    sb.Append(", ");
+                }
+                sb.Append('\'').Append(chars[i]).Append('\'');
+            }
+            return sb.ToString();
         }
 
         /// <summary>
@@ -465,10 +489,7 @@ namespace Microsoft.OData
 
             if (!IsValidPropertyName(propertyName))
             {
-                string invalidChars = string.Join(
-                    ", ",
-                    ValidationUtils.InvalidCharactersInPropertyNames.Select(c => string.Format(CultureInfo.InvariantCulture, "'{0}'", c)).ToArray());
-                throw new ODataException(Error.Format(SRResources.ValidationUtils_PropertiesMustNotContainReservedChars, propertyName, invalidChars));
+                throw new ODataException(Error.Format(SRResources.ValidationUtils_PropertiesMustNotContainReservedChars, propertyName, InvalidCharactersInPropertyNamesAsErrorString));
             }
         }
     }

--- a/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="CsdlReader.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -509,9 +509,9 @@ namespace Microsoft.OData.Edm.Csdl
                 {
                     if (this.reader.NodeType == XmlNodeType.Element)
                     {
-                        if (elementParsers.ContainsKey(this.reader.LocalName))
+                        if (elementParsers.TryGetValue(this.reader.LocalName, out Action parser))
                         {
-                            elementParsers[this.reader.LocalName]();
+                            parser();
                         }
                         else
                         {

--- a/src/Microsoft.OData.Edm/Csdl/EdmValueParser.cs
+++ b/src/Microsoft.OData.Edm/Csdl/EdmValueParser.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="EdmValueParser.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -27,12 +27,15 @@ namespace Microsoft.OData.Edm.Csdl
     /// <summary>
     /// Contains xml parsing methods for Edm.
     /// </summary>
-    internal static class EdmValueParser
+    internal static partial class EdmValueParser
     {
         /// <summary>
-        /// This pattern eliminates all durations with year or month fields, leaving only those with day, hour, minutes, and/or seconds fields
+        /// This pattern eliminates all durations with year or month fields, leaving only those with day, hour, minutes, and/or seconds fields.
         /// </summary>
-        internal static readonly Regex DayTimeDurationValidator = PlatformHelper.CreateCompiled("^[^YM]*[DT].*$", RegexOptions.Singleline);
+        [GeneratedRegex("^[^YM]*[DT].*$", RegexOptions.Singleline)]
+        private static partial Regex DayTimeDurationValidatorRegex();
+
+        internal static readonly Regex DayTimeDurationValidator = DayTimeDurationValidatorRegex();
 
         /// <summary>
         /// Converts a string to a TimeSpan.

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParserBase.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParserBase.cs
@@ -117,7 +117,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
             CsdlTypeReference elementType = null;
             if (typeString != null)
             {
-                string[] typeInformation = typeString.Split(new char[] { '(', ')' });
+                string[] typeInformation = typeString.Split('(', ')');
                 string typeName = typeInformation[0];
                 switch (typeName)
                 {

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/JsonParserContext.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/JsonParserContext.cs
@@ -218,7 +218,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
             }
             else
             {
-                return string.Format(CultureInfo.InvariantCulture, "[{0}]", (int)node);
+                return string.Create(CultureInfo.InvariantCulture, $"[{(int)node}]");
             }
         }
     }

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsPathExpression.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsPathExpression.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 
         private IEnumerable<string> ComputePath()
         {
-            return this.Expression.Path.Split(new char[] { '/' }, StringSplitOptions.None);
+            return this.Expression.Path.Split('/', StringSplitOptions.None);
         }
     }
 }

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
@@ -582,7 +582,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
                 foreach (IEdmOperationParameter parameter in function.Parameters)
                 {
                     parameterTypeNameEnumerator.MoveNext();
-                    string[] typeInformation = parameterTypeNameEnumerator.Current.Split(new char[] { '(', ')' });
+                    string[] typeInformation = parameterTypeNameEnumerator.Current.Split('(', ')');
                     switch (typeInformation[0])
                     {
                         case CsdlConstants.Value_Collection:

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
@@ -47,9 +47,8 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
                         // Skip actionImports that have the same name for same overloads of a action.
                         IEdmActionImport actionImport = (IEdmActionImport)element;
                         string uniqueActionName = actionImport.Name + "_" + actionImport.Action.FullName() + GetEntitySetString(actionImport);
-                        if (!actionImportsWritten.Contains(uniqueActionName))
+                        if (actionImportsWritten.Add(uniqueActionName))
                         {
-                            actionImportsWritten.Add(uniqueActionName);
                             this.ProcessActionImport(actionImport);
                         }
 
@@ -58,9 +57,8 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
                         // Skip functionImports that have the same name for same overloads of a function.
                         IEdmFunctionImport functionImport = (IEdmFunctionImport)element;
                         string uniqueFunctionName = functionImport.Name + "_" + functionImport.Function.FullName() + GetEntitySetString(functionImport);
-                        if (!functionImportsWritten.Contains(uniqueFunctionName))
+                        if (functionImportsWritten.Add(uniqueFunctionName))
                         {
-                            functionImportsWritten.Add(uniqueFunctionName);
                             this.ProcessFunctionImport(functionImport);
                         }
 
@@ -99,9 +97,8 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
                         IEdmActionImport actionImport = (IEdmActionImport)element;
 
                         var uniqueActionName = string.Concat(actionImport.Name, "_", actionImport.Action.FullName(), GetEntitySetString(actionImport));
-                        if (!actionImportsWritten.Contains(uniqueActionName))
+                        if (actionImportsWritten.Add(uniqueActionName))
                         {
-                            actionImportsWritten.Add(uniqueActionName);
                             await this.ProcessActionImportAsync(actionImport).ConfigureAwait(false);
                         }
 
@@ -111,9 +108,8 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
                         IEdmFunctionImport functionImport = (IEdmFunctionImport)element;
 
                         var uniqueFunctionName = string.Concat(functionImport.Name, "_", functionImport.Function.FullName(), GetEntitySetString(functionImport));
-                        if (!functionImportsWritten.Contains(uniqueFunctionName))
+                        if (functionImportsWritten.Add(uniqueFunctionName))
                         {
-                            functionImportsWritten.Add(uniqueFunctionName);
                             await this.ProcessFunctionImportAsync(functionImport).ConfigureAwait(false);
                         }
 

--- a/src/Microsoft.OData.Edm/EdmUtil.cs
+++ b/src/Microsoft.OData.Edm/EdmUtil.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="EdmUtil.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -21,7 +21,7 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// Utilities for Edm.
     /// </summary>
-    public static class EdmUtil
+    public static partial class EdmUtil
     {
         // this is what we should be doing for CDM schemas
         // the RegEx for valid identifiers are taken from the C# Language Specification (2.4.2 Identifiers)
@@ -37,7 +37,10 @@ namespace Microsoft.OData.Edm
         private const string NameExp = StartCharacterExp + OtherCharacterExp + "{0,}";
 
         // private static Regex ValidDottedName=new Regex(@"^"+NameExp+@"(\."+NameExp+@"){0,}$",RegexOptions.Singleline);
-        private static Regex UndottedNameValidator = PlatformHelper.CreateCompiled(@"^" + NameExp + @"$", RegexOptions.Singleline);
+        [GeneratedRegex("^" + NameExp + "$", RegexOptions.Singleline)]
+        private static partial Regex UndottedNameValidatorRegex();
+
+        private static Regex UndottedNameValidator = UndottedNameValidatorRegex();
 
         /// <summary>
         /// Checks whether the <paramref name="annotatableProperty"/> has a MIME type annotation.

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -29,7 +29,6 @@ namespace Microsoft.OData.Edm
     public static partial class ExtensionMethods
     {
         private const int ContainerExtendsMaxDepth = 100;
-        private const string CollectionTypeFormat = EdmConstants.Type_Collection + "({0})";
 
         private static readonly IEnumerable<IEdmStructuralProperty> EmptyStructuralProperties = Enumerable.Empty<IEdmStructuralProperty>();
         private static readonly IEnumerable<IEdmNavigationProperty> EmptyNavigationProperties = Enumerable.Empty<IEdmNavigationProperty>();
@@ -1743,7 +1742,7 @@ namespace Microsoft.OData.Edm
             {
                 // Handle collection case.
                 namedDefinition = (type as IEdmCollectionType).ElementType.Definition as IEdmSchemaElement;
-                return namedDefinition != null ? string.Format(CultureInfo.InvariantCulture, CollectionTypeFormat, namedDefinition.FullName()) : null;
+                return namedDefinition != null ? $"{EdmConstants.Type_Collection}({namedDefinition.FullName()})" : null;
             }
         }
 
@@ -2844,7 +2843,7 @@ namespace Microsoft.OData.Edm
                     }
                 }
 
-                return (ns != null) ? string.Format(CultureInfo.InvariantCulture, "{0}{1}", ns, name.Substring(idx)) : name;
+                return (ns != null) ? string.Concat(ns, name.AsSpan(idx)) : name;
             }
 
             return name;
@@ -3691,7 +3690,7 @@ namespace Microsoft.OData.Edm
 
             Debug.Assert(!string.IsNullOrEmpty(name), "name must be provided");
 
-            string qualifiedName = String.Format(CultureInfo.InvariantCulture, "{0}.{1}", namespaceName, name);
+            string qualifiedName = $"{namespaceName}.{name}";
 
             // If the user has already defined his own UInt TypeDefinition, we don't define ours anymore.
             var type = model.FindDeclaredType(qualifiedName) as IEdmTypeDefinition;

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ToTraceStringExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ToTraceStringExtensionMethods.cs
@@ -149,7 +149,7 @@ namespace Microsoft.OData.Edm
         {
             if (type.IsUnbounded == true || type.MaxLength != null)
             {
-                sb.AppendKeyValue(EdmConstants.FacetName_MaxLength, (type.IsUnbounded) ? EdmConstants.Value_Max : string.Format(CultureInfo.InvariantCulture, $"{type.MaxLength}"));
+                sb.AppendKeyValue(EdmConstants.FacetName_MaxLength, (type.IsUnbounded) ? EdmConstants.Value_Max : type.MaxLength.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             if (type.IsUnicode != null)
@@ -162,7 +162,7 @@ namespace Microsoft.OData.Edm
         {
             if (type.Precision != null)
             {
-                sb.AppendKeyValue(EdmConstants.FacetName_Precision, string.Format(CultureInfo.InvariantCulture, $"{type.Precision}"));
+                sb.AppendKeyValue(EdmConstants.FacetName_Precision, type.Precision.Value.ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -170,18 +170,18 @@ namespace Microsoft.OData.Edm
         {
             if (type.Precision != null)
             {
-                sb.AppendKeyValue(EdmConstants.FacetName_Precision, string.Format(CultureInfo.InvariantCulture, $"{type.Precision}"));
+                sb.AppendKeyValue(EdmConstants.FacetName_Precision, type.Precision.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             if (type.Scale != null)
             {
-                sb.AppendKeyValue(EdmConstants.FacetName_Scale, string.Format(CultureInfo.InvariantCulture, $"{type.Scale}"));
+                sb.AppendKeyValue(EdmConstants.FacetName_Scale, type.Scale.Value.ToString(CultureInfo.InvariantCulture));
             }
         }
 
         private static void AppendSpatialFacets(this StringBuilder sb, IEdmSpatialTypeReference type)
         {
-            sb.AppendKeyValue(EdmConstants.FacetName_Srid, type.SpatialReferenceIdentifier != null ? string.Format(CultureInfo.InvariantCulture, $"{type.SpatialReferenceIdentifier}") : EdmConstants.Value_SridVariable);
+            sb.AppendKeyValue(EdmConstants.FacetName_Srid, type.SpatialReferenceIdentifier != null ? type.SpatialReferenceIdentifier.Value.ToString(CultureInfo.InvariantCulture) : EdmConstants.Value_SridVariable);
         }
 
         private static void AppendKeyValue(this StringBuilder sb, string key, string value)

--- a/src/Microsoft.OData.Edm/SRResources.Designer.cs
+++ b/src/Microsoft.OData.Edm/SRResources.Designer.cs
@@ -2337,6 +2337,24 @@ namespace Microsoft.OData.Edm {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The binding path {0} for navigation property {1} under navigation source {2} is not valid..
+        /// </summary>
+        internal static string EdmModel_Validator_Semantic_NavigationSourceMappingMustResolveToValidNavigationProperty {
+            get {
+                return ResourceManager.GetString("EdmModel_Validator_Semantic_NavigationSourceMappingMustResolveToValidNavigationProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot resolve partner path for navigation property &apos;{0}&apos;..
+        /// </summary>
+        internal static string EdmModel_Validator_Semantic_NavigationPropertyPartnerPathInvalid {
+            get {
+                return ResourceManager.GetString("EdmModel_Validator_Semantic_NavigationPropertyPartnerPathInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Term type &apos;{0}&apos; is not supported for value retrieval..
         /// </summary>
         internal static string EdmVocabularyAnnotations_TermTypeNotSupported {
@@ -2405,6 +2423,15 @@ namespace Microsoft.OData.Edm {
         internal static string PathSegmentMustNotContainSlash {
             get {
                 return ResourceManager.GetString("PathSegmentMustNotContainSlash", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path segments must not be null..
+        /// </summary>
+        internal static string PathSegmentMustNotBeNull {
+            get {
+                return ResourceManager.GetString("PathSegmentMustNotBeNull", resourceCulture);
             }
         }
         

--- a/src/Microsoft.OData.Edm/SRResources.resx
+++ b/src/Microsoft.OData.Edm/SRResources.resx
@@ -156,6 +156,9 @@
   <data name="PathSegmentMustNotContainSlash" xml:space="preserve">
     <value>Path segments must not contain '/' character.</value>
   </data>
+  <data name="PathSegmentMustNotBeNull" xml:space="preserve">
+    <value>Path segments must not be null.</value>
+  </data>
   <data name="PropertyPathMustEndingWithCorrectPropertyName" xml:space="preserve">
     <value>Property Path '{0}' is not ended with '{1}'.</value>
   </data>
@@ -1049,5 +1052,11 @@
   </data>
   <data name="EdmVocabularyAnnotations_InvalidLocationForTargetPathAnnotation" xml:space="preserve">
     <value>Invalid to set inline location for a path target '{0}'.</value>
+  </data>
+  <data name="EdmModel_Validator_Semantic_NavigationSourceMappingMustResolveToValidNavigationProperty" xml:space="preserve">
+    <value>The binding path {0} for navigation property {1} under navigation source {2} is not valid.</value>
+  </data>
+  <data name="EdmModel_Validator_Semantic_NavigationPropertyPartnerPathInvalid" xml:space="preserve">
+    <value>Cannot resolve partner path for navigation property '{0}'.</value>
   </data>
 </root>

--- a/src/Microsoft.OData.Edm/Schema/EdmModel.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmModel.cs
@@ -183,7 +183,8 @@ namespace Microsoft.OData.Edm
                 this.vocabularyAnnotationsDictionary.Add(annotation.Target, elementAnnotations);
             }
 
-            elementAnnotations.RemoveAll(p => p.Term.FullName() == annotation.Term.FullName());
+            string termFullName = annotation.Term.FullName();
+            elementAnnotations.RemoveAll(p => string.Equals(p.Term.FullName(), termFullName, StringComparison.Ordinal));
             elementAnnotations.Add(annotation);
         }
     }

--- a/src/Microsoft.OData.Edm/Schema/EdmPathExpression.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmPathExpression.cs
@@ -45,12 +45,25 @@ namespace Microsoft.OData.Edm
         {
             EdmUtil.CheckArgumentNull(pathSegments, "pathSegments");
 
-            if (pathSegments.Any(segment => segment.Contains("/", StringComparison.Ordinal)))
+            List<string> segments = pathSegments is ICollection<string> col
+                ? new List<string>(col.Count)
+                : new List<string>();
+            foreach (string segment in pathSegments)
             {
-                throw new ArgumentException(SRResources.PathSegmentMustNotContainSlash);
+                if (segment == null)
+                {
+                    throw new ArgumentException(SRResources.PathSegmentMustNotBeNull, nameof(pathSegments));
+                }
+
+                if (segment.IndexOf('/') >= 0)
+                {
+                    throw new ArgumentException(SRResources.PathSegmentMustNotContainSlash);
+                }
+
+                segments.Add(segment);
             }
 
-            this.pathSegments = pathSegments.ToList();
+            this.pathSegments = segments;
         }
 
         /// <summary>
@@ -66,7 +79,7 @@ namespace Microsoft.OData.Edm
         /// </summary>
         public string Path
         {
-            get { return this.path ?? (this.path = string.Join("/", this.pathSegments.ToArray())); }
+            get { return this.path ?? (this.path = string.Join('/', this.pathSegments)); }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Validation/ValidationRules.cs
+++ b/src/Microsoft.OData.Edm/Validation/ValidationRules.cs
@@ -433,13 +433,10 @@ namespace Microsoft.OData.Edm.Validation
 
                         if (!TryResolveNavigationPropertyBindingPath(context.Model, navigationSource, mapping))
                         {
-                            // TODO: Update error message in V7.1 #644
                             context.AddError(
                                 navigationSource.Location(),
                                 EdmErrorCode.UnresolvedNavigationPropertyBindingPath,
-                                string.Format(
-                                    CultureInfo.CurrentCulture,
-                                    "The binding path {0} for navigation property {1} under navigation source {2} is not valid.",
+                                Error.Format(SRResources.EdmModel_Validator_Semantic_NavigationSourceMappingMustResolveToValidNavigationProperty,
                                     mapping.Path.Path,
                                     mapping.NavigationProperty.Name,
                                     navigationSource.Name));
@@ -1428,10 +1425,7 @@ namespace Microsoft.OData.Edm.Validation
                         context.AddError(
                         property.Location(),
                         EdmErrorCode.UnresolvedNavigationPropertyPartnerPath,
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            "Cannot resolve partner path for navigation property '{0}'.",
-                            property.Name));
+                        Error.Format(SRResources.EdmModel_Validator_Semantic_NavigationPropertyPartnerPathInvalid, property.Name));
                     }
                 });
 

--- a/src/Microsoft.OData.Edm/Vocabularies/EdmExpressionEvaluator.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/EdmExpressionEvaluator.cs
@@ -668,7 +668,7 @@ namespace Microsoft.OData.Edm.Vocabularies
                     {
                         if (!enumType.IsFlags || !EdmEnumValueParser.IsEnumIntegerType(enumType))
                         {
-                            throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Type {0} cannot be assigned with multi-values.", enumType.FullName()));
+                            throw new InvalidOperationException($"Type {enumType.FullName()} cannot be assigned with multi-values.");
                         }
 
                         long result = 0;

--- a/src/Microsoft.Spatial/CoordinateSystem.cs
+++ b/src/Microsoft.Spatial/CoordinateSystem.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -115,7 +116,7 @@ namespace Microsoft.Spatial
         /// <returns>The coordinate system, for debugging.</returns>
         public override string ToString()
         {
-            return string.Format(CultureInfo.InvariantCulture, "{0}CoordinateSystem(EpsgId={1})", this.topology, this.EpsgId);
+            return FormattableString.Invariant($"{this.topology}CoordinateSystem(EpsgId={this.EpsgId})");
         }
 
         /// <summary>Displays a string that can be used with extended WKT.</summary>

--- a/src/Microsoft.Spatial/Geography/GeographyPosition.cs
+++ b/src/Microsoft.Spatial/Geography/GeographyPosition.cs
@@ -153,7 +153,9 @@ namespace Microsoft.Spatial
         /// <returns>The string representation of this instance.</returns>
         public override string ToString()
         {
-            return String.Format(System.Globalization.CultureInfo.InvariantCulture, "GeographyPosition(latitude:{0}, longitude:{1}, z:{2}, m:{3})", this.latitude, this.longitude, this.z.HasValue ? $"{this.z}" : "null", this.m.HasValue ? $"{this.m}" : "null");
+            string z = this.z.HasValue ? this.z.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : "null";
+            string m = this.m.HasValue ? this.m.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : "null";
+            return FormattableString.Invariant($"GeographyPosition(latitude:{this.latitude}, longitude:{this.longitude}, z:{z}, m:{m})");
         }
     }
 }

--- a/src/Microsoft.Spatial/Geometry/GeometryPosition.cs
+++ b/src/Microsoft.Spatial/Geometry/GeometryPosition.cs
@@ -152,7 +152,9 @@ namespace Microsoft.Spatial
         /// <returns>The string representation of this instance.</returns>
         public override string ToString()
         {
-            return String.Format(System.Globalization.CultureInfo.InvariantCulture, "GeometryPosition({0}, {1}, {2}, {3})", this.x, this.y, this.z.HasValue ? $"{this.z}" : "null", this.m.HasValue ? $"{this.m}" : "null");
+            string z = this.z.HasValue ? this.z.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : "null";
+            string m = this.m.HasValue ? this.m.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : "null";
+            return FormattableString.Invariant($"GeometryPosition({this.x}, {this.y}, {z}, {m})");
         }
     }
 }

--- a/src/Microsoft.Spatial/Gml/GmlReader.cs
+++ b/src/Microsoft.Spatial/Gml/GmlReader.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="GmlReader.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -7,6 +7,7 @@
 namespace Microsoft.Spatial
 {
     using System;
+    using System.Collections.Frozen;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Xml;
@@ -54,16 +55,16 @@ namespace Microsoft.Spatial
             private static readonly char[] coordinateDelimiter = { ' ', '\t', '\r', '\n' };
 
             /// <summary>
-            /// List of known gml elements that can be ignored by the parser
+            /// List of known gml elements that can be ignored by the parser.
             /// </summary>
-            private static readonly Dictionary<String, String> skippableElements = new Dictionary<string, string>(StringComparer.Ordinal)
+            private static readonly FrozenSet<string> skippableElements = new HashSet<string>(StringComparer.Ordinal)
                 {
-                    { GmlConstants.Name, GmlConstants.Name },
-                    { GmlConstants.Description, GmlConstants.Description },
-                    { GmlConstants.MetadataProperty, GmlConstants.MetadataProperty },
-                    { GmlConstants.DescriptionReference, GmlConstants.DescriptionReference },
-                    { GmlConstants.IdentifierElement, GmlConstants.IdentifierElement }
-                };
+                    GmlConstants.Name,
+                    GmlConstants.Description,
+                    GmlConstants.MetadataProperty,
+                    GmlConstants.DescriptionReference,
+                    GmlConstants.IdentifierElement
+                }.ToFrozenSet(StringComparer.Ordinal);
 
             #region Atomized Constants
 
@@ -788,7 +789,7 @@ namespace Microsoft.Spatial
                     {
                         // calling LocalName_get() multiple times should be avoided.
                         String localName = this.reader.LocalName;
-                        shouldSkip = skippableElements.ContainsKey(localName);
+                        shouldSkip = skippableElements.Contains(localName);
                     }
                     else
                     {

--- a/src/Microsoft.Spatial/WellKnown/WellKnownTextSqlReader.cs
+++ b/src/Microsoft.Spatial/WellKnown/WellKnownTextSqlReader.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="WellKnownTextSqlReader.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -308,49 +308,57 @@ namespace Microsoft.Spatial
                     throw new FormatException(Error.Format(SRResources.WellKnownText_UnknownTaggedText, string.Empty));
                 }
 
-                switch (this.lexer.CurrentToken.Text.ToUpperInvariant())
+                string token = this.lexer.CurrentToken.Text;
+                if (string.Equals(token, WellKnownTextConstants.WktPoint, StringComparison.OrdinalIgnoreCase))
                 {
-                    case WellKnownTextConstants.WktPoint:
-                        this.pipeline.BeginGeo(SpatialType.Point);
-                        this.ParsePointText();
-                        this.pipeline.EndGeo();
-                        break;
-                    case WellKnownTextConstants.WktLineString:
-                        this.pipeline.BeginGeo(SpatialType.LineString);
-                        this.ParseLineStringText();
-                        this.pipeline.EndGeo();
-                        break;
-                    case WellKnownTextConstants.WktPolygon:
-                        this.pipeline.BeginGeo(SpatialType.Polygon);
-                        this.ParsePolygonText();
-                        this.pipeline.EndGeo();
-                        break;
-                    case WellKnownTextConstants.WktMultiPoint:
-                        this.pipeline.BeginGeo(SpatialType.MultiPoint);
-                        this.ParseMultiGeoText(SpatialType.Point, this.ParsePointText);
-                        this.pipeline.EndGeo();
-                        break;
-                    case WellKnownTextConstants.WktMultiLineString:
-                        this.pipeline.BeginGeo(SpatialType.MultiLineString);
-                        this.ParseMultiGeoText(SpatialType.LineString, this.ParseLineStringText);
-                        this.pipeline.EndGeo();
-                        break;
-                    case WellKnownTextConstants.WktMultiPolygon:
-                        this.pipeline.BeginGeo(SpatialType.MultiPolygon);
-                        this.ParseMultiGeoText(SpatialType.Polygon, this.ParsePolygonText);
-                        this.pipeline.EndGeo();
-                        break;
-                    case WellKnownTextConstants.WktCollection:
-                        this.pipeline.BeginGeo(SpatialType.Collection);
-                        this.ParseCollectionText();
-                        this.pipeline.EndGeo();
-                        break;
-                    case WellKnownTextConstants.WktFullGlobe:
-                        this.pipeline.BeginGeo(SpatialType.FullGlobe);
-                        this.pipeline.EndGeo();
-                        break;
-                    default:
-                        throw new FormatException(Error.Format(SRResources.WellKnownText_UnknownTaggedText, this.lexer.CurrentToken.Text));
+                    this.pipeline.BeginGeo(SpatialType.Point);
+                    this.ParsePointText();
+                    this.pipeline.EndGeo();
+                }
+                else if (string.Equals(token, WellKnownTextConstants.WktLineString, StringComparison.OrdinalIgnoreCase))
+                {
+                    this.pipeline.BeginGeo(SpatialType.LineString);
+                    this.ParseLineStringText();
+                    this.pipeline.EndGeo();
+                }
+                else if (string.Equals(token, WellKnownTextConstants.WktPolygon, StringComparison.OrdinalIgnoreCase))
+                {
+                    this.pipeline.BeginGeo(SpatialType.Polygon);
+                    this.ParsePolygonText();
+                    this.pipeline.EndGeo();
+                }
+                else if (string.Equals(token, WellKnownTextConstants.WktMultiPoint, StringComparison.OrdinalIgnoreCase))
+                {
+                    this.pipeline.BeginGeo(SpatialType.MultiPoint);
+                    this.ParseMultiGeoText(SpatialType.Point, this.ParsePointText);
+                    this.pipeline.EndGeo();
+                }
+                else if (string.Equals(token, WellKnownTextConstants.WktMultiLineString, StringComparison.OrdinalIgnoreCase))
+                {
+                    this.pipeline.BeginGeo(SpatialType.MultiLineString);
+                    this.ParseMultiGeoText(SpatialType.LineString, this.ParseLineStringText);
+                    this.pipeline.EndGeo();
+                }
+                else if (string.Equals(token, WellKnownTextConstants.WktMultiPolygon, StringComparison.OrdinalIgnoreCase))
+                {
+                    this.pipeline.BeginGeo(SpatialType.MultiPolygon);
+                    this.ParseMultiGeoText(SpatialType.Polygon, this.ParsePolygonText);
+                    this.pipeline.EndGeo();
+                }
+                else if (string.Equals(token, WellKnownTextConstants.WktCollection, StringComparison.OrdinalIgnoreCase))
+                {
+                    this.pipeline.BeginGeo(SpatialType.Collection);
+                    this.ParseCollectionText();
+                    this.pipeline.EndGeo();
+                }
+                else if (string.Equals(token, WellKnownTextConstants.WktFullGlobe, StringComparison.OrdinalIgnoreCase))
+                {
+                    this.pipeline.BeginGeo(SpatialType.FullGlobe);
+                    this.pipeline.EndGeo();
+                }
+                else
+                {
+                    throw new FormatException(Error.Format(SRResources.WellKnownText_UnknownTaggedText, this.lexer.CurrentToken.Text));
                 }
             }
 
@@ -361,17 +369,16 @@ namespace Microsoft.Spatial
             private double ReadDouble()
             {
                 // <double> := <NUM> {.<NUM>}
-                var numberText = new StringBuilder();
                 this.ReadToken(WellKnownTextTokenType.Number, null);
-                numberText.Append(this.lexer.CurrentToken.Text);
+                string intPart = this.lexer.CurrentToken.Text;
                 if (this.ReadOptionalToken(WellKnownTextTokenType.Period, null))
                 {
-                    numberText.Append(WellKnownTextConstants.WktPeriod);
                     this.ReadToken(WellKnownTextTokenType.Number, null);
-                    numberText.Append(this.lexer.CurrentToken.Text);
+                    string fracPart = this.lexer.CurrentToken.Text;
+                    return double.Parse(string.Concat(intPart, WellKnownTextConstants.WktPeriod, fracPart), CultureInfo.InvariantCulture);
                 }
 
-                return Double.Parse(numberText.ToString(), CultureInfo.InvariantCulture);
+                return double.Parse(intPart, CultureInfo.InvariantCulture);
             }
 
             /// <summary>
@@ -402,19 +409,18 @@ namespace Microsoft.Spatial
             private bool TryReadOptionalNullableDouble(out double? value)
             {
                 // <double> := <NUM> {.<NUM>}
-                var numberText = new StringBuilder();
-
                 if (this.ReadOptionalToken(WellKnownTextTokenType.Number, null))
                 {
-                    numberText.Append(this.lexer.CurrentToken.Text);
+                    string intPart = this.lexer.CurrentToken.Text;
                     if (this.ReadOptionalToken(WellKnownTextTokenType.Period, null))
                     {
-                        numberText.Append(WellKnownTextConstants.WktPeriod);
                         this.ReadToken(WellKnownTextTokenType.Number, null);
-                        numberText.Append(this.lexer.CurrentToken.Text);
+                        string fracPart = this.lexer.CurrentToken.Text;
+                        value = double.Parse(string.Concat(intPart, WellKnownTextConstants.WktPeriod, fracPart), CultureInfo.InvariantCulture);
+                        return true;
                     }
 
-                    value = Double.Parse(numberText.ToString(), CultureInfo.InvariantCulture);
+                    value = double.Parse(intPart, CultureInfo.InvariantCulture);
                     return true;
                 }
 

--- a/src/PlatformHelper.cs
+++ b/src/PlatformHelper.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="PlatformHelper.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -41,7 +41,7 @@ namespace Microsoft.OData.Edm
     /// Helper methods that provide a common API surface on all platforms.
     /// </summary>
     [SuppressMessage("Performance", "CA1825:Avoid zero-length array allocations.", Justification = "<Pending>")]
-    internal static class PlatformHelper
+    internal static partial class PlatformHelper
     {
         /// <summary>
         /// Use this instead of Type.EmptyTypes.
@@ -50,19 +50,28 @@ namespace Microsoft.OData.Edm
         internal static readonly Type[] EmptyTypes = new Type[0];
 
         /// <summary>
-        /// This pattern eliminates all invalid dateOnly, the supported format should be "YYYY-MM-DD"
+        /// This pattern eliminates all invalid dateOnly, the supported format should be "YYYY-MM-DD".
         /// </summary>
-        internal static readonly Regex DateOnlyValidator = CreateCompiled(@"^(\d{4})-(0?[1-9]|1[012])-(0?[1-9]|[12]\d|3[0|1])$", RegexOptions.Singleline);
+        [GeneratedRegex(@"^(\d{4})-(0?[1-9]|1[012])-(0?[1-9]|[12]\d|3[0|1])$", RegexOptions.Singleline)]
+        private static partial Regex DateOnlyValidatorRegex();
+
+        internal static readonly Regex DateOnlyValidator = DateOnlyValidatorRegex();
 
         /// <summary>
-        /// This pattern eliminates all invalid timeOnly, the supported format should be "hh:mm:ss.fffffff"
+        /// This pattern eliminates all invalid timeOnly, the supported format should be "hh:mm:ss.fffffff".
         /// </summary>
-        internal static readonly Regex TimeOnlyValidator = CreateCompiled(@"^(0?\d|1\d|2[0-3]):(0?\d|[1-5]\d)(:(0?\d|[1-5]\d)(\.\d{1,7})?)?$", RegexOptions.Singleline);
+        [GeneratedRegex(@"^(0?\d|1\d|2[0-3]):(0?\d|[1-5]\d)(:(0?\d|[1-5]\d)(\.\d{1,7})?)?$", RegexOptions.Singleline)]
+        private static partial Regex TimeOnlyValidatorRegex();
+
+        internal static readonly Regex TimeOnlyValidator = TimeOnlyValidatorRegex();
 
         /// <summary>
-        /// This pattern eliminates whether a text is potentially DateTimeOffset but not others like GUID, digit .etc
+        /// This pattern eliminates whether a text is potentially DateTimeOffset but not others like GUID, digit .etc.
         /// </summary>
-        internal static readonly Regex PotentialDateTimeOffsetValidator = CreateCompiled(@"^(\d{2,4})-(\d{1,2})-(\d{1,2})(T|(\s+))(\d{1,2}):(\d{1,2})", RegexOptions.Singleline);
+        [GeneratedRegex(@"^(\d{2,4})-(\d{1,2})-(\d{1,2})(T|(\s+))(\d{1,2}):(\d{1,2})", RegexOptions.Singleline)]
+        private static partial Regex PotentialDateTimeOffsetValidatorRegex();
+
+        internal static readonly Regex PotentialDateTimeOffsetValidator = PotentialDateTimeOffsetValidatorRegex();
 
         /// <summary>
         /// Replacement for Uri.UriSchemeHttp, which does not exist on.
@@ -228,7 +237,7 @@ namespace Microsoft.OData.Edm
         {
             if (!PlatformHelper.TryConvertStringToDateOnly(text, out DateOnly date))
             {
-                throw new FormatException(string.Format(CultureInfo.InvariantCulture, "String '{0}' was not recognized as a valid Edm.Date.", text));
+                throw new FormatException($"String '{text}' was not recognized as a valid Edm.Date.");
             }
 
             return date;
@@ -260,7 +269,7 @@ namespace Microsoft.OData.Edm
         {
             if (!TimeOnly.TryParse(text, CultureInfo.CurrentCulture, out TimeOnly timeOnly))
             {
-                throw new FormatException(string.Format(CultureInfo.InvariantCulture, "String '{0}' was not recognized as a valid Edm.TimeOfDay.", text));
+                throw new FormatException($"String '{text}' was not recognized as a valid Edm.TimeOfDay.");
             }
 
             return timeOnly;

--- a/test/PerformanceTests/ComponentTests/Microbenchmarks/CsdlMicrobenchmarks.cs
+++ b/test/PerformanceTests/ComponentTests/Microbenchmarks/CsdlMicrobenchmarks.cs
@@ -1,0 +1,54 @@
+//---------------------------------------------------------------------
+// <copyright file="CsdlMicrobenchmarks.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Performance.Microbenchmarks
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Xml;
+    using BenchmarkDotNet.Attributes;
+    using Microsoft.OData.Edm;
+    using Microsoft.OData.Edm.Csdl;
+    using Microsoft.OData.Edm.Validation;
+
+    /// <summary>
+    /// CSDL XML read / write roundtrip benchmark for a representative model.
+    /// Exercises CSDL parser dispatch (TryGetValue), serializer set.Add, and
+    /// XML LINQ / namespace lookup hotspots.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class CsdlMicrobenchmarks
+    {
+        private byte[] _csdl;
+        private IEdmModel _model;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _csdl = TestUtils.ReadTestResource("AdventureWorksPlus.csdl");
+            _model = TestUtils.GetAdventureWorksModel();
+        }
+
+        [Benchmark]
+        public IEdmModel ReadCsdl()
+        {
+            using var ms = new MemoryStream(_csdl);
+            using var xr = XmlReader.Create(ms);
+            CsdlReader.TryParse(xr, out IEdmModel model, out IEnumerable<EdmError> _);
+            return model;
+        }
+
+        [Benchmark]
+        public int WriteCsdl()
+        {
+            using var ms = new MemoryStream(64 * 1024);
+            using var xw = XmlWriter.Create(ms);
+            CsdlWriter.TryWriteCsdl(_model, xw, CsdlTarget.OData, out _);
+            xw.Flush();
+            return (int)ms.Length;
+        }
+    }
+}

--- a/test/PerformanceTests/ComponentTests/Microbenchmarks/EdmModelLookupMicrobenchmarks.cs
+++ b/test/PerformanceTests/ComponentTests/Microbenchmarks/EdmModelLookupMicrobenchmarks.cs
@@ -1,0 +1,66 @@
+//---------------------------------------------------------------------
+// <copyright file="EdmModelLookupMicrobenchmarks.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Performance.Microbenchmarks
+{
+    using System.Linq;
+    using BenchmarkDotNet.Attributes;
+    using Microsoft.OData.Edm;
+
+    /// <summary>
+    /// Targets repeated EDM model lookups: <see cref="IEdmType"/> resolution,
+    /// <see cref="IEdmModel.FindBoundOperations"/>, and FullName comparisons.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class EdmModelLookupMicrobenchmarks
+    {
+        private IEdmModel _model;
+        private IEdmStructuredType _bindingType;
+        private string[] _typeFullNames;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _model = TestUtils.GetAdventureWorksModel();
+            _bindingType = (IEdmStructuredType)_model.FindDeclaredType("PerformanceServices.Edm.AdventureWorks.Product");
+            _typeFullNames = _model.SchemaElements
+                .OfType<IEdmSchemaType>()
+                .Select(t => t.FullName())
+                .ToArray();
+        }
+
+        [Benchmark]
+        public int FindDeclaredType_Bulk()
+        {
+            int hits = 0;
+            for (int round = 0; round < 100; round++)
+            {
+                foreach (string name in _typeFullNames)
+                {
+                    if (_model.FindDeclaredType(name) != null)
+                    {
+                        hits++;
+                    }
+                }
+            }
+            return hits;
+        }
+
+        [Benchmark]
+        public int FindBoundOperations_Bulk()
+        {
+            int total = 0;
+            for (int round = 0; round < 1000; round++)
+            {
+                foreach (var _ in _model.FindBoundOperations(_bindingType))
+                {
+                    total++;
+                }
+            }
+            return total;
+        }
+    }
+}

--- a/test/PerformanceTests/ComponentTests/Microbenchmarks/UriParserMicrobenchmarks.cs
+++ b/test/PerformanceTests/ComponentTests/Microbenchmarks/UriParserMicrobenchmarks.cs
@@ -1,0 +1,48 @@
+//---------------------------------------------------------------------
+// <copyright file="UriParserMicrobenchmarks.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Performance.Microbenchmarks
+{
+    using System;
+    using BenchmarkDotNet.Attributes;
+    using Microsoft.OData.Edm;
+    using Microsoft.OData.UriParser;
+
+    /// <summary>
+    /// Targets the URI parser tokenization hot path indirectly via the
+    /// public <see cref="ODataUriParser"/>.  The internal lexer/parser
+    /// allocations are exercised by ParseFilter-heavy queries.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class UriParserMicrobenchmarks
+    {
+        private static readonly IEdmModel Model = TestUtils.GetAdventureWorksModel();
+        private static readonly Uri ServiceRoot = new Uri("http://odata.org/Perf.svc/");
+
+        // Heavy parameter aliases & numeric mix; exercises ExpressionLexer paths.
+        private const string AliasHeavy = "Product?$filter=Name eq @p1 and Price lt @p2 and Cost gt @p3 and Foo eq @bar";
+        private const string NumericHeavy = "Product?$filter=Price eq 1.5 and Cost lt 100 and Inf eq -INF and Other gt 1.234e10";
+        private const string DeepExpand = "Product?$expand=ProductInventory($expand=Location($expand=WorkOrderRouting($expand=WorkOrder($expand=Product))))";
+
+        [Benchmark]
+        public object Filter_Aliases()
+        {
+            return new ODataUriParser(Model, ServiceRoot, new Uri(ServiceRoot, AliasHeavy)).ParseFilter();
+        }
+
+        [Benchmark]
+        public object Filter_Numerics()
+        {
+            return new ODataUriParser(Model, ServiceRoot, new Uri(ServiceRoot, NumericHeavy)).ParseFilter();
+        }
+
+        [Benchmark]
+        public object Expand_Deep()
+        {
+            return new ODataUriParser(Model, ServiceRoot, new Uri(ServiceRoot, DeepExpand)).ParseSelectAndExpand();
+        }
+    }
+}

--- a/test/PerformanceTests/ComponentTests/Microbenchmarks/Utf8JsonWriterMicrobenchmarks.cs
+++ b/test/PerformanceTests/ComponentTests/Microbenchmarks/Utf8JsonWriterMicrobenchmarks.cs
@@ -1,0 +1,94 @@
+//---------------------------------------------------------------------
+// <copyright file="Utf8JsonWriterMicrobenchmarks.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Performance.Microbenchmarks
+{
+    using System.IO;
+    using BenchmarkDotNet.Attributes;
+    using Microsoft.OData.Json;
+
+    /// <summary>
+    /// Targets the inner writes performed millions of times when serializing
+    /// large feeds: doubles (which previously allocated ".0" suffix strings),
+    /// property names (UTF8 byte allocation), and raw values.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class Utf8JsonWriterMicrobenchmarks
+    {
+        private const int Count = 5000;
+        private MemoryStream _stream;
+        private IJsonWriter _writer;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _stream = new MemoryStream(1024 * 1024);
+        }
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            _stream.Seek(0, SeekOrigin.Begin);
+            _stream.SetLength(0);
+            _writer = ODataUtf8JsonWriterFactory.Default.CreateJsonWriter(_stream, isIeee754Compatible: false, encoding: System.Text.Encoding.UTF8);
+        }
+
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            _writer.Flush();
+            (_writer as System.IDisposable)?.Dispose();
+        }
+
+        [Benchmark]
+        public void WriteIntegerDoubles()
+        {
+            // Representative numeric feed - integer-shaped doubles trigger the ".0" suffix path.
+            _writer.StartArrayScope();
+            for (int i = 0; i < Count; i++)
+            {
+                _writer.WriteValue((double)i);
+            }
+            _writer.EndArrayScope();
+        }
+
+        [Benchmark]
+        public void WriteFractionalDoubles()
+        {
+            _writer.StartArrayScope();
+            double v = 0.1;
+            for (int i = 0; i < Count; i++)
+            {
+                _writer.WriteValue(v);
+                v += 0.5;
+            }
+            _writer.EndArrayScope();
+        }
+
+        [Benchmark]
+        public void WritePropertyNames()
+        {
+            _writer.StartObjectScope();
+            for (int i = 0; i < Count; i++)
+            {
+                _writer.WriteName("PropertyName");
+                _writer.WriteValue(1);
+            }
+            _writer.EndObjectScope();
+        }
+
+        [Benchmark]
+        public void WriteRawValues()
+        {
+            _writer.StartArrayScope();
+            for (int i = 0; i < Count; i++)
+            {
+                _writer.WriteRawValue("{\"k\":1}");
+            }
+            _writer.EndArrayScope();
+        }
+    }
+}

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataAnnotationNamesTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataAnnotationNamesTests.cs
@@ -31,8 +31,8 @@ namespace Microsoft.OData.Tests.Json
             {
                 Assert.True(ODataAnnotationNames.IsODataAnnotationName(annotationName));
 
-                Assert.Contains(annotationName, ODataAnnotationNames.KnownODataAnnotationNames);
-                Assert.DoesNotContain(annotationName.ToUpperInvariant(), ODataAnnotationNames.KnownODataAnnotationNames);
+                Assert.Contains(annotationName, ODataAnnotationNames.KnownODataAnnotationNames.AsEnumerable());
+                Assert.DoesNotContain(annotationName.ToUpperInvariant(), ODataAnnotationNames.KnownODataAnnotationNames.AsEnumerable());
             }
         }
 


### PR DESCRIPTION
Ports performance optimizations and BenchmarkDotNet microbenchmark suites from main (commit e375dd74e) onto dev-9.x. All changes are surgical and behaviour-preserving.

New BenchmarkDotNet microbenchmark suites live under test/PerformanceTests/ComponentTests/Microbenchmarks/: Utf8JsonWriterMicrobenchmarks, UriParserMicrobenchmarks, EdmModelLookupMicrobenchmarks, CsdlMicrobenchmarks.

Conflicts resolved against dev-9.x:
- PlatformHelper.cs: applied GeneratedRegex pattern to DateOnly/TimeOnly validators (dev-9.x kept CreateCompiled for those two).
- EdmLibraryExtensions.cs: refactored primitive-type map to use a FrozenDictionary built via _primitiveTypeReferenceMapBuilder.
- ExpressionLexer.cs: kept dev-9.x's ReadOnlyMemory<char> slices and applied the IndexOf('.') < 0 optimization.
- UriPrimitiveTypeParser.cs: removed redundant string.Format wrappers around Error.Format in all three catch blocks.
- InBinder.cs / EdmXmlDocumentParser.cs: dev-9.x already removed or rewrote the affected code paths; kept dev-9.x version.
- SRResources.resx (Edm): added PathSegmentMustNotBeNull alongside dev-9.x's PropertyPathMustEndingWithCorrectPropertyName.

Validation:
- sln/OData.sln builds clean (0 errors).
- Microsoft.OData.Core.Tests: 11423 passed.
- Microsoft.OData.Edm.Tests: 1569 passed.
- Microsoft.OData.Client.Tests: 589 passed.
- Microsoft.Spatial.Tests: 402 passed.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
