### PR TITLE
Fix #3491: nullable enum with null in 'in' operator throws invalid enum constant error

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -513,7 +513,12 @@ namespace Microsoft.OData.UriParser
                     }
 
                     // If item is already quoted, keep it; otherwise wrap in single quotes
+                    // Exception: 'null' literal should be kept as-is (not quoted) to represent null value
                     if (token.Length > 0 && (token[0] == '\'' || token[0] == '"'))
+                    {
+                        result.Append(token);
+                    }
+                    else if (token.Equals(NullLiteral, StringComparison.Ordinal))
                     {
                         result.Append(token);
                     }

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/EnumerationTypeTests/EnumerationTypeQueryTests.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/EnumerationTypeTests/EnumerationTypeQueryTests.cs
@@ -603,6 +603,24 @@ public class EnumerationTypeQueryTests : EndToEndTestBase<EnumerationTypeQueryTe
         Assert.Contains(expectedErrorMessage, exception.Message);
     }
 
+    [Fact]
+    public async Task QueryNullableEnumWithNullInOperator_DoesNotThrowParserError()
+    {
+        // Arrange - tests fix for issue #3491: nullable enum with null in 'in' operator.
+        // Before the fix, the URI parser would throw "not a valid enumeration type constant"
+        // because null was being quoted as 'null' and treated as an enum member name.
+        // SkinColor is a nullable Color enum (Color?). No products have SkinColor = null,
+        // so this should return an empty set rather than throwing a parser error.
+        var filter = "SkinColor in (null)";
+        var queryText = $"Products?$filter={filter}";
+
+        // Act - should not throw; before the fix this would throw ODataException
+        List<ODataResource> entries = await TestsHelper.QueryResourceSetsAsync(queryText, MimeTypeODataParameterMinimalMetadata);
+
+        // Assert - no products have null SkinColor, so expect empty result
+        Assert.Empty(entries);
+    }
+
     #endregion
 
     #region Private methods

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/EnumFilterFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/EnumFilterFunctionalTests.cs
@@ -634,6 +634,49 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             action.Throws<ODataException>(Error.Format(SRResources.Binder_IsNotValidEnumConstant, expectedExceptionParameter));
         }
 
+        [Fact]
+        public void ParseFilterWithInOperatorWithNullableEnumAndNullValue()
+        {
+            // Regression test for https://github.com/OData/odata.net/issues/3491
+            // $filter=Color in (null, 'Green') should work for nullable enum properties.
+            string filterQuery = "Color in (null, 'Green')";
+
+            // Act
+            FilterClause filter = ParseFilter(filterQuery, this.userModel, this.entityType, this.entitySet);
+
+            // Assert
+            InNode inNode = filter.Expression.ShouldBeInNode();
+            Assert.IsType<SingleValuePropertyAccessNode>(inNode.Left);
+
+            CollectionConstantNode collection = Assert.IsType<CollectionConstantNode>(inNode.Right);
+            Assert.Equal(2, collection.Collection.Count);
+
+            // First item should be null
+            ConstantNode nullItem = collection.Collection[0];
+            Assert.Null(nullItem.Value);
+
+            // Second item should be the enum value 'Green'
+            ConstantNode greenItem = collection.Collection[1];
+            ODataEnumValue enumValue = Assert.IsType<ODataEnumValue>(greenItem.Value);
+            Assert.Equal("Green", enumValue.Value);
+        }
+
+        [Fact]
+        public void ParseFilterWithInOperatorWithNullableEnumAndOnlyNullValue()
+        {
+            // $filter=Color in (null) should work for nullable enum properties.
+            string filterQuery = "Color in (null)";
+
+            // Act
+            FilterClause filter = ParseFilter(filterQuery, this.userModel, this.entityType, this.entitySet);
+
+            // Assert
+            InNode inNode = filter.Expression.ShouldBeInNode();
+            CollectionConstantNode collection = Assert.IsType<CollectionConstantNode>(inNode.Right);
+            Assert.Single(collection.Collection);
+            Assert.Null(collection.Collection[0].Value);
+        }
+
         private T GetIEdmType<T>(string typeName) where T : IEdmType
         {
             return (T)this.userModel.FindType(typeName);


### PR DESCRIPTION
When using \=Status in (null, 'Active') with a nullable enum property, the null literal was being wrapped in single quotes by NormalizeEnumCollectionItems, turning it into 'null' which was then treated as an invalid enum member name.

Fix: skip quoting for the 'null' literal so it passes through as-is to the JSON reader, which correctly interprets it as a null value.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3491.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
