### PR TITLE
Add regression test for issue #3491: nullable enum with null in 'in' operator

### DIFF
--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2676,6 +2676,50 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void FilterWithInOperationWithNullableEnumAndNullValue()
+        {
+            // Regression test for https://github.com/OData/odata.net/issues/3491
+            // $filter=Status in (null, 'Active') should work for nullable enum properties.
+            var enumType = new EdmEnumType("NS", "Status");
+            enumType.AddMember("New", new EdmEnumMemberValue(1));
+            enumType.AddMember("Active", new EdmEnumMemberValue(2));
+            enumType.AddMember("Closed", new EdmEnumMemberValue(3));
+
+            var entityType = new EdmEntityType("NS", "Order");
+            entityType.AddKeys(entityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            entityType.AddStructuralProperty("Status", new EdmEnumTypeReference(enumType, isNullable: true));
+
+            var container = new EdmEntityContainer("NS", "Default");
+            var entitySet = container.AddEntitySet("Orders", entityType);
+
+            var model = new EdmModel();
+            model.AddElement(enumType);
+            model.AddElement(entityType);
+            model.AddElement(container);
+
+            // Act - parse "$filter=Status in (null, 'Active')"
+            FilterClause filter = new ODataQueryOptionParser(
+                model, entityType, entitySet,
+                new Dictionary<string, string> { { "$filter", "Status in (null, 'Active')" } }).ParseFilter();
+
+            // Assert
+            InNode inNode = Assert.IsType<InNode>(filter.Expression);
+            Assert.Equal("Status", Assert.IsType<SingleValuePropertyAccessNode>(inNode.Left).Property.Name);
+
+            CollectionConstantNode collection = Assert.IsType<CollectionConstantNode>(inNode.Right);
+            Assert.Equal(2, collection.Items.Count);
+
+            // First item should be null
+            ConstantNode nullItem = Assert.IsType<ConstantNode>(collection.Items[0]);
+            Assert.Null(nullItem.Value);
+
+            // Second item should be the enum value 'Active'
+            ConstantNode activeItem = Assert.IsType<ConstantNode>(collection.Items[1]);
+            ODataEnumValue enumValue = Assert.IsType<ODataEnumValue>(activeItem.Value);
+            Assert.Equal("Active", enumValue.Value);
+        }
+
+        [Fact]
         public void MatchesPatternInFilterWithTheReturnType()
         {
             // Arrange & Act - Filter people whose names match capitalized pattern


### PR DESCRIPTION

Verify that \=Status in (null, 'Active') works correctly for nullable enum properties. The issue was reported against 8.4.3 but is already fixed in dev-9.x.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3491.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
