### PR TITLE
Add Base64Url decoding support for binary values

### DIFF
--- a/src/Microsoft.OData.Client/Serialization/PrimitiveXmlConverter.cs
+++ b/src/Microsoft.OData.Client/Serialization/PrimitiveXmlConverter.cs
@@ -28,6 +28,7 @@ namespace Microsoft.OData.Client
     using System.Reflection;
     using System.Xml;
     using Microsoft.OData.Edm;
+    using Microsoft.OData.Json;
     using Microsoft.Spatial;
 
     /// <summary>
@@ -156,7 +157,7 @@ namespace Microsoft.OData.Client
         /// <returns>An instance of primitive type</returns>
         internal override object Parse(String text)
         {
-            return Convert.FromBase64String(text);
+            return JsonSharedUtils.ConvertFromBase64String(text);
         }
 
         /// <summary>
@@ -194,7 +195,7 @@ namespace Microsoft.OData.Client
         /// <returns>An instance of primitive type</returns>
         internal override object Parse(String text)
         {
-            return Activator.CreateInstance(BinaryType, Convert.FromBase64String(text));
+            return Activator.CreateInstance(BinaryType, JsonSharedUtils.ConvertFromBase64String(text));
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
@@ -197,7 +197,7 @@ namespace Microsoft.OData.Json
 
             object value = this.GetValue();
             Stream result = value == null ? Stream.Null :
-                new MemoryStream(Convert.FromBase64String((string)value));
+                new MemoryStream(JsonSharedUtils.ConvertFromBase64String((string)value));
             this.innerReader.Read();
             return result;
         }
@@ -352,7 +352,7 @@ namespace Microsoft.OData.Json
             }
             else
             {
-                result = new MemoryStream(Convert.FromBase64String((string)value));
+                result = new MemoryStream(JsonSharedUtils.ConvertFromBase64String((string)value));
             }
 
             await this.innerReader.ReadAsync()

--- a/src/Microsoft.OData.Core/Json/JsonSharedUtils.cs
+++ b/src/Microsoft.OData.Core/Json/JsonSharedUtils.cs
@@ -70,5 +70,40 @@ namespace Microsoft.OData.Json
                     return false;
             }
         }
+
+        /// <summary>
+        /// Converts a Base64/Base64Url string to bytes.
+        /// </summary>
+        /// <param name="value">The Base64/Base64Url string value.</param>
+        /// <returns>The decoded byte array.</returns>
+        /// <exception cref="FormatException">Thrown if the value is not valid Base64 or Base64Url.</exception>
+        internal static byte[] ConvertFromBase64String(string value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (value.AsSpan().IndexOfAny('-', '_') >= 0)
+            {
+                char[] chars = value.ToCharArray();
+
+                for (int i = 0; i < chars.Length; i++)
+                {
+                    if (chars[i] == '-')
+                    {
+                        chars[i] = '+';
+                    }
+                    else if (chars[i] == '_')
+                    {
+                        chars[i] = '/';
+                    }
+                }
+
+                return Convert.FromBase64CharArray(chars, 0, chars.Length);
+            }
+
+            return Convert.FromBase64String(value);
+        }
     }
 }

--- a/src/Microsoft.OData.Core/Json/ODataJsonBatchBodyContentReaderStream.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonBatchBodyContentReaderStream.cs
@@ -353,7 +353,7 @@ namespace Microsoft.OData.Json
         /// <param name="encodedContent">The base64url-encoded content.</param>
         private void WriteBinaryContent(string encodedContent)
         {
-            byte[] bytes = Convert.FromBase64String(encodedContent.Replace('-', '+').Replace('_', '/'));
+            byte[] bytes = JsonSharedUtils.ConvertFromBase64String(encodedContent);
             WriteBytes(bytes);
         }
 
@@ -479,7 +479,7 @@ namespace Microsoft.OData.Json
         /// <returns>A task that represents the asynchronous write operation.</returns>
         private Task WriteBinaryContentAsync(string encodedContent)
         {
-            byte[] bytes = Convert.FromBase64String(encodedContent.Replace('-', '+').Replace('_', '/'));
+            byte[] bytes = JsonSharedUtils.ConvertFromBase64String(encodedContent);
             
             return WriteBytesAsync(bytes);
         }

--- a/src/Microsoft.OData.Core/Json/ReorderingJsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/ReorderingJsonReader.cs
@@ -47,7 +47,7 @@ namespace Microsoft.OData.Json
             try
             {
                 result = this.GetValue() == null ? Stream.Null :
-                    new MemoryStream(Convert.FromBase64String((string)this.GetValue()));
+                    new MemoryStream(JsonSharedUtils.ConvertFromBase64String((string)this.GetValue()));
             }
             catch (FormatException)
             {
@@ -113,7 +113,7 @@ namespace Microsoft.OData.Json
                 }
                 else
                 {
-                    result = new MemoryStream(Convert.FromBase64String((string)value));
+                    result = new MemoryStream(JsonSharedUtils.ConvertFromBase64String((string)value));
                 }
             }
             catch (FormatException)

--- a/src/Microsoft.OData.Core/ODataPayloadValueConverter.cs
+++ b/src/Microsoft.OData.Core/ODataPayloadValueConverter.cs
@@ -146,7 +146,7 @@ namespace Microsoft.OData
             // COMPAT 53: Support for System.Data.Linq.Binary and System.Xml.Linq.XElement
             if (targetType == typeof(byte[]))
             {
-                return Convert.FromBase64String(stringValue);
+                return JsonSharedUtils.ConvertFromBase64String(stringValue);
             }
 
             if (targetType == typeof(Guid))

--- a/src/Microsoft.OData.Core/ODataRawValueUtils.cs
+++ b/src/Microsoft.OData.Core/ODataRawValueUtils.cs
@@ -12,6 +12,7 @@ namespace Microsoft.OData
     using System.Xml;
     using Microsoft.OData.Edm;
     using Microsoft.OData.Core;
+    using Microsoft.OData.Json;
     #endregion Namespaces
 
     /// <summary>
@@ -152,7 +153,7 @@ namespace Microsoft.OData
                 switch (primitiveKind)
                 {
                     case EdmPrimitiveTypeKind.Binary:
-                        return Convert.FromBase64String(text);
+                        return JsonSharedUtils.ConvertFromBase64String(text);
                     case EdmPrimitiveTypeKind.Boolean:
                         return ConvertXmlBooleanValue(text);
                     case EdmPrimitiveTypeKind.Byte:

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ClientPrimitiveTypeTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ClientPrimitiveTypeTests.cs
@@ -91,6 +91,20 @@ namespace AstoriaUnitTests.Tests
             Assert.Equal("AAECAw==", converter.ToString(new byte[] { 0, 1, 2, 3 }));
         }
 
+        [Fact]
+        public void ByteArrayTypeConverterTests_Base64Url()
+        {
+            PrimitiveTypeConverter converter = new ByteArrayTypeConverter();
+
+            // "AAEA_w==" is the Base64Url form of standard Base64 "AAEA/w==" ({ 0x00, 0x01, 0x00, 0xFF })
+            Byte[] array = (Byte[])converter.Parse("AAEA_w==");
+            Assert.Equal(new byte[] { 0x00, 0x01, 0x00, 0xFF }, array);
+
+            // "AAEC-w==" is the Base64Url form of standard Base64 "AAEC+w==" ({ 0x00, 0x01, 0x02, 0xFB })
+            array = (Byte[])converter.Parse("AAEC-w==");
+            Assert.Equal(new byte[] { 0x00, 0x01, 0x02, 0xFB }, array);
+        }
+
 #if !(NETCOREAPP1_0 || NETCOREAPP2_0)
         [Fact]
         public void BinaryTypeConverterTests()
@@ -102,6 +116,23 @@ namespace AstoriaUnitTests.Tests
             {
                 Assert.Equal(new System.Data.Linq.Binary(new byte[] { 0, 1, 2, 3 }), (System.Data.Linq.Binary)converter.Parse("AAECAw=="));
                 Assert.Equal("\"AAECAw==\"", converter.ToString(new System.Data.Linq.Binary(new byte[] { 0, 1, 2, 3 })));
+            }
+            finally
+            {
+                BinaryTypeConverter.BinaryType = temp;
+            }
+        }
+
+        [Fact]
+        public void BinaryTypeConverterTests_Base64Url()
+        {
+            PrimitiveTypeConverter converter = new BinaryTypeConverter();
+            Type temp = BinaryTypeConverter.BinaryType;
+            BinaryTypeConverter.BinaryType = typeof(System.Data.Linq.Binary);
+            try
+            {
+                // "AAEA_w==" is Base64Url for { 0x00, 0x01, 0x00, 0xFF }
+                Assert.Equal(new System.Data.Linq.Binary(new byte[] { 0x00, 0x01, 0x00, 0xFF }), (System.Data.Linq.Binary)converter.Parse("AAEA_w=="));
             }
             finally
             {

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/ByteArrayTypeConverterBase64UrlTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/ByteArrayTypeConverterBase64UrlTests.cs
@@ -1,0 +1,43 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ByteArrayTypeConverterBase64UrlTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Microsoft.OData.Client;
+using Xunit;
+
+namespace Microsoft.OData.Client.Tests.Serialization
+{
+    /// <summary>
+    /// Tests that ByteArrayTypeConverter accepts Base64Url-encoded input.
+    /// </summary>
+    public class ByteArrayTypeConverterBase64UrlTests
+    {
+        [Fact]
+        public void ByteArrayTypeConverter_Parse_Base64Url_WithUnderscore()
+        {
+            // "AAEA_w==" is the Base64Url form of "AAEA/w==" which decodes to { 0x00, 0x01, 0x00, 0xFF }
+            var converter = new ByteArrayTypeConverter();
+            byte[] result = (byte[])converter.Parse("AAEA_w==");
+            Assert.Equal(new byte[] { 0x00, 0x01, 0x00, 0xFF }, result);
+        }
+
+        [Fact]
+        public void ByteArrayTypeConverter_Parse_Base64Url_WithHyphen()
+        {
+            // "AAEC-w==" is the Base64Url form of "AAEC+w==" which decodes to { 0x00, 0x01, 0x02, 0xFB }
+            var converter = new ByteArrayTypeConverter();
+            byte[] result = (byte[])converter.Parse("AAEC-w==");
+            Assert.Equal(new byte[] { 0x00, 0x01, 0x02, 0xFB }, result);
+        }
+
+        [Fact]
+        public void ByteArrayTypeConverter_Parse_StandardBase64_StillWorks()
+        {
+            var converter = new ByteArrayTypeConverter();
+            byte[] result = (byte[])converter.Parse("AAECAw==");
+            Assert.Equal(new byte[] { 0x00, 0x01, 0x02, 0x03 }, result);
+        }
+    }
+}

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonSharedUtilsConvertFromBase64StringTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonSharedUtilsConvertFromBase64StringTests.cs
@@ -1,0 +1,77 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="JsonSharedUtilsConvertFromBase64StringTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using Microsoft.OData.Json;
+using Xunit;
+
+namespace Microsoft.OData.Tests.Json
+{
+    public class JsonSharedUtilsConvertFromBase64StringTests
+    {
+        [Fact]
+        public void ConvertFromBase64String_StandardBase64_ReturnsExpectedBytes()
+        {
+            // "AAEC" is Base64 for { 0x00, 0x01, 0x02 }
+            byte[] result = JsonSharedUtils.ConvertFromBase64String("AAEC");
+            Assert.Equal(new byte[] { 0x00, 0x01, 0x02 }, result);
+        }
+
+        [Fact]
+        public void ConvertFromBase64String_StandardBase64WithPadding_ReturnsExpectedBytes()
+        {
+            // "AAEA/w==" is Base64 for { 0x00, 0x01, 0x00, 0xFF }
+            byte[] result = JsonSharedUtils.ConvertFromBase64String("AAEA/w==");
+            Assert.Equal(new byte[] { 0x00, 0x01, 0x00, 0xFF }, result);
+        }
+
+        [Fact]
+        public void ConvertFromBase64String_Base64UrlWithUnderscore_ReturnsExpectedBytes()
+        {
+            // "AAEA_w==" is Base64Url for { 0x00, 0x01, 0x00, 0xFF }
+            byte[] result = JsonSharedUtils.ConvertFromBase64String("AAEA_w==");
+            Assert.Equal(new byte[] { 0x00, 0x01, 0x00, 0xFF }, result);
+        }
+
+        [Fact]
+        public void ConvertFromBase64String_Base64UrlWithHyphen_ReturnsExpectedBytes()
+        {
+            // '+' in standard Base64 becomes '-' in Base64Url
+            // "AAEC+w==" is standard, "AAEC-w==" is Base64Url for { 0x00, 0x01, 0x02, 0xFB }
+            byte[] result = JsonSharedUtils.ConvertFromBase64String("AAEC-w==");
+            Assert.Equal(new byte[] { 0x00, 0x01, 0x02, 0xFB }, result);
+        }
+
+        [Fact]
+        public void ConvertFromBase64String_Base64UrlWithBothSpecialChars_ReturnsExpectedBytes()
+        {
+            // Contains both '-' and '_' (Base64Url equivalents of '+' and '/')
+            // Standard: "+/8=" -> Base64Url: "-_8="
+            byte[] result = JsonSharedUtils.ConvertFromBase64String("-_8=");
+            byte[] expected = Convert.FromBase64String("+/8=");
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void ConvertFromBase64String_EmptyString_ReturnsEmptyArray()
+        {
+            byte[] result = JsonSharedUtils.ConvertFromBase64String("");
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void ConvertFromBase64String_InvalidString_ThrowsFormatException()
+        {
+            Assert.Throws<FormatException>(() => JsonSharedUtils.ConvertFromBase64String("!!!invalid!!!"));
+        }
+
+        [Fact]
+        public void ConvertFromBase64String_NullValue_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => JsonSharedUtils.ConvertFromBase64String(null));
+        }
+    }
+}

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Query/ODataUriUtilsTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Query/ODataUriUtilsTests.cs
@@ -163,6 +163,9 @@ namespace Microsoft.OData.Tests.Query
             result = ODataUriUtils.ConvertFromUriLiteral("binary''", ODataVersion.V4) as byte[];
             Assert.Empty(result);
 
+            result = ODataUriUtils.ConvertFromUriLiteral("binary'AAEA_w=='", ODataVersion.V4) as byte[];
+            Assert.Equal(new byte[] { 0x00, 0x01, 0x00, 0xff }, result);
+
             // Invalid base64 value.
             Action action = () => { ODataUriUtils.ConvertFromUriLiteral("binary'AwEEAQUJAgYFAwUJ='", ODataVersion.V4); };
             action.Throws<ODataException>(Error.Format(SRResources.UriQueryExpressionParser_UnrecognizedLiteral, "Edm.Binary", "binary'AwEEAQUJAgYFAwUJ='", "0", "binary'AwEEAQUJAgYFAwUJ='"));

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriPrimitiveTypeParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriPrimitiveTypeParserTests.cs
@@ -395,6 +395,14 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             Assert.False(this.TryParseUriStringToPrimitiveType("null", EdmCoreModel.Instance.GetInt32(false), out output));
         }
 
+        [Fact]
+        public void TryUriStringToPrimitiveWithUrlSafeBinaryLiteralShouldReturnByteArray()
+        {
+            object output;
+            Assert.True(this.TryParseUriStringToPrimitiveType("binary'AAEA_w=='", EdmCoreModel.Instance.GetBinary(false), out output));
+            Assert.Equal(new byte[] { 0x00, 0x01, 0x00, 0xff }, (byte[])output);
+        }
+
         #region Private Methods
 
         private bool TryParseUriStringToPrimitiveType(string text, IEdmTypeReference targetType, out object targetValue)


### PR DESCRIPTION
Centralize Base64/Base64Url decoding in JsonSharedUtils.ConvertFromBase64String, which falls back to Base64Url decoding (replacing '-' with '+' and '_' with '/') when standard Base64 parsing fails. Replace all direct Convert.FromBase64String calls with this new helper across:

- PrimitiveXmlConverter (Client)
- ODataPayloadValueConverter
- ODataRawValueUtils
- LiteralParser
- UriPrimitiveTypeParser

Add unit tests verifying Base64Url binary literals are parsed correctly.

Fixes #3387

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
