### PR TITLE
Port async-native WASM compatibility to dev-9.x

### DIFF
--- a/src/Microsoft.OData.Client/BatchSaveResult.cs
+++ b/src/Microsoft.OData.Client/BatchSaveResult.cs
@@ -17,6 +17,8 @@ namespace Microsoft.OData.Client
     using System.Linq;
     using System.Net;
     using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.OData;
     using Microsoft.OData.Client.Metadata;
 
@@ -179,6 +181,41 @@ namespace Microsoft.OData.Client
                         // For non-async batch requests we call the test hook to get the response stream but we cannot consume it
                         // because we rethrow what we caught and the customer need to be able to read the response stream from the WebException.
                         // Note that on the async batch code path we do consume the response stream and throw a DataServiceRequestException.
+                        this.responseStream = this.batchResponseMessage.GetStream();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously sends the batch request without blocking waits.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous batch request operation.</returns>
+        internal async Task BatchRequestAsync(CancellationToken cancellationToken = default)
+        {
+            ODataRequestMessageWrapper batchRequestMessage = this.GenerateBatchRequest();
+
+            if (batchRequestMessage != null)
+            {
+                batchRequestMessage.SetRequestStream(batchRequestMessage.CachedRequestStream);
+
+                try
+                {
+                    this.batchResponseMessage = await this.RequestInfo.GetResponseAsync(batchRequestMessage, false, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (DataServiceTransportException ex)
+                {
+                    InvalidOperationException exception = WebUtil.GetHttpWebResponse(ex, ref this.batchResponseMessage);
+
+                    // Rethrow to preserve existing error-handling behavior for callers.
+                    throw exception;
+                }
+                finally
+                {
+                    if (this.batchResponseMessage != null)
+                    {
                         this.responseStream = this.batchResponseMessage.GetStream();
                     }
                 }

--- a/src/Microsoft.OData.Client/BatchSaveResult.cs
+++ b/src/Microsoft.OData.Client/BatchSaveResult.cs
@@ -906,7 +906,7 @@ namespace Microsoft.OData.Client
             try
             {
                 operationResponseContentStream = new MemoryStream();
-                WebUtil.CopyStream(originalOperationResponseContentStream, operationResponseContentStream, ref this.streamCopyBuffer);
+                WebUtil.CopyStream(originalOperationResponseContentStream, operationResponseContentStream, this.streamCopyBuffer);
                 operationResponseContentStream.Position = 0;
             }
             finally

--- a/src/Microsoft.OData.Client/BulkUpdateSaveResult.cs
+++ b/src/Microsoft.OData.Client/BulkUpdateSaveResult.cs
@@ -226,7 +226,7 @@ namespace Microsoft.OData.Client
 
             try
             {
-                this.batchResponseMessage = await this.RequestInfo.GetResponseAsync(bulkUpdateRequestMessage, false, cancellationToken);
+                this.batchResponseMessage = await this.RequestInfo.GetResponseAsync(bulkUpdateRequestMessage, false, cancellationToken).ConfigureAwait(false);
                 this.responseStream = this.batchResponseMessage.GetStream();
                 this.HandleBulkUpdateResponse(this.batchResponseMessage, responseStream);
             }

--- a/src/Microsoft.OData.Client/BulkUpdateSaveResult.cs
+++ b/src/Microsoft.OData.Client/BulkUpdateSaveResult.cs
@@ -12,6 +12,8 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.OData.Client.Materialization;
 
 namespace Microsoft.OData.Client
@@ -186,6 +188,45 @@ namespace Microsoft.OData.Client
             try
             {
                 this.batchResponseMessage = this.RequestInfo.GetSynchronousResponse(bulkUpdateRequestMessage, false);
+                this.responseStream = this.batchResponseMessage.GetStream();
+                this.HandleBulkUpdateResponse(this.batchResponseMessage, responseStream);
+            }
+            catch (DataServiceTransportException ex)
+            {
+                InvalidOperationException exception = WebUtil.GetHttpWebResponse(ex, ref this.batchResponseMessage);
+
+                throw exception;
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously sends a bulk update request without blocking waits.
+        /// </summary>
+        /// <typeparam name="T">The type of objects to be bulk updated.</typeparam>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="objects">The objects to be bulk updated.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        internal async Task BulkUpdateRequestAsync<T>(CancellationToken cancellationToken, params T[] objects)
+        {
+            if (objects == null || objects.Length == 0)
+            {
+                throw Error.Argument(SRResources.Util_EmptyArray, nameof(objects));
+            }
+
+            BuildDescriptorGraph(this.ChangedEntries, true, objects);
+
+            ODataRequestMessageWrapper bulkUpdateRequestMessage = this.GenerateBulkUpdateRequest();
+
+            if (bulkUpdateRequestMessage == null)
+            {
+                return;
+            }
+
+            bulkUpdateRequestMessage.SetRequestStream(bulkUpdateRequestMessage.CachedRequestStream);
+
+            try
+            {
+                this.batchResponseMessage = await this.RequestInfo.GetResponseAsync(bulkUpdateRequestMessage, false, cancellationToken);
                 this.responseStream = this.batchResponseMessage.GetStream();
                 this.HandleBulkUpdateResponse(this.batchResponseMessage, responseStream);
             }

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -1774,9 +1774,10 @@ namespace Microsoft.OData.Client
         /// <param name="requestUri">The URI to which the query request will be sent. The URI may be any valid data service URI; it can contain $ query parameters.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <typeparam name="TElement">The type returned by the query.</typeparam>
-        public virtual Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, CancellationToken cancellationToken)
+        public virtual async Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, CancellationToken cancellationToken)
         {
-            return this.FromAsync(this.BeginExecute<TElement>, this.EndExecute<TElement>, requestUri, cancellationToken);
+            return await this.ExecuteAsyncInternal<TElement>(requestUri, XmlConstants.HttpMethodGet, null, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously sends a request to the data service to execute a specific URI.</summary>
@@ -1811,9 +1812,16 @@ namespace Microsoft.OData.Client
         /// <param name="httpMethod">The HTTP data transfer method used by the client.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="operationParameters">The operation parameters used.</param>
-        public virtual Task<OperationResponse> ExecuteAsync(Uri requestUri, string httpMethod, CancellationToken cancellationToken, params OperationParameter[] operationParameters)
+        public async virtual Task<OperationResponse> ExecuteAsync(Uri requestUri, string httpMethod, CancellationToken cancellationToken, params OperationParameter[] operationParameters)
         {
-            return this.FromAsync((callback, state) => this.BeginExecute(requestUri, callback, state, httpMethod, operationParameters), this.EndExecute, cancellationToken);
+            QueryOperationResponse<object> result = await ExecuteAsyncInternal<object>(requestUri, httpMethod, false, cancellationToken, operationParameters)
+                .ConfigureAwait(false);
+            if (result.Any())
+            {
+                throw new DataServiceClientException(SRResources.Context_ExecuteExpectedVoidResponse);
+            }
+
+            return result;
         }
 
         /// <summary>Asynchronously sends a request to the data service to execute a specific URI.</summary>
@@ -1851,9 +1859,10 @@ namespace Microsoft.OData.Client
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="operationParameters">The operation parameters used.</param>
         /// <typeparam name="TElement">The type returned by the query.</typeparam>
-        public virtual Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, string httpMethod, bool singleResult, CancellationToken cancellationToken, params OperationParameter[] operationParameters)
+        public virtual async Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, string httpMethod, bool singleResult, CancellationToken cancellationToken, params OperationParameter[] operationParameters)
         {
-            return this.FromAsync((callback, state) => this.BeginExecute<TElement>(requestUri, callback, state, httpMethod, singleResult, operationParameters), this.EndExecute<TElement>, cancellationToken);
+            return await ExecuteAsyncInternal<TElement>(requestUri, httpMethod, singleResult, cancellationToken, operationParameters)
+                .ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously sends a request to the data service to execute a specific URI.</summary>
@@ -1889,9 +1898,10 @@ namespace Microsoft.OData.Client
         /// <param name="operationParameters">The operation parameters used.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <typeparam name="TElement">The type returned by the query.</typeparam>
-        public virtual Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, string httpMethod, CancellationToken cancellationToken, params OperationParameter[] operationParameters)
+        public virtual async Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, string httpMethod, CancellationToken cancellationToken, params OperationParameter[] operationParameters)
         {
-            return this.FromAsync((callback, state) => this.BeginExecute<TElement>(requestUri, callback, state, httpMethod, operationParameters), this.EndExecute<TElement>, cancellationToken);
+            return await this.ExecuteAsyncInternal<TElement>(requestUri, httpMethod, null, cancellationToken, operationParameters)
+                .ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously sends a request to the data service to retrieve the next page of data in a paged query result.</summary>
@@ -1923,9 +1933,15 @@ namespace Microsoft.OData.Client
         /// <param name="continuation">A <see cref="Microsoft.OData.Client.DataServiceQueryContinuation{T}" /> object that represents the next page of data to return from the data service.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <typeparam name="TElement">The type returned by the query.</typeparam>
-        public virtual Task<IEnumerable<TElement>> ExecuteAsync<TElement>(DataServiceQueryContinuation<TElement> continuation, CancellationToken cancellationToken)
+        public virtual async Task<IEnumerable<TElement>> ExecuteAsync<TElement>(DataServiceQueryContinuation<TElement> continuation, CancellationToken cancellationToken)
         {
-            return this.FromAsync(this.BeginExecute, this.EndExecute<TElement>, continuation, cancellationToken);
+            Util.CheckArgumentNull(continuation, "continuation");
+
+            QueryComponents qc = continuation.CreateQueryComponents();
+            Uri requestUri = qc.Uri;
+            DataServiceRequest request = new DataServiceRequest<TElement>(requestUri, qc, continuation.Plan);
+
+            return await request.ExecuteAsync<TElement>(this, qc, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Called to complete the <see cref="Microsoft.OData.Client.DataServiceContext.BeginExecute{TElement}(System.Uri,System.AsyncCallback,System.Object)" />.</summary>
@@ -3220,6 +3236,76 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary>
+        /// Asynchronously executes a request against the data service using the specified parameters.
+        /// </summary>
+        /// <typeparam name="TElement">The type of elements in the result.</typeparam>
+        /// <param name="requestUri">The request URI.</param>
+        /// <param name="httpMethod">The HTTP method to use.</param>
+        /// <param name="singleResult">Whether a single result is expected.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="operationParameters">The operation parameters associated with the request.</param>
+        /// <returns>A task representing the query operation response.</returns>
+        internal Task<QueryOperationResponse<TElement>> ExecuteAsyncInternal<TElement>(
+            Uri requestUri,
+            string httpMethod,
+            bool? singleResult,
+            CancellationToken cancellationToken,
+            params OperationParameter[] operationParameters)
+        {
+            List<UriOperationParameter> uriOperationParameters = null;
+            List<BodyOperationParameter> bodyOperationParameters = null;
+            try
+            {
+                this.ValidateExecuteParameters<TElement>(
+                    ref requestUri,
+                    httpMethod,
+                    ref singleResult,
+                    out bodyOperationParameters,
+                    out uriOperationParameters,
+                    operationParameters);
+            }
+            catch (Exception ex) when (CommonUtil.IsCatchableExceptionType(ex))
+            {
+                return Task.FromException<QueryOperationResponse<TElement>>(ex);
+            }
+
+            QueryComponents queryComponents = new QueryComponents(
+                requestUri,
+                Util.ODataVersionEmpty,
+                lastSegmentType: typeof(TElement),
+                projection: null,
+                normalizerRewrites: null,
+                httpMethod,
+                singleResult,
+                bodyOperationParameters,
+                uriOperationParameters);
+
+            requestUri = queryComponents.Uri;
+            DataServiceRequest request = new DataServiceRequest<TElement>(requestUri, queryComponents, null);
+
+            return request.ExecuteAsync<TElement>(this, queryComponents, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously executes a query continuation to retrieve the next page of results.
+        /// </summary>
+        /// <typeparam name="TElement">The type of elements in the query result.</typeparam>
+        /// <param name="continuation">The continuation token representing the next page of results.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result contains a query operation response with the next page of results.</returns>
+        internal Task<QueryOperationResponse<TElement>> ExecuteAsyncInternal<TElement>(
+            DataServiceQueryContinuation<TElement> continuation,
+            CancellationToken cancellationToken)
+        {
+            QueryComponents queryComponents = continuation.CreateQueryComponents();
+            Uri requestUri = queryComponents.Uri;
+            DataServiceRequest request = new DataServiceRequest<TElement>(requestUri, queryComponents, continuation.Plan);
+
+            return request.ExecuteAsync<TElement>(this, queryComponents, cancellationToken);
+        }
+
+        /// <summary>
         /// Track a binding.
         /// </summary>
         /// <param name="source">Source resource.</param>
@@ -3344,6 +3430,29 @@ namespace Microsoft.OData.Client
         {
             Debug.Assert(asyncResult != null, "Expected a non-null asyncResult for all scenarios calling EndGetResponse");
             return this.GetResponseHelper(request, asyncResult, true);
+        }
+
+        /// <summary>
+        /// Asynchronously gets the response for the request.
+        /// </summary>
+        /// <param name="request">The OData request message wrapper to get the response from.</param>
+        /// <param name="handleWebException">If true, suppresses <see cref="WebException"/> if the response is available;
+        /// otherwise, always rethrows <see cref="WebException"/>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result contains the OData response message.</returns>
+        /// <exception cref="DataServiceTransportException">
+        /// Thrown when a transport-level error occurs and <paramref name="handleWebException"/> is false or the response is null.
+        /// </exception>
+        /// <remarks>
+        /// This method fires the <see cref="ReceivingResponse"/> event after receiving the response.
+        /// </remarks>
+        internal Task<IODataResponseMessage> GetResponseAsync(
+            ODataRequestMessageWrapper request,
+            bool handleWebException,
+            CancellationToken cancellationToken = default)
+        {
+            return this.GetResponseHelperAsync(request, handleWebException, cancellationToken);
         }
 
         #endregion
@@ -4102,6 +4211,48 @@ namespace Microsoft.OData.Client
 
                 this.FireReceivingResponseEvent(new ReceivingResponseEventArgs(response, request.Descriptor));
 
+                if (!handleWebException || response == null)
+                {
+                    throw;
+                }
+            }
+
+            return response;
+        }
+
+        /// <summary>
+        /// Asynchronously gets the response, fires the ReceivingResponse event, and handles transport exceptions.
+        /// </summary>
+        /// <param name="request">The OData request message wrapper to get the response from.</param>
+        /// <param name="handleWebException">If true, suppresses <see cref="WebException"/> if the response is available;
+        /// otherwise, always rethrows <see cref="WebException"/>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result contains the OData response message.</returns>
+        /// <exception cref="DataServiceTransportException">
+        /// Thrown when a transport-level error occurs and <paramref name="handleWebException"/> is false or the response is null.
+        /// </exception>
+        /// <remarks>
+        /// This method fires the <see cref="ReceivingResponse"/> event after receiving the response.
+        /// </remarks>
+        internal async Task<IODataResponseMessage> GetResponseHelperAsync(
+            ODataRequestMessageWrapper request,
+            bool handleWebException,
+            CancellationToken cancellationToken)
+        {
+            Debug.Assert(request != null, "Expected a non-null request for all scenarios calling GetAsynchronousResponse");
+            IODataResponseMessage response = null;
+
+            try
+            {
+                response = await request.GetResponseAsync(cancellationToken).ConfigureAwait(false);
+
+                this.FireReceivingResponseEvent(new ReceivingResponseEventArgs(response, request.Descriptor));
+            }
+            catch (DataServiceTransportException e)
+            {
+                response = e.Response;
+                this.FireReceivingResponseEvent(new ReceivingResponseEventArgs(response, request.Descriptor));
                 if (!handleWebException || response == null)
                 {
                     throw;

--- a/src/Microsoft.OData.Client/DataServiceQuery.cs
+++ b/src/Microsoft.OData.Client/DataServiceQuery.cs
@@ -10,6 +10,7 @@ namespace Microsoft.OData.Client
     using System.Collections;
     using System.Linq;
     using System.Linq.Expressions;
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>non-generic placeholder for generic implementation</summary>
@@ -66,7 +67,7 @@ namespace Microsoft.OData.Client
         /// <returns>A task represents An <see cref="System.Collections.Generic.IEnumerable{T}" /> that contains the results of the query operation.</returns>
         public virtual Task<IEnumerable> ExecuteAsync()
         {
-            return Task<IEnumerable>.Factory.FromAsync(this.BeginExecute, this.EndExecute, null);
+            return this.ExecuteAsyncInternal(CancellationToken.None);
         }
 
         /// <summary>Called to complete the asynchronous operation of executing a data service query.</summary>
@@ -83,6 +84,16 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <returns>An IEnumerable that contains the response from the Internet resource.</returns>
         internal abstract IEnumerable ExecuteInternal();
+
+        /// <summary>
+        /// Asynchronously returns an <see cref="IEnumerable"/> from an internet resource.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation.
+        /// The result contains the response from the internet resource.
+        /// </returns>
+        internal abstract Task<IEnumerable> ExecuteAsyncInternal(CancellationToken cancellationToken);
 
         /// <summary>
         /// Begins an asynchronous request to an Internet resource.

--- a/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
@@ -287,7 +287,7 @@ namespace Microsoft.OData.Client
         /// Pages are fetched on-demand as you iterate through the results.
         /// </summary>
         /// <remarks>
-        /// Use this method for large result sets or when you want to process the results incrementaly.
+        /// Use this method for large result sets or when you want to process the results incrementally.
         /// Network requests for additional pages are made as you iterate through the results.
         /// For small result sets where you need all results upfront, consider using <see cref="GetAllPagesAsync(CancellationToken)" /> instead.
         /// </remarks>

--- a/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
@@ -287,7 +287,7 @@ namespace Microsoft.OData.Client
         /// Pages are fetched on-demand as you iterate through the results.
         /// </summary>
         /// <remarks>
-        /// Use this method for large result sets or when you want to process the results incrementally.
+        /// Use this method for large result sets or when you want to process the results incrementally.
         /// Network requests for additional pages are made as you iterate through the results.
         /// For small result sets where you need all results upfront, consider using <see cref="GetAllPagesAsync(CancellationToken)" /> instead.
         /// </remarks>

--- a/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
@@ -13,6 +13,7 @@ namespace Microsoft.OData.Client
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
+    using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -227,7 +228,12 @@ namespace Microsoft.OData.Client
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public virtual Task<IEnumerable<TElement>> ExecuteAsync(CancellationToken cancellationToken)
         {
-            return this.Context.FromAsync(this.BeginExecute, this.EndExecute, cancellationToken);
+            if (this.IsFunction)
+            {
+                return this.Context.ExecuteAsync<TElement>(this.RequestUri, XmlConstants.HttpMethodGet, false, cancellationToken);
+            }
+
+            return this.ExecuteAsyncImpl(cancellationToken);
         }
 
         /// <summary>Ends an asynchronous query request to a data service.</summary>
@@ -255,18 +261,41 @@ namespace Microsoft.OData.Client
             return GetAllPagesAsync(CancellationToken.None);
         }
 
-
         /// <summary>
-        /// Asynchronously sends a request to get all items by auto iterating all pages
+        /// Asynchronously retrieves all pages of results and returns them as a materialized collection.
+        /// All pages are fetched before this method returns.
         /// </summary>
+        /// <remarks>
+        /// Use this method when you need all results upfront. For large result sets, or when you need to process
+        /// results incrementally, consider using <see cref="EnumerateAllPagesAsync(CancellationToken)" /> instead.
+        /// </remarks>
         /// <returns>A task that represents an <see cref="System.Collections.Generic.IEnumerable{T}" /> that contains the results of the query operation.</returns>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2008:Do not create tasks without passing a TaskScheduler", Justification = "<Pending>")]
-        public virtual Task<IEnumerable<TElement>> GetAllPagesAsync(CancellationToken cancellationToken)
+        public virtual async Task<IEnumerable<TElement>> GetAllPagesAsync(CancellationToken cancellationToken)
         {
-            var currentTask = this.Context.FromAsync(this.BeginExecute, this.EndExecute, cancellationToken);
-            var nextTask = currentTask.ContinueWith(t => this.ContinuePage(t.Result, cancellationToken), cancellationToken);
-            return nextTask;
+            List<TElement> elements = new List<TElement>();
+            await foreach (TElement element in this.GetAllPagesAsyncInternal(cancellationToken).ConfigureAwait(false))
+            {
+                elements.Add(element);
+            }
+
+            return elements;
+        }
+
+        /// <summary>
+        /// Asynchronously enumerates all pages of results with lazy evaluation.
+        /// Pages are fetched on-demand as you iterate through the results.
+        /// </summary>
+        /// <remarks>
+        /// Use this method for large result sets or when you want to process the results incrementaly.
+        /// Network requests for additional pages are made as you iterate through the results.
+        /// For small result sets where you need all results upfront, consider using <see cref="GetAllPagesAsync(CancellationToken)" /> instead.
+        /// </remarks>
+        /// <returns>An <see cref="IAsyncEnumerable{T}" /> that contains the results of the query operation.</returns>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        public virtual IAsyncEnumerable<TElement> EnumerateAllPagesAsync(CancellationToken cancellationToken = default)
+        {
+            return this.GetAllPagesAsyncInternal(cancellationToken);
         }
 
         /// <summary>Executes the query and returns the results as a collection that implements IEnumerable.</summary>
@@ -436,6 +465,50 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary>
+        /// Asynchronously executes the query and returns the results.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result contains the query results.</returns>
+        internal override async Task<IEnumerable> ExecuteAsyncInternal(CancellationToken cancellationToken)
+        {
+            return await this.ExecuteAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves all pages of results by iterating through continuation tokens.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>An async enumerable that yields elements from all pages of results.</returns>
+        internal async IAsyncEnumerable<TElement> GetAllPagesAsyncInternal([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            // Get first page
+            QueryOperationResponse<TElement> response = await this.ExecuteAsync<TElement>(
+                this.Context,
+                this.Translate(),
+                cancellationToken).ConfigureAwait(false);
+
+            do
+            {
+                foreach (TElement element in response)
+                {
+                    yield return element;
+                }
+
+                DataServiceQueryContinuation<TElement> continuation = response.GetContinuation();
+                if (continuation == null)
+                {
+                    break;
+                }
+
+                response = await this.Context.ExecuteAsyncInternal<TElement>(continuation, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            while (true);
+        }
+
+        /// <summary>
         /// gets the query components for the query after translating
         /// </summary>
         /// <returns>QueryComponents for query</returns>
@@ -447,6 +520,20 @@ namespace Microsoft.OData.Client
             }
 
             return this.queryComponents;
+        }
+
+        /// <summary>
+        /// Asynchronously executes the query and returns the results.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result contains the query results.</returns>
+        private async Task<IEnumerable<TElement>> ExecuteAsyncImpl(CancellationToken cancellationToken)
+        {
+            return await this.ExecuteAsync<TElement>(
+                this.Context,
+                this.Translate(),
+                cancellationToken).ConfigureAwait(false); // Implicit cast to IEnumerable<TElement>
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/DataServiceQuerySingleOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceQuerySingleOfT.cs
@@ -7,6 +7,7 @@
 namespace Microsoft.OData.Client
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
     using System.Threading;
@@ -165,9 +166,21 @@ namespace Microsoft.OData.Client
         /// <summary>Starts an asynchronous network operation that executes the query represented by this object instance.</summary>
         /// <returns>A task that represents the result of the query operation.</returns>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        public virtual Task<TElement> GetValueAsync(CancellationToken cancellationToken)
+        public async virtual Task<TElement> GetValueAsync(CancellationToken cancellationToken)
         {
-            return this.Context.FromAsync(this.BeginGetValue, this.EndGetValue, cancellationToken);
+            IEnumerable<TElement> result;
+
+            if (this.isFunction)
+            {
+                result = await this.Context.ExecuteAsync<TElement>(this.RequestUri, XmlConstants.HttpMethodGet, true, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                result = await this.Query.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            return result.SingleOrDefault();
         }
 
         /// <summary>Ends an asynchronous query request to a data service.</summary>

--- a/src/Microsoft.OData.Client/DataServiceRequest.cs
+++ b/src/Microsoft.OData.Client/DataServiceRequest.cs
@@ -11,6 +11,8 @@ namespace Microsoft.OData.Client
     using System.Diagnostics;
     using System.Linq;
     using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.OData;
     using Microsoft.OData.Client.Materialization;
 
@@ -156,6 +158,63 @@ namespace Microsoft.OData.Client
                 DataServiceRequest<TElement> serviceRequest = new DataServiceRequest<TElement>(requestUri, queryComponents, this.Plan);
                 result = serviceRequest.CreateExecuteResult(this, context, null, null, Util.ExecuteMethodName);
                 result.ExecuteQuery();
+                return result.ProcessResult<TElement>(this.Plan);
+            }
+            catch (InvalidOperationException ex)
+            {
+                if (result != null)
+                {
+                    QueryOperationResponse operationResponse = result.GetResponse<TElement>(ObjectMaterializer.EmptyResults);
+
+                    if (operationResponse != null)
+                    {
+                        if (context.IgnoreResourceNotFoundException)
+                        {
+                            DataServiceClientException cex = ex as DataServiceClientException;
+                            if (cex != null && cex.StatusCode == (int)HttpStatusCode.NotFound)
+                            {
+                                // don't throw
+                                return (QueryOperationResponse<TElement>)operationResponse;
+                            }
+                        }
+
+                        operationResponse.Error = ex;
+                        throw new DataServiceQueryException(SRResources.DataServiceException_GeneralError, ex, operationResponse);
+                    }
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously executes the query and returns a typed <see cref="QueryOperationResponse{TElement}"/>.
+        /// </summary>
+        /// <typeparam name="TElement">The element type of the response.</typeparam>
+        /// <param name="context">The data service context.</param>
+        /// <param name="queryComponents">The query components describing the request.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// A task whose result is a <see cref="QueryOperationResponse{TElement}"/> whose enumerable results can be iterated to
+        /// materialize <typeparamref name="TElement"/> instances. The response also carries HTTP status,
+        /// headers, and the request <see cref="Uri"/> for diagnostics and paging.
+        /// </returns>
+        internal async Task<QueryOperationResponse<TElement>> ExecuteAsync<TElement>(
+            DataServiceContext context,
+            QueryComponents queryComponents,
+            CancellationToken cancellationToken)
+        {
+            Debug.Assert(context != null, "context is null");
+            Debug.Assert(queryComponents != null, "queryComponents is null");
+
+            QueryResult result = null;
+
+            try
+            {
+                Uri requestUri = queryComponents.Uri;
+                DataServiceRequest<TElement> serviceRequest = new DataServiceRequest<TElement>(requestUri, queryComponents, this.Plan);
+                result = serviceRequest.CreateExecuteResult(this, context, null, null, "ExecuteAsync");
+                await result.ExecuteQueryAsync(cancellationToken).ConfigureAwait(false);
                 return result.ProcessResult<TElement>(this.Plan);
             }
             catch (InvalidOperationException ex)

--- a/src/Microsoft.OData.Client/DeepInsertSaveResult.cs
+++ b/src/Microsoft.OData.Client/DeepInsertSaveResult.cs
@@ -13,6 +13,8 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.OData.Client.Materialization;
 using Microsoft.OData.Edm;
 
@@ -110,6 +112,44 @@ namespace Microsoft.OData.Client
             try
             {
                 this.batchResponseMessage = this.RequestInfo.GetSynchronousResponse(deepInsertRequestMessage, false);
+                this.responseStream = this.batchResponseMessage.GetStream();
+            }
+            catch (DataServiceTransportException ex)
+            {
+                InvalidOperationException exception = WebUtil.GetHttpWebResponse(ex, ref this.batchResponseMessage);
+
+                throw exception;
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously sends a deep insert request without blocking waits.
+        /// </summary>
+        /// <typeparam name="T">The type of the top-level object to be deep inserted.</typeparam>
+        /// <param name="resource">The top-level object to be deep inserted.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        internal async Task DeepInsertRequestAsync<T>(T resource, CancellationToken cancellationToken)
+        {
+            if (resource == null)
+            {
+                throw Error.ArgumentNull(nameof(resource));
+            }
+
+            BuildDescriptorGraph(this.ChangedEntries, true, resource);
+
+            ODataRequestMessageWrapper deepInsertRequestMessage = this.GenerateDeepInsertRequest();
+
+            if (deepInsertRequestMessage == null)
+            {
+                return;
+            }
+
+            deepInsertRequestMessage.SetRequestStream(deepInsertRequestMessage.CachedRequestStream);
+
+            try
+            {
+                this.batchResponseMessage = await this.RequestInfo.GetResponseAsync(deepInsertRequestMessage, false, cancellationToken);
                 this.responseStream = this.batchResponseMessage.GetStream();
             }
             catch (DataServiceTransportException ex)

--- a/src/Microsoft.OData.Client/DeepInsertSaveResult.cs
+++ b/src/Microsoft.OData.Client/DeepInsertSaveResult.cs
@@ -149,7 +149,7 @@ namespace Microsoft.OData.Client
 
             try
             {
-                this.batchResponseMessage = await this.RequestInfo.GetResponseAsync(deepInsertRequestMessage, false, cancellationToken);
+                this.batchResponseMessage = await this.RequestInfo.GetResponseAsync(deepInsertRequestMessage, false, cancellationToken).ConfigureAwait(false);
                 this.responseStream = this.batchResponseMessage.GetStream();
             }
             catch (DataServiceTransportException ex)

--- a/src/Microsoft.OData.Client/GetReadStreamResult.cs
+++ b/src/Microsoft.OData.Client/GetReadStreamResult.cs
@@ -9,6 +9,8 @@ namespace Microsoft.OData.Client
     using System;
     using System.Diagnostics;
     using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.OData;
 
     /// <summary>
@@ -114,6 +116,38 @@ namespace Microsoft.OData.Client
             try
             {
                 this.responseMessage = this.requestInfo.GetSynchronousResponse(this.requestMessage, true);
+                Debug.Assert(this.responseMessage != null, "Can't set a null response.");
+            }
+            catch (Exception e)
+            {
+                this.HandleFailure(e);
+                throw;
+            }
+            finally
+            {
+                this.SetCompleted();
+                this.CompletedRequest();
+            }
+
+            if (this.Failure != null)
+            {
+                throw this.Failure;
+            }
+
+            return this.End();
+        }
+
+        /// <summary>
+        /// Asynchronously executes the request and returns the stream response.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the stream response.</returns>
+        internal async Task<DataServiceStreamResponse> ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                this.responseMessage = await this.requestInfo.GetResponseAsync(this.requestMessage, true, cancellationToken)
+                    .ConfigureAwait(false);
                 Debug.Assert(this.responseMessage != null, "Can't set a null response.");
             }
             catch (Exception e)

--- a/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
+++ b/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
@@ -252,7 +252,7 @@ namespace Microsoft.OData.Client
                 else
                 {
                     byte[] buffer = new byte[WebUtil.DefaultBufferSizeForStreamCopy];
-                    WebUtil.CopyStream(requestStreamContent.Stream, requestStream, ref buffer);
+                    WebUtil.CopyStream(requestStreamContent.Stream, requestStream, buffer);
                 }
             }
         }

--- a/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
+++ b/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
@@ -296,6 +296,19 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary>
+        /// Asynchronously gets the response from the request.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the response message.</returns>
+        internal Task<IODataResponseMessage> GetResponseAsync(CancellationToken cancellationToken = default)
+        {
+#if DEBUG
+            this.ValidateHeaders();
+#endif
+            return this.requestMessage.GetResponseAsync(cancellationToken);
+        }
+
+        /// <summary>
         /// Sets the content length header for the given request message.
         /// </summary>
         internal void SetContentLengthHeader()

--- a/src/Microsoft.OData.Client/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+virtual Microsoft.OData.Client.DataServiceClientRequestMessage.GetResponseAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.OData.IODataResponseMessage>
+override Microsoft.OData.Client.HttpClientRequestMessage.GetResponseAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.OData.IODataResponseMessage>
+virtual Microsoft.OData.Client.DataServiceQuery<TElement>.EnumerateAllPagesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<TElement>

--- a/src/Microsoft.OData.Client/QueryResult.cs
+++ b/src/Microsoft.OData.Client/QueryResult.cs
@@ -251,7 +251,7 @@ namespace Microsoft.OData.Client
 
                             Byte[] buffer = this.GetAsyncResponseStreamCopyBuffer();
 
-                            long copied = WebUtil.CopyStream(stream, copy, ref buffer);
+                            long copied = WebUtil.CopyStream(stream, copy, buffer);
                             if (this.responseStreamOwner)
                             {
                                 if (copied == 0)

--- a/src/Microsoft.OData.Client/QueryResult.cs
+++ b/src/Microsoft.OData.Client/QueryResult.cs
@@ -298,9 +298,9 @@ namespace Microsoft.OData.Client
                     this.Request.SetRequestStream(this.requestContentStream);
                 }
 
-                IODataResponseMessage response = await this.RequestInfo.GetResponseAsync(this.Request, true, cancellationToken);
+                IODataResponseMessage response = await this.RequestInfo.GetResponseAsync(this.Request, true, cancellationToken).ConfigureAwait(false);
                 this.SetHttpWebResponse(Util.NullCheck(response, InternalError.InvalidGetResponse));
-                await this.ProcessResponseStreamAsync(cancellationToken);
+                await this.ProcessResponseStreamAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -770,7 +770,7 @@ namespace Microsoft.OData.Client
 
                 Byte[] buffer = this.GetAsyncResponseStreamCopyBuffer();
 
-                long copied = await WebUtil.CopyStreamAsync(stream, copy, buffer, cancellationToken);
+                long copied = await WebUtil.CopyStreamAsync(stream, copy, buffer, cancellationToken).ConfigureAwait(false);
 
                 this.FinalizeStreamCopy(copy, copied);
                 this.PutAsyncResponseStreamCopyBuffer(buffer);

--- a/src/Microsoft.OData.Client/QueryResult.cs
+++ b/src/Microsoft.OData.Client/QueryResult.cs
@@ -13,6 +13,8 @@ namespace Microsoft.OData.Client
     using System.IO;
     using System.Linq;
     using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.OData;
 
     /// <summary>
@@ -266,6 +268,39 @@ namespace Microsoft.OData.Client
                         }
                     }
                 }
+            }
+            catch (Exception e)
+            {
+                this.HandleFailure(e);
+                throw;
+            }
+            finally
+            {
+                this.SetCompleted();
+                this.CompletedRequest();
+            }
+
+            if (this.Failure != null)
+            {
+                throw this.Failure;
+            }
+        }
+
+        /// <summary>Asynchronous query execution without blocking waits.</summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous query execution.</returns>
+        internal async Task ExecuteQueryAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                if (this.requestContentStream != null && this.requestContentStream.Stream != null)
+                {
+                    this.Request.SetRequestStream(this.requestContentStream);
+                }
+
+                IODataResponseMessage response = await this.RequestInfo.GetResponseAsync(this.Request, true, cancellationToken);
+                this.SetHttpWebResponse(Util.NullCheck(response, InternalError.InvalidGetResponse));
+                await this.ProcessResponseStreamAsync(cancellationToken);
             }
             catch (Exception e)
             {
@@ -709,6 +744,57 @@ namespace Microsoft.OData.Client
                 responseMessageWrapper,
                 payloadKind,
                 base.MaterializerCache);
+        }
+
+        /// <summary>
+        /// Asynchronously processes the response stream by copying it to the output stream.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous stream processing.</returns>
+        private async ValueTask ProcessResponseStreamAsync(CancellationToken cancellationToken)
+        {
+            if (HttpStatusCode.NoContent == this.StatusCode)
+            {
+                return;
+            }
+
+            using (Stream stream = this.responseMessage.GetStream())
+            {
+                if (stream == null)
+                {
+                    return;
+                }
+
+                Stream copy = this.GetAsyncResponseStreamCopy();
+                this.outputResponseStream = copy;
+
+                Byte[] buffer = this.GetAsyncResponseStreamCopyBuffer();
+
+                long copied = await WebUtil.CopyStreamAsync(stream, copy, buffer, cancellationToken);
+
+                this.FinalizeStreamCopy(copy, copied);
+                this.PutAsyncResponseStreamCopyBuffer(buffer);
+            }
+        }
+
+        /// <summary>
+        /// Finalizes the stream copy by adjusting the length of the output stream if necessary.
+        /// </summary>
+        private void FinalizeStreamCopy(Stream copy, long copied)
+        {
+            if (!this.responseStreamOwner)
+            {
+                return;
+            }
+
+            if (copied == 0)
+            {
+                this.outputResponseStream = null;
+            }
+            else if (copy.Position < copy.Length)
+            {
+                ((MemoryStream)copy).SetLength(copy.Position);
+            }
         }
     }
 }

--- a/src/Microsoft.OData.Client/RequestInfo.cs
+++ b/src/Microsoft.OData.Client/RequestInfo.cs
@@ -11,6 +11,8 @@ namespace Microsoft.OData.Client
     using System.Diagnostics;
     using System.Linq;
     using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
     using System.Xml.Linq;
     using System.Net;
     using Microsoft.OData;
@@ -199,6 +201,22 @@ namespace Microsoft.OData.Client
         internal IODataResponseMessage GetSynchronousResponse(ODataRequestMessageWrapper request, bool handleWebException)
         {
             return this.Context.GetSynchronousResponse(request, handleWebException);
+        }
+
+        /// <summary>
+        /// Asynchronously gets the response for the request.
+        /// </summary>
+        /// <param name="request">The OData request message wrapper to get the response from.</param>
+        /// <param name="handleWebException">If true, suppresses <see cref="WebException"/> if the response is available;
+        /// otherwise, always rethrows <see cref="WebException"/>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the response message.</returns>
+        internal Task<IODataResponseMessage> GetResponseAsync(
+            ODataRequestMessageWrapper request,
+            bool handleWebException,
+            CancellationToken cancellationToken = default)
+        {
+            return this.Context.GetResponseAsync(request, handleWebException, cancellationToken);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/SaveResult.cs
+++ b/src/Microsoft.OData.Client/SaveResult.cs
@@ -880,7 +880,8 @@ namespace Microsoft.OData.Client
                     // we need to check for whether the incoming stream was data or not. Hence we need to copy it to a temporary memory stream
                     using (MemoryStream memoryStream = new MemoryStream())
                     {
-                        if (WebUtil.CopyStream(stream, memoryStream, ref this.buildBatchBuffer) != 0)
+                        this.buildBatchBuffer ??= new byte[WebUtil.DefaultBufferSizeForStreamCopy];
+                        if (WebUtil.CopyStream(stream, memoryStream, this.buildBatchBuffer) != 0)
                         {
                             // set the memory stream position to zero again.
                             memoryStream.Position = 0;

--- a/src/Microsoft.OData.Client/SaveResult.cs
+++ b/src/Microsoft.OData.Client/SaveResult.cs
@@ -16,6 +16,8 @@ namespace Microsoft.OData.Client
     using System.Net;
     using System.Text;
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.OData;
     using Microsoft.OData.Client.Materialization;
     using Microsoft.OData.Client.Metadata;
@@ -248,6 +250,67 @@ namespace Microsoft.OData.Client
                 finally
                 {
                     WebUtil.DisposeMessage(responseMsg);
+                }
+
+                // we have no more pending requests or there has been an error in the previous request and we decided not to continue
+                // (When an error occurs and we are not going to continue on error, we call SetCompleted
+            }
+            while (this.entryIndex < this.ChangedEntries.Count && !this.IsCompletedInternally);
+
+            Debug.Assert(this.entryIndex < this.ChangedEntries.Count || this.ChangedEntries.All(o => o.ContentGeneratedForSave), "didn't generate content for all entities/links");
+        }
+
+        /// <summary>
+        /// Asynchronously processes all pending changes without blocking waits.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        internal async Task CreateNextChangeAsync(CancellationToken cancellationToken = default)
+        {
+            ODataRequestMessageWrapper requestMessage = null;
+
+            do
+            {
+                IODataResponseMessage responseMessage = null;
+
+                try
+                {
+                    requestMessage = this.CreateNextRequest();
+                    if ((requestMessage != null) || (this.entryIndex < this.ChangedEntries.Count))
+                    {
+                        if (this.ChangedEntries[this.entryIndex].ContentGeneratedForSave)
+                        {
+                            Debug.Assert(this.ChangedEntries[this.entryIndex] is LinkDescriptor, "only expected RelatedEnd to presave");
+                            Debug.Assert(
+                                this.ChangedEntries[this.entryIndex].State == EntityStates.Added ||
+                                this.ChangedEntries[this.entryIndex].State == EntityStates.Modified,
+                                "only expected added to presave");
+                            continue;
+                        }
+
+                        ContentStream contentStream = this.CreateNonBatchChangeData(this.entryIndex, requestMessage);
+                        if (contentStream != null && contentStream.Stream != null)
+                        {
+                            requestMessage.SetRequestStream(contentStream);
+                        }
+
+                        responseMessage = await this.RequestInfo.GetResponseAsync(requestMessage, false, cancellationToken)
+                            .ConfigureAwait(false);
+
+                        this.HandleOperationResponse(responseMessage);
+                        this.HandleOperationResponseHeaders((HttpStatusCode)responseMessage.StatusCode, new HeaderCollection(responseMessage));
+                        this.HandleOperationResponseData(responseMessage);
+                        this.perRequest = null;
+                    }
+                }
+                catch (InvalidOperationException e)
+                {
+                    e = WebUtil.GetHttpWebResponse(e, ref responseMessage);
+                    this.HandleOperationException(e, responseMessage);
+                }
+                finally
+                {
+                    WebUtil.DisposeMessage(responseMessage);
                 }
 
                 // we have no more pending requests or there has been an error in the previous request and we decided not to continue

--- a/src/Microsoft.OData.Client/Serialization/DataServiceClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/DataServiceClientRequestMessage.cs
@@ -159,11 +159,11 @@ namespace Microsoft.OData.Client
         /// <returns>A task that represents the asynchronous operation. The task result contains the response message.</returns>
         public virtual Task<IODataResponseMessage> GetResponseAsync(CancellationToken cancellationToken)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled<IODataResponseMessage>(cancellationToken);
-            }
-
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<IODataResponseMessage>(cancellationToken);
+            }
+
             try
             {
                 return Task.FromResult(GetResponse());

--- a/src/Microsoft.OData.Client/Serialization/DataServiceClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/DataServiceClientRequestMessage.cs
@@ -151,5 +151,22 @@ namespace Microsoft.OData.Client
         /// <returns>A System.Net.WebResponse that contains the response from the Internet resource.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "This is intentionally a method.")]
         public abstract IODataResponseMessage GetResponse();
+
+        /// <summary>
+        /// Asynchronously returns a response from a network resource.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the response message.</returns>
+        public virtual Task<IODataResponseMessage> GetResponseAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                return Task.FromResult(GetResponse());
+            }
+            catch (Exception ex) when (CommonUtil.IsCatchableExceptionType(ex))
+            {
+                return Task.FromException<IODataResponseMessage>(ex);
+            }
+        }
     }
 }

--- a/src/Microsoft.OData.Client/Serialization/DataServiceClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/DataServiceClientRequestMessage.cs
@@ -159,6 +159,11 @@ namespace Microsoft.OData.Client
         /// <returns>A task that represents the asynchronous operation. The task result contains the response message.</returns>
         public virtual Task<IODataResponseMessage> GetResponseAsync(CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<IODataResponseMessage>(cancellationToken);
+            }
+
             try
             {
                 return Task.FromResult(GetResponse());

--- a/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
@@ -422,7 +422,13 @@ namespace Microsoft.OData.Client
         public override async Task<IODataResponseMessage> GetResponseAsync(CancellationToken cancellationToken)
         {
             HttpResponseMessage httpResponseMessage = await CreateSendTask(cancellationToken).ConfigureAwait(false);
-            cancellationToken.ThrowIfCancellationRequested();
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                httpResponseMessage?.Dispose();
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
             _httpResponseMessage = httpResponseMessage;
 
             return await ConvertHttpWebResponseAsync(httpResponseMessage).ConfigureAwait(false);

--- a/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
@@ -422,6 +422,7 @@ namespace Microsoft.OData.Client
         public override async Task<IODataResponseMessage> GetResponseAsync(CancellationToken cancellationToken)
         {
             HttpResponseMessage httpResponseMessage = await CreateSendTask(cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
             _httpResponseMessage = httpResponseMessage;
 
             return await ConvertHttpWebResponseAsync(httpResponseMessage).ConfigureAwait(false);

--- a/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
@@ -542,8 +542,10 @@ namespace Microsoft.OData.Client
                     throw;
                 }
 
-                // Wrap internal timeout / abort as DataServiceTransportException
-                throw new DataServiceTransportException(response: null, ex);
+                // Wrap internal timeout / abort as DataServiceTransportException.
+                // The inner exception must be an InvalidOperationException for compatibility with
+                // WebUtil.GetHttpWebResponse, which casts InnerException to InvalidOperationException.
+                throw new DataServiceTransportException(response: null, new InvalidOperationException(ex.Message, ex));
             }
             finally
             {

--- a/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
@@ -414,8 +414,27 @@ namespace Microsoft.OData.Client
             });
         }
 
-        private Task<HttpResponseMessage> CreateSendTask()
+        /// <summary>
+        /// Asynchronously returns a response from a network resource.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the response message.</returns>
+        public override async Task<IODataResponseMessage> GetResponseAsync(CancellationToken cancellationToken)
         {
+            HttpResponseMessage httpResponseMessage = await CreateSendTask(cancellationToken).ConfigureAwait(false);
+            _httpResponseMessage = httpResponseMessage;
+
+            return await ConvertHttpWebResponseAsync(httpResponseMessage).ConfigureAwait(false);
+        }
+
+        private Task<HttpResponseMessage> CreateSendTask(CancellationToken cancellationToken = default)
+        {
+            // Check if the external cancellation token is already cancelled
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<HttpResponseMessage>(cancellationToken);
+            }
+
             // Only set the message content if the stream has been written to, otherwise
             // HttpClient will complain if it's a GET request.
             Byte[] messageContent = _messageStream.ToArray();
@@ -453,7 +472,20 @@ namespace Microsoft.OData.Client
             CancellationTokenSource timeoutTokenSource = null;
             CancellationTokenSource linkedTokenSource = null;
 
-            if (_isTimeoutProvidedByCaller && _timeout > TimeSpan.Zero)
+            bool hasTimeout = _isTimeoutProvidedByCaller && _timeout > TimeSpan.Zero;
+            bool hasCancellationToken = cancellationToken.CanBeCanceled;
+
+            if (hasTimeout && hasCancellationToken)
+            {
+                // Link abort + timeout + external token so any cancels the send
+                timeoutTokenSource = new CancellationTokenSource(_timeout);
+                linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+                    _abortRequestCancellationTokenSource.Token,
+                    timeoutTokenSource.Token,
+                    cancellationToken);
+                sendToken = linkedTokenSource.Token;
+            }
+            else if (hasTimeout)
             {
                 // Per-request timeout: link abort + timeout so either cancels the send
                 timeoutTokenSource = new CancellationTokenSource(_timeout);
@@ -462,8 +494,17 @@ namespace Microsoft.OData.Client
                     timeoutTokenSource.Token);
                 sendToken = linkedTokenSource.Token;
             }
+            else if (hasCancellationToken)
+            {
+                // Link abort + external token so either cancels the send
+                linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+                    _abortRequestCancellationTokenSource.Token,
+                    cancellationToken);
+                sendToken = linkedTokenSource.Token;
+            }
+            // else use abort token only (already set)
 
-            return SendInternalAsync(_requestMessage, sendToken, linkedTokenSource, timeoutTokenSource);
+            return SendInternalAsync(_requestMessage, sendToken, linkedTokenSource, timeoutTokenSource, cancellationToken);
         }
 
         /// <summary>
@@ -474,6 +515,7 @@ namespace Microsoft.OData.Client
         /// <param name="sendToken"><see cref="CancellationToken"/> combining abort and optional timeout.</param>
         /// <param name="linkedTokenSource">Linked <see cref="CancellationTokenSource"/> (abort + timeout) if a timeout was specified; otherwise null.</param>
         /// <param name="timeoutTokenSource"><see cref="CancellationTokenSource"/> created for the per-request timeout; null if no timeout.</param>
+        /// <param name="cancellationToken">The external cancellation token provided by the caller.</param>
         /// <returns>A task producing the <see cref="HttpResponseMessage"/>.</returns>
         /// <remarks>
         /// Internal cancellations (abort or timeout) are wrapped as <see cref="DataServiceTransportException"/>; 
@@ -484,7 +526,8 @@ namespace Microsoft.OData.Client
             HttpRequestMessage request,
             CancellationToken sendToken,
             CancellationTokenSource linkedTokenSource,
-            CancellationTokenSource timeoutTokenSource)
+            CancellationTokenSource timeoutTokenSource,
+            CancellationToken cancellationToken)
         {
             try
             {
@@ -493,9 +536,13 @@ namespace Microsoft.OData.Client
             }
             catch (OperationCanceledException ex)
             {
+                // If the external cancellation token triggered the cancellation, propagate as is
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+
                 // Wrap internal timeout / abort as DataServiceTransportException
-                // but let external caller-driven cancellations propagate as OperationCanceledException.
-                // Currently, only abort or per-request timeout can trigger cancellation (no external token linked)
                 throw new DataServiceTransportException(response: null, ex);
             }
             finally
@@ -534,6 +581,20 @@ namespace Microsoft.OData.Client
                     return task.Result;
                 },
                 getResponseStreamAsync: response.Content.ReadAsStreamAsync);
+        }
+
+        private static async Task<HttpWebResponseMessage> ConvertHttpWebResponseAsync(HttpResponseMessage response)
+        {
+            IEnumerable<KeyValuePair<string, string>> allHeaders = HttpHeadersToStringDictionary(response.Headers).Concat(
+                HttpHeadersToStringDictionary(response.Content.Headers));
+
+            Stream contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+
+            return new HttpWebResponseMessage(
+                allHeaders.ToDictionary((h1) => h1.Key, (h2) => h2.Value),
+                (int)response.StatusCode,
+                getResponseStream: () => contentStream,
+                getResponseStreamAsync: null);
         }
 
         private static T UnwrapAggregateException<T>(Func<T> action)

--- a/src/Microsoft.OData.Client/WebUtil.cs
+++ b/src/Microsoft.OData.Client/WebUtil.cs
@@ -15,6 +15,8 @@ namespace Microsoft.OData.Client
     using System.Linq;
     using System.Reflection;
     using System.Runtime.CompilerServices;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.OData;
     using Microsoft.OData.Client.Metadata;
 
@@ -82,6 +84,32 @@ namespace Microsoft.OData.Client
             while (input.CanRead && ((count = input.Read(buffer, 0, buffer.Length)) > 0))
             {
                 output.Write(buffer, 0, count);
+                total += count;
+            }
+
+            return total;
+        }
+
+        /// <summary>Asynchronously copy from one stream to another.</summary>
+        /// <param name="input">Input stream to read from.</param>
+        /// <param name="output">Output stream to write to.</param>
+        /// <param name="buffer">Buffer to use for copying. If null, a new buffer will be created.</param>
+        /// <param name="cancellationToken">Cancellation token to observe.</param>
+        /// <returns>
+        /// A task that represents the asynchronous copy operation.
+        /// The task result contains the total number of bytes copied.
+        /// </returns>
+        internal static async Task<long> CopyStreamAsync(Stream input, Stream output, byte[] buffer, CancellationToken cancellationToken = default)
+        {
+            Debug.Assert(input != null, "null input stream");
+            Debug.Assert(output != null, "null output stream");
+            Debug.Assert(buffer == null || buffer.Length > 0, "null or empty buffer");
+
+            long total = 0;
+            int count;
+            while (input.CanRead && (count = await input.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false)) > 0)
+            {
+                await output.WriteAsync(buffer.AsMemory(0, count), cancellationToken).ConfigureAwait(false);
                 total += count;
             }
 

--- a/src/Microsoft.OData.Client/WebUtil.cs
+++ b/src/Microsoft.OData.Client/WebUtil.cs
@@ -105,6 +105,11 @@ namespace Microsoft.OData.Client
             Debug.Assert(output != null, "null output stream");
             Debug.Assert(buffer == null || buffer.Length > 0, "null or empty buffer");
 
+            if (buffer == null)
+            {
+                buffer = new byte[1000];
+            }
+
             long total = 0;
             int count;
             while (input.CanRead && (count = await input.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false)) > 0)

--- a/src/Microsoft.OData.Client/WebUtil.cs
+++ b/src/Microsoft.OData.Client/WebUtil.cs
@@ -25,6 +25,7 @@ namespace Microsoft.OData.Client
     {
         /// <summary>
         /// Default buffer size used for stream copy.
+        /// Aligned with .NET's default Stream.CopyTo buffer size to balance memory usage and I/O efficiency.
         /// </summary>
         internal const int DefaultBufferSizeForStreamCopy = 4096;
 

--- a/src/Microsoft.OData.Client/WebUtil.cs
+++ b/src/Microsoft.OData.Client/WebUtil.cs
@@ -66,19 +66,16 @@ namespace Microsoft.OData.Client
         /// <summary>copy from one stream to another</summary>
         /// <param name="input">input stream</param>
         /// <param name="output">output stream</param>
-        /// <param name="refBuffer">reusable buffer</param>
+        /// <param name="refBuffer">reusable buffer, must be non-null and non-empty</param>
         /// <returns>count of copied bytes</returns>
         internal static long CopyStream(Stream input, Stream output, ref byte[] refBuffer)
         {
             Debug.Assert(input != null, "null input stream");
             Debug.Assert(output != null, "null output stream");
+            Debug.Assert(refBuffer != null && refBuffer.Length > 0, "null or empty buffer");
 
             long total = 0;
             byte[] buffer = refBuffer;
-            if (buffer == null)
-            {
-                refBuffer = buffer = new byte[1000];
-            }
 
             int count;
             while (input.CanRead && ((count = input.Read(buffer, 0, buffer.Length)) > 0))
@@ -93,7 +90,7 @@ namespace Microsoft.OData.Client
         /// <summary>Asynchronously copy from one stream to another.</summary>
         /// <param name="input">Input stream to read from.</param>
         /// <param name="output">Output stream to write to.</param>
-        /// <param name="buffer">Buffer to use for copying. If null, a new buffer will be created.</param>
+        /// <param name="buffer">Buffer to use for copying. Must be non-null and non-empty.</param>
         /// <param name="cancellationToken">Cancellation token to observe.</param>
         /// <returns>
         /// A task that represents the asynchronous copy operation.
@@ -103,12 +100,7 @@ namespace Microsoft.OData.Client
         {
             Debug.Assert(input != null, "null input stream");
             Debug.Assert(output != null, "null output stream");
-            Debug.Assert(buffer == null || buffer.Length > 0, "null or empty buffer");
-
-            if (buffer == null)
-            {
-                buffer = new byte[1000];
-            }
+            Debug.Assert(buffer != null && buffer.Length > 0, "null or empty buffer");
 
             long total = 0;
             int count;

--- a/src/Microsoft.OData.Client/WebUtil.cs
+++ b/src/Microsoft.OData.Client/WebUtil.cs
@@ -26,7 +26,7 @@ namespace Microsoft.OData.Client
         /// <summary>
         /// Default buffer size used for stream copy.
         /// </summary>
-        internal const int DefaultBufferSizeForStreamCopy = 64 * 1024;
+        internal const int DefaultBufferSizeForStreamCopy = 4096;
 
         /// <summary>
         /// Whether DataServiceCollection&lt;&gt; type is available.
@@ -66,16 +66,15 @@ namespace Microsoft.OData.Client
         /// <summary>copy from one stream to another</summary>
         /// <param name="input">input stream</param>
         /// <param name="output">output stream</param>
-        /// <param name="refBuffer">reusable buffer, must be non-null and non-empty</param>
+        /// <param name="buffer">reusable buffer; must be non-null and non-empty</param>
         /// <returns>count of copied bytes</returns>
-        internal static long CopyStream(Stream input, Stream output, ref byte[] refBuffer)
+        internal static long CopyStream(Stream input, Stream output, byte[] buffer)
         {
             Debug.Assert(input != null, "null input stream");
             Debug.Assert(output != null, "null output stream");
-            Debug.Assert(refBuffer != null && refBuffer.Length > 0, "null or empty buffer");
+            Debug.Assert(buffer != null && buffer.Length > 0, "null or empty buffer");
 
             long total = 0;
-            byte[] buffer = refBuffer;
 
             int count;
             while (input.CanRead && ((count = input.Read(buffer, 0, buffer.Length)) > 0))

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AsynchronousTests/AsyncMethodTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AsynchronousTests/AsyncMethodTests.cs
@@ -583,16 +583,14 @@ public class AsyncMethodTests : AsynchronousEndToEndTestBase<AsyncMethodTests.Te
         context.SendingRequest2 += sendRequestEvent;
 
         // Act & Assert
-        var customers = context.Customers.GetAllPagesAsync();
-        Assert.Equal(1, sentRequestCount);
-        foreach (var customer in await customers)
+        await foreach (var customer in context.Customers.EnumerateAllPagesAsync())
         {
             if (++count == 3)
             {
                 break;
             }
         }
-        //Only two Request sent
+        // Only two requests sent (one per page, stopping after 3 items)
         Assert.Equal(2, sentRequestCount);
         this.EnqueueTestComplete();
     }

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/CancellationTokenTests/Tests/CancellationTokenTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/CancellationTokenTests/Tests/CancellationTokenTests.cs
@@ -107,8 +107,8 @@ public class CancellationTokenTests : EndToEndTestBase<CancellationTokenTests.Te
         // Act & Assert
         Task response() => _context.Customers.ByKey(11).GetValueAsync(source.Token);
         source.Cancel();
-        var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
-        Assert.Equal("The operation was canceled.", exception.Message);
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(response);
+        Assert.True(exception.CancellationToken.IsCancellationRequested);
     }
 
     #endregion
@@ -130,8 +130,8 @@ public class CancellationTokenTests : EndToEndTestBase<CancellationTokenTests.Te
 
         Task response() => _context.Customers.ExecuteAsync(source.Token);
         source.Cancel();
-        var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
-        Assert.Equal("The operation was canceled.", exception.Message);
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(response);
+        Assert.True(exception.CancellationToken.IsCancellationRequested);
 
         // ExecuteAsync by continuation
         var customers = await _context.Customers.ExecuteAsync() as QueryOperationResponse<Customer>;
@@ -142,8 +142,8 @@ public class CancellationTokenTests : EndToEndTestBase<CancellationTokenTests.Te
 
         Task response2() => _context.ExecuteAsync(continuation, source.Token);
         source.Cancel();
-        var exception2 = await Assert.ThrowsAsync<OperationCanceledException>(response2);
-        Assert.Equal("The operation was canceled.", exception2.Message);
+        var exception2 = await Assert.ThrowsAnyAsync<OperationCanceledException>(response2);
+        Assert.True(exception2.CancellationToken.IsCancellationRequested);
 
         // ExecuteAsync by nextLink
         var customers2 = await _context.Customers.ExecuteAsync() as QueryOperationResponse<Customer>;
@@ -154,8 +154,8 @@ public class CancellationTokenTests : EndToEndTestBase<CancellationTokenTests.Te
 
         Task response3() => _context.ExecuteAsync<Customer>(continuation2.NextLinkUri, source.Token);
         source.Cancel();
-        var exception3 = await Assert.ThrowsAsync<OperationCanceledException>(response3);
-        Assert.Equal("The operation was canceled.", exception3.Message);
+        var exception3 = await Assert.ThrowsAnyAsync<OperationCanceledException>(response3);
+        Assert.True(exception3.CancellationToken.IsCancellationRequested);
     }
 
     #endregion
@@ -177,8 +177,8 @@ public class CancellationTokenTests : EndToEndTestBase<CancellationTokenTests.Te
 
         Task response() => _context.Customers.GetAllPagesAsync(source.Token);
         source.Cancel();
-        var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
-        Assert.Equal("The operation was canceled.", exception.Message);
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(response);
+        Assert.True(exception.CancellationToken.IsCancellationRequested);
     }
 
     #endregion
@@ -291,7 +291,7 @@ public class CancellationTokenTests : EndToEndTestBase<CancellationTokenTests.Te
             });
 
         source.Cancel();
-        var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(response);
         Assert.Equal("The operation was canceled.", exception.Message);
     }
 
@@ -323,8 +323,8 @@ public class CancellationTokenTests : EndToEndTestBase<CancellationTokenTests.Te
         Task response() => getComputerAction.ExecuteAsync(source.Token);
 
         source.Cancel();
-        var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
-        Assert.Equal("The operation was canceled.", exception.Message);
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(response);
+        Assert.True(exception.CancellationToken.IsCancellationRequested);
     }
 
     #endregion

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/AsyncWasmCompatibilityTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/AsyncWasmCompatibilityTests.cs
@@ -1,0 +1,425 @@
+//---------------------------------------------------------------------
+// <copyright file="AsyncWasmCompatibilityTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.OData.Edm.Csdl;
+using Xunit;
+
+namespace Microsoft.OData.Client.Tests.Serialization
+{
+    /// <summary>
+    /// Tests for the async-native WASM compatibility path that eliminates Task.Wait() blocking.
+    /// These tests verify that GetResponseAsync, ExecuteAsync, GetAllPagesAsync, and
+    /// EnumerateAllPagesAsync work correctly through the new async pipeline.
+    /// </summary>
+    public class AsyncWasmCompatibilityTests
+    {
+        private const string ServiceRoot = "http://localhost:9090";
+
+        private const string Edmx = @"<edmx:Edmx xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"" Version=""4.0"">
+  <edmx:DataServices>
+    <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""Test"">
+      <EntityType Name=""Product"">
+        <Key>
+          <PropertyRef Name=""Id"" />
+        </Key>
+        <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""Name"" Type=""Edm.String"" />
+      </EntityType>
+    </Schema>
+    <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""Default"">
+      <EntityContainer Name=""Container"">
+        <EntitySet Name=""Products"" EntityType=""Test.Product"" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+
+        private const string ProductsResponse = @"{
+    ""@odata.context"": ""http://localhost:9090/$metadata#Products"",
+    ""value"": [
+        { ""Id"": 1, ""Name"": ""Widget"" },
+        { ""Id"": 2, ""Name"": ""Gadget"" }
+    ]
+}";
+
+        private const string ProductsPage1Response = @"{
+    ""@odata.context"": ""http://localhost:9090/$metadata#Products"",
+    ""value"": [
+        { ""Id"": 1, ""Name"": ""Widget"" },
+        { ""Id"": 2, ""Name"": ""Gadget"" }
+    ],
+    ""@odata.nextLink"": ""http://localhost:9090/Products?$skip=2""
+}";
+
+        private const string ProductsPage2Response = @"{
+    ""@odata.context"": ""http://localhost:9090/$metadata#Products"",
+    ""value"": [
+        { ""Id"": 3, ""Name"": ""Doohickey"" }
+    ]
+}";
+
+        #region GetResponseAsync Tests
+
+        [Fact]
+        public async Task GetResponseAsync_ReturnsResponse_WithoutBlocking()
+        {
+            // Arrange
+            var context = CreateContext();
+            SetupRequestPipeline(context, ProductsResponse);
+
+            // Act
+            var query = context.Products;
+            var results = await query.ExecuteAsync();
+
+            // Assert
+            var products = results.ToList();
+            Assert.Equal(2, products.Count);
+            Assert.Equal("Widget", products[0].Name);
+            Assert.Equal("Gadget", products[1].Name);
+        }
+
+        [Fact]
+        public async Task GetResponseAsync_SupportsCancellation()
+        {
+            // Arrange
+            var context = CreateContext();
+            SetupRequestPipeline(context, ProductsResponse);
+            var cts = new CancellationTokenSource();
+            cts.Cancel(); // Pre-cancel
+
+            // Act & Assert
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => context.Products.ExecuteAsync(cts.Token));
+        }
+
+        [Fact]
+        public async Task GetResponseAsync_WithHttpClientFactory_UsesAsyncPath()
+        {
+            // Arrange - MockHttpClientHandler returns proper OData JSON response
+            using var handler = new MockHttpClientHandler(request =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(ProductsResponse, Encoding.UTF8, "application/json")
+                };
+                return response;
+            });
+            var factory = new MockHttpClientFactory(handler);
+
+            var context = CreateContext();
+            context.HttpClientFactory = factory;
+
+            // Act
+            var results = await context.Products.ExecuteAsync();
+
+            // Assert
+            var products = results.ToList();
+            Assert.Equal(2, products.Count);
+            Assert.Equal(1, factory.NumCalls);
+            Assert.Single(handler.Requests);
+            Assert.Contains("Products", handler.Requests[0]);
+        }
+
+        #endregion
+
+        #region ExecuteAsync (DataServiceQuery) Tests
+
+        [Fact]
+        public async Task ExecuteAsync_WithCancellationToken_ReturnsResults()
+        {
+            // Arrange
+            var context = CreateContext();
+            SetupRequestPipeline(context, ProductsResponse);
+
+            // Act
+            var results = await context.Products.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.Equal(2, results.Count());
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ForFunction_UsesContextExecuteAsync()
+        {
+            // Arrange - simulate function call via ExecuteAsync on context
+            var context = CreateContext();
+            SetupRequestPipeline(context, ProductsResponse);
+
+            // Act - use Context.ExecuteAsync directly (the function path)
+            var results = await context.ExecuteAsync<Product>(
+                new Uri($"{ServiceRoot}/Products"), CancellationToken.None);
+
+            // Assert
+            Assert.Equal(2, results.Count());
+        }
+
+        #endregion
+
+        #region GetAllPagesAsync Tests
+
+        [Fact]
+        public async Task GetAllPagesAsync_IteratesAllPages()
+        {
+            // Arrange
+            int requestCount = 0;
+            var context = CreateContext();
+            context.Configurations.RequestPipeline.OnMessageCreating = (args) =>
+            {
+                requestCount++;
+                string response = requestCount == 1 ? ProductsPage1Response : ProductsPage2Response;
+                return new AsyncTestRequestMessage(args, response);
+            };
+
+            // Act
+            var results = await context.Products.GetAllPagesAsync();
+
+            // Assert
+            var products = results.ToList();
+            Assert.Equal(3, products.Count);
+            Assert.Equal("Widget", products[0].Name);
+            Assert.Equal("Gadget", products[1].Name);
+            Assert.Equal("Doohickey", products[2].Name);
+            Assert.Equal(2, requestCount);
+        }
+
+        [Fact]
+        public async Task GetAllPagesAsync_WithCancellation_Throws()
+        {
+            // Arrange
+            var context = CreateContext();
+            SetupRequestPipeline(context, ProductsPage1Response);
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // Act & Assert
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => context.Products.GetAllPagesAsync(cts.Token));
+        }
+
+        #endregion
+
+        #region EnumerateAllPagesAsync Tests
+
+        [Fact]
+        public async Task EnumerateAllPagesAsync_YieldsElementsLazily()
+        {
+            // Arrange
+            int requestCount = 0;
+            var context = CreateContext();
+            context.Configurations.RequestPipeline.OnMessageCreating = (args) =>
+            {
+                requestCount++;
+                string response = requestCount == 1 ? ProductsPage1Response : ProductsPage2Response;
+                return new AsyncTestRequestMessage(args, response);
+            };
+
+            // Act
+            var elements = new List<Product>();
+            await foreach (var product in context.Products.EnumerateAllPagesAsync())
+            {
+                elements.Add(product);
+            }
+
+            // Assert
+            Assert.Equal(3, elements.Count);
+            Assert.Equal("Doohickey", elements[2].Name);
+            Assert.Equal(2, requestCount);
+        }
+
+        [Fact]
+        public async Task EnumerateAllPagesAsync_SupportsCancellation()
+        {
+            // Arrange
+            var context = CreateContext();
+            SetupRequestPipeline(context, ProductsPage1Response);
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // Act & Assert
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            {
+                await foreach (var _ in context.Products.EnumerateAllPagesAsync(cts.Token))
+                {
+                    // Should not reach here
+                }
+            });
+        }
+
+        #endregion
+
+        #region DataServiceContext.ExecuteAsync Tests
+
+        [Fact]
+        public async Task Context_ExecuteAsync_WithHttpMethod_ReturnsResults()
+        {
+            // Arrange
+            var context = CreateContext();
+            SetupRequestPipeline(context, ProductsResponse);
+
+            // Act
+            var results = await context.ExecuteAsync<Product>(
+                new Uri($"{ServiceRoot}/Products"), "GET", true, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(2, results.Count());
+        }
+
+        [Fact]
+        public async Task Context_ExecuteAsync_Continuation_ReturnsNextPage()
+        {
+            // Arrange
+            int requestCount = 0;
+            var context = CreateContext();
+            context.Configurations.RequestPipeline.OnMessageCreating = (args) =>
+            {
+                requestCount++;
+                string response = requestCount == 1 ? ProductsPage1Response : ProductsPage2Response;
+                return new AsyncTestRequestMessage(args, response);
+            };
+
+            // Get first page
+            var firstPage = (QueryOperationResponse<Product>)await context.Products.ExecuteAsync();
+            var firstPageResults = firstPage.ToList();
+            Assert.Equal(2, firstPageResults.Count);
+
+            var continuation = firstPage.GetContinuation();
+            Assert.NotNull(continuation);
+
+            // Act
+            var nextPage = await context.ExecuteAsync(continuation, CancellationToken.None);
+
+            // Assert
+            var products = nextPage.ToList();
+            Assert.Single(products);
+            Assert.Equal("Doohickey", products[0].Name);
+        }
+
+        #endregion
+
+        #region DataServiceQuerySingle.GetValueAsync Tests
+
+        [Fact]
+        public async Task GetValueAsync_ReturnsEntity_WithAsyncPath()
+        {
+            // Arrange
+            string singleProductResponse = @"{
+    ""@odata.context"": ""http://localhost:9090/$metadata#Products/$entity"",
+    ""Id"": 1,
+    ""Name"": ""Widget""
+}";
+            var context = CreateContext();
+            SetupRequestPipeline(context, singleProductResponse);
+
+            var querySingle = new DataServiceQuerySingle<Product>(context, "Products(1)");
+
+            // Act
+            var product = await querySingle.GetValueAsync(CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(product);
+            Assert.Equal(1, product.Id);
+            Assert.Equal("Widget", product.Name);
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private TestContainer CreateContext()
+        {
+            return new TestContainer(new Uri(ServiceRoot));
+        }
+
+        private void SetupRequestPipeline(DataServiceContext context, string response)
+        {
+            context.Configurations.RequestPipeline.OnMessageCreating = (args) =>
+                new AsyncTestRequestMessage(args, response);
+        }
+
+        #endregion
+
+        #region Test Types
+
+        [Key("Id")]
+        public class Product
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class TestContainer : DataServiceContext
+        {
+            public TestContainer(Uri serviceRoot) : base(serviceRoot, ODataProtocolVersion.V4)
+            {
+                Format.LoadServiceModel = () => CsdlReader.Parse(XmlReader.Create(new StringReader(Edmx)));
+                Format.UseJson();
+                Products = base.CreateQuery<Product>("Products");
+            }
+
+            public DataServiceQuery<Product> Products { get; private set; }
+        }
+
+        /// <summary>
+        /// A test request message that overrides GetResponseAsync to verify the async path works
+        /// without making real HTTP calls (simulating a WASM-compatible environment).
+        /// </summary>
+        private class AsyncTestRequestMessage : HttpClientRequestMessage
+        {
+            private readonly string _response;
+
+            public AsyncTestRequestMessage(DataServiceClientRequestMessageArgs args, string response)
+                : base(args)
+            {
+                _response = response;
+            }
+
+            public override IODataResponseMessage GetResponse()
+            {
+                return CreateMockResponse();
+            }
+
+            public override Task<IODataResponseMessage> GetResponseAsync(CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return Task.FromResult(GetResponse());
+            }
+
+            public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
+            {
+                var tcs = new TaskCompletionSource<bool>(state);
+                tcs.TrySetResult(true);
+                callback(tcs.Task);
+                return tcs.Task;
+            }
+
+            public override IODataResponseMessage EndGetResponse(IAsyncResult asyncResult)
+            {
+                return GetResponse();
+            }
+
+            private IODataResponseMessage CreateMockResponse()
+            {
+                return new HttpWebResponseMessage(
+                    new Dictionary<string, string> { { "Content-Type", "application/json;charset=utf-8" } },
+                    200,
+                    () => new MemoryStream(Encoding.UTF8.GetBytes(_response)),
+                    null);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextNoTrackingStreamsTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextNoTrackingStreamsTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.OData.Client.Tests.Tracking
     using System.IO;
     using System.Linq;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using System.Xml;
     using Edm.Csdl;
@@ -444,6 +445,13 @@ namespace Microsoft.OData.Client.Tests.Tracking
                     return new MemoryStream(byteArray);
                 },
                 null);
+        }
+
+        public override Task<IODataResponseMessage> GetResponseAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return Task.FromResult(GetResponse());
         }
 
         public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextQueryTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextQueryTests.cs
@@ -342,11 +342,12 @@ namespace Microsoft.OData.Client.Tests.Tracking
 
             // Act
             DataServiceQuery<EmployeeWithNullableEnumKey> query = _defaultContext.EmployeesWithNullableEnumKey;
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => query.ExecuteAsync());
+            var exception = await Assert.ThrowsAsync<DataServiceQueryException>(() => query.ExecuteAsync());
 
             // Assert
             Assert.NotNull(exception);
-            Assert.Equal("The key property 'EmpType' on type 'Microsoft.OData.Client.Tests.Tracking.EmployeeWithNullableEnumKey' is of type 'System.Nullable`1[[Microsoft.OData.Client.Tests.Tracking.EmployeeType, Microsoft.OData.Client.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=69c3241e6f0468ca]]', which is nullable. Key properties cannot be nullable.", exception.Message);
+            Assert.IsType<InvalidOperationException>(exception.InnerException);
+            Assert.Equal("The key property 'EmpType' on type 'Microsoft.OData.Client.Tests.Tracking.EmployeeWithNullableEnumKey' is of type 'System.Nullable`1[[Microsoft.OData.Client.Tests.Tracking.EmployeeType, Microsoft.OData.Client.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=69c3241e6f0468ca]]', which is nullable. Key properties cannot be nullable.", exception.InnerException.Message);
         }
 
         [Theory]
@@ -470,11 +471,12 @@ namespace Microsoft.OData.Client.Tests.Tracking
             EmployeeWithNullableEnumKeySingle query = _defaultContext.EmployeesWithNullableEnumKey.ByKey(
                 new Dictionary<string, object>() { { "EmpNumber", 8 }, { "EmpType", EmployeeType.PartTime }, { "OrgId", 1 } });
 
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => query.GetValueAsync());
+            var exception = await Assert.ThrowsAsync<DataServiceQueryException>(() => query.GetValueAsync());
 
             // Assert
             Assert.NotNull(exception);
-            Assert.Equal("The key property 'EmpType' on type 'Microsoft.OData.Client.Tests.Tracking.EmployeeWithNullableEnumKey' is of type 'System.Nullable`1[[Microsoft.OData.Client.Tests.Tracking.EmployeeType, Microsoft.OData.Client.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=69c3241e6f0468ca]]', which is nullable. Key properties cannot be nullable.", exception.Message);
+            Assert.IsType<InvalidOperationException>(exception.InnerException);
+            Assert.Equal("The key property 'EmpType' on type 'Microsoft.OData.Client.Tests.Tracking.EmployeeWithNullableEnumKey' is of type 'System.Nullable`1[[Microsoft.OData.Client.Tests.Tracking.EmployeeType, Microsoft.OData.Client.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=69c3241e6f0468ca]]', which is nullable. Key properties cannot be nullable.", exception.InnerException.Message);
         }
 
         [Theory]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

## Summary
 
 Ports the async-native request/response path from PR #3474 to dev-9.x, eliminating `Task.Wait()` blocking calls that prevent Blazor WebAssembly from working (fixes #3452).
 
 ## Problem
 
 In `HttpClientRequestMessage.ConvertHttpWebResponse()`, there is a synchronous `task.Wait()` on `response.Content.ReadAsStreamAsync()`. Blazor WASM disallows blocking waits, causing "Cannot wait on monitors on this runtime".
 
 ## Changes
 
 ### Transport Layer
 - `DataServiceClientRequestMessage`: Added virtual `GetResponseAsync(CancellationToken)` with sync fallback
 - `HttpClientRequestMessage`: Added `GetResponseAsync` override, `ConvertHttpWebResponseAsync`, updated `CreateSendTask` with CT param (4-case linked cancellation), updated `SendInternalAsync` with external CT propagation
 
 ### Plumbing
 - `ODataRequestMessageWrapper`, `RequestInfo`, `DataServiceContext`: Added `GetResponseAsync`/`GetResponseHelperAsync` forwarders
 
 ### Async Execution
 - `DataServiceRequest`: Added `ExecuteAsync<TElement>` for true async query execution
 - `DataServiceContext`: Added `ExecuteAsyncInternal<TElement>` overloads; updated 5 public `ExecuteAsync` methods from `FromAsync(BeginExecute, EndExecute)` to async-native
 - `DataServiceQuery<T>`: Updated `ExecuteAsync`, added `ExecuteAsyncImpl`, `GetAllPagesAsyncInternal` (IAsyncEnumerable), `EnumerateAllPagesAsync`
 - `DataServiceQuerySingle<T>`: Changed `GetValueAsync` from APM to async/await
 - `QueryResult`: Added `ExecuteQueryAsync`, `ProcessResponseStreamAsync`
 - `SaveResult`, `BatchSaveResult`, `DeepInsertSaveResult`, `BulkUpdateSaveResult`: Added async request methods
 - `GetReadStreamResult`: Added `ExecuteAsync`
 - `WebUtil`: Added `CopyStreamAsync`
 
 ### Tests
 - Added 12 new unit tests in `AsyncWasmCompatibilityTests.cs` covering the async pipeline
 - Updated existing test mocks for async path compatibility
 
 ## Testing
 
 All 604 unit tests pass (592 existing + 12 new).

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
