### PR TITLE
Refactor: use FullNameEquals extension and related cleanups

### DIFF
--- a/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
+++ b/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
@@ -1692,7 +1692,7 @@ namespace Microsoft.OData.Metadata
 
             // if the container name of the operationImport doesn't equal the current container, don't search just return empty as there are no matches.
             if (containerName != null &&
-                !(container.Name.Equals(containerName, StringComparison.Ordinal) || container.FullName().Equals(containerName, StringComparison.Ordinal)))
+                !(container.Name.Equals(containerName, StringComparison.Ordinal) || container.FullNameEquals(containerName, StringComparison.Ordinal)))
             {
                 return Enumerable.Empty<IEdmOperationImport>();
             }

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -96,7 +96,7 @@ namespace Microsoft.OData
         /// <summary>
         /// Returns <paramref name="source"/> as an <see cref="IReadOnlyList{T}"/>, materializing the
         /// sequence to an array when it isn't already a known collection. Used to avoid re-enumerating
-        /// the LINQ iterator returned by <see cref="ExtensionMethods.GetDerivedTypeConstraints"/>.
+        /// the LINQ iterator returned by <see cref="ExtensionMethods.GetDerivedTypeConstraints(IEdmModel, IEdmNavigationSource)"/>.
         /// </summary>
         private static IReadOnlyList<string> MaterializeOrNull(IEnumerable<string> source)
         {

--- a/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
@@ -604,9 +604,10 @@ namespace Microsoft.OData.UriParser
 
         private static void FindSchemaElementsInModel<T>(IEdmModel model, ReadOnlySpan<char> qualifiedName, bool caseInsensitive, ref IList<T> results) where T : IEdmSchemaElement
         {
+            StringComparison comparisonType = caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
             foreach (IEdmSchemaElement schema in model.SchemaElements)
             {
-                if (qualifiedName.Equals(schema.FullName(), caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+                if (schema.FullNameEquals(qualifiedName, comparisonType))
                 {
                     if (schema is T)
                     {

--- a/src/Microsoft.OData.Core/UrlValidation/Rules/DeprecationRules.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/Rules/DeprecationRules.cs
@@ -269,8 +269,9 @@ namespace Microsoft.OData.UriParser.Validation.Rules
         /// <returns>True if the annotation is the Revisions annotation, otherwise false.</returns>
         private static bool isRevisionsAnnotation(IEdmVocabularyAnnotation annotation)
         {
-            return string.Equals(annotation.Term.FullName(), CoreVocabularyConstants.Revisions, StringComparison.OrdinalIgnoreCase) ||
-                            string.Equals(annotation.Term.FullName(), DefaultCoreAliasWithRevisionTerm, StringComparison.OrdinalIgnoreCase);
+            IEdmTerm term = annotation.Term;
+            return term.FullNameEquals(CoreVocabularyConstants.Revisions, StringComparison.OrdinalIgnoreCase) ||
+                            term.FullNameEquals(DefaultCoreAliasWithRevisionTerm, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.ReadOnlySpan.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.ReadOnlySpan.cs
@@ -446,7 +446,7 @@ namespace Microsoft.OData.Edm
             ReadOnlySpan<char> firstElementName = path[segmentRanges.Current];
             if (firstElementName.Contains(".".AsSpan(), StringComparison.Ordinal))
             {
-                if (firstElementName.Equals(container.FullName(), StringComparison.OrdinalIgnoreCase))
+                if (container.FullNameEquals(firstElementName, StringComparison.OrdinalIgnoreCase))
                 {
                     if (segmentRanges.MoveNext())
                     {

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -1587,6 +1587,69 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
+        /// Compares the full name of <paramref name="element"/> to <paramref name="qualifiedName"/>
+        /// using <see cref="StringComparison.Ordinal"/> without materializing the concatenated
+        /// "Namespace.Name" string when the element does not implement <see cref="IEdmFullNamedElement"/>.
+        /// Mirrors the semantics of <see cref="FullName(IEdmSchemaElement)"/>.
+        /// </summary>
+        /// <param name="element">Reference to the calling object.</param>
+        /// <param name="qualifiedName">The qualified name to compare against.</param>
+        /// <returns>true if the element's full name equals <paramref name="qualifiedName"/> using <see cref="StringComparison.Ordinal"/>; otherwise, false.</returns>
+        public static bool FullNameEquals(this IEdmSchemaElement element, ReadOnlySpan<char> qualifiedName)
+        {
+            return FullNameEquals(element, qualifiedName, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Compares the full name of <paramref name="element"/> to <paramref name="qualifiedName"/>
+        /// using the specified <see cref="StringComparison"/> without materializing the concatenated
+        /// "Namespace.Name" string when the element does not implement <see cref="IEdmFullNamedElement"/>.
+        /// Mirrors the semantics of <see cref="FullName(IEdmSchemaElement)"/>.
+        /// </summary>
+        /// <param name="element">Reference to the calling object.</param>
+        /// <param name="qualifiedName">The qualified name to compare against.</param>
+        /// <param name="comparisonType">The string comparison to apply.</param>
+        /// <returns>true if the element's full name equals <paramref name="qualifiedName"/> using <paramref name="comparisonType"/>; otherwise, false.</returns>
+        public static bool FullNameEquals(this IEdmSchemaElement element, ReadOnlySpan<char> qualifiedName, StringComparison comparisonType)
+        {
+            EdmUtil.CheckArgumentNull(element, "element");
+
+            if (element is IEdmFullNamedElement fullNamed)
+            {
+                return qualifiedName.Equals(fullNamed.FullName.AsSpan(), comparisonType);
+            }
+
+            string name = element.Name;
+            string ns = element.Namespace;
+
+            if (name == null)
+            {
+                return qualifiedName.Length == 0;
+            }
+
+            if (ns == null)
+            {
+                return qualifiedName.Equals(name.AsSpan(), comparisonType);
+            }
+
+            // Compare "ns + '.' + name" against qualifiedName in place.
+            int nsLen = ns.Length;
+            int nameLen = name.Length;
+            if (qualifiedName.Length != nsLen + 1 + nameLen)
+            {
+                return false;
+            }
+
+            if (qualifiedName[nsLen] != '.')
+            {
+                return false;
+            }
+
+            return qualifiedName.Slice(0, nsLen).Equals(ns.AsSpan(), comparisonType)
+                && qualifiedName.Slice(nsLen + 1, nameLen).Equals(name.AsSpan(), comparisonType);
+        }
+
+        /// <summary>
         /// Gets the Short Qualified name of the element.
         /// </summary>
         /// <param name="element">Reference to the calling object.</param>
@@ -2631,7 +2694,7 @@ namespace Microsoft.OData.Edm
 
             if (forceFullyQualifiedNameFilter || operationName.IndexOf(".", StringComparison.Ordinal) > -1)
             {
-                return operations.Where(o => o.FullName() == operationName);
+                return operations.Where(o => o.FullNameEquals(operationName.AsSpan(), StringComparison.Ordinal));
             }
             else
             {
@@ -3238,7 +3301,7 @@ namespace Microsoft.OData.Edm
             int nextIndex = 1;
             if (firstElementName.Contains(".", StringComparison.Ordinal))
             {
-                if (string.Equals(firstElementName, container.FullName(), StringComparison.OrdinalIgnoreCase))
+                if (container.FullNameEquals(firstElementName, StringComparison.OrdinalIgnoreCase))
                 {
                     if (pathSegments.Length > 1)
                     {

--- a/src/Microsoft.OData.Edm/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+static Microsoft.OData.Edm.ExtensionMethods.FullNameEquals(this Microsoft.OData.Edm.IEdmSchemaElement element, System.ReadOnlySpan<char> qualifiedName) -> bool
+static Microsoft.OData.Edm.ExtensionMethods.FullNameEquals(this Microsoft.OData.Edm.IEdmSchemaElement element, System.ReadOnlySpan<char> qualifiedName, System.StringComparison comparisonType) -> bool

--- a/src/Microsoft.OData.Edm/Schema/EdmModel.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmModel.cs
@@ -184,7 +184,7 @@ namespace Microsoft.OData.Edm
             }
 
             string termFullName = annotation.Term.FullName();
-            elementAnnotations.RemoveAll(p => string.Equals(p.Term.FullName(), termFullName, StringComparison.Ordinal));
+            elementAnnotations.RemoveAll(p => p.Term.FullNameEquals(termFullName, StringComparison.Ordinal));
             elementAnnotations.Add(annotation);
         }
     }

--- a/src/Microsoft.OData.Edm/Schema/EdmModelBase.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmModelBase.cs
@@ -246,7 +246,8 @@ namespace Microsoft.OData.Edm
                 return Enumerable.Empty<IEdmOperation>();
             }
 
-            IList<IEdmOperation> matchedOperations = new List<IEdmOperation>();
+            // Needn't to allocate a new list every call. Defer the allocation until we find the first matched operation.
+            IList<IEdmOperation> matchedOperations = null;
 
             IList<IEdmOperation> operations = enumerable as IList<IEdmOperation>;
 
@@ -254,9 +255,9 @@ namespace Microsoft.OData.Edm
             {
                 for (int i = 0; i < operations.Count; i++)
                 {
-                    if (qualifiedName.Equals(operations[i].FullName(), StringComparison.Ordinal))
+                    if (operations[i].FullNameEquals(qualifiedName, StringComparison.Ordinal))
                     {
-                        matchedOperations.Add(operations[i]);
+                        (matchedOperations ??= new List<IEdmOperation>()).Add(operations[i]);
                     }
                 }
             }
@@ -264,14 +265,14 @@ namespace Microsoft.OData.Edm
             {
                 foreach (IEdmOperation operation in enumerable)
                 {
-                    if (qualifiedName.Equals(operation.FullName(), StringComparison.Ordinal))
+                    if (operation.FullNameEquals(qualifiedName, StringComparison.Ordinal))
                     {
-                        matchedOperations.Add(operation);
+                        (matchedOperations ??= new List<IEdmOperation>()).Add(operation);
                     }
                 }
             }
 
-            return matchedOperations;
+            return (IEnumerable<IEdmOperation>)matchedOperations ?? Array.Empty<IEdmOperation>();
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Schema/EdmPathExpression.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmPathExpression.cs
@@ -55,7 +55,7 @@ namespace Microsoft.OData.Edm
                     throw new ArgumentException(SRResources.PathSegmentMustNotBeNull, nameof(pathSegments));
                 }
 
-                if (segment.IndexOf('/') >= 0)
+                if (segment.IndexOf('/', StringComparison.Ordinal) >= 0)
                 {
                     throw new ArgumentException(SRResources.PathSegmentMustNotContainSlash);
                 }

--- a/test/App.Debug.config
+++ b/test/App.Debug.config
@@ -5,7 +5,6 @@
       <listeners xdt:Transform="InsertIfMissing">
         <remove name="Default" xdt:Transform="InsertIfMissing" />
         <!--remove any existing default trace listeners; they cannot be configured the app.config, so they will always show the assert failure dialog-->
-        <add type="System.Diagnostics.DefaultTraceListener" xdt:Transform="RemoveAll" xdt:Locator="Match(type)" />
         <!--insert a DebugAssertTraceListener which will not display the a UI on Debug.Assert failures but instead throw an exception.-->
         <add name="Default" type="Microsoft.OData.TestCommon.DebugAssertTraceListener, Microsoft.OData.TestCommon, Version=1.0.0.0, Culture=neutral, PublicKeyToken=69c3241e6f0468ca" xdt:Transform="InsertIfMissing" xdt:Locator="Match(name)" />
       </listeners>


### PR DESCRIPTION
- Add FullNameEquals extension methods on IEdmSchemaElement/IEdmType.
- Update call sites in Core (EdmLibraryExtensions, ODataWriterCore, ODataUriResolver, DeprecationRules) and Edm (EdmModel, EdmModelBase, EdmPathExpression) to use the new extension.
- Update PublicAPI.Unshipped.txt for the new APIs.
- Remove redundant DefaultTraceListener RemoveAll transform from test/App.Debug.config to fix XDT 'no matching element' warning.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
