### PR TITLE
Fix sync deadlock under UI SynchronizationContext (#3540)

### DIFF
--- a/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
@@ -489,7 +489,7 @@ namespace Microsoft.OData.Client
             try
             {
                 // Use HttpCompletionOption.ResponseHeadersRead to shorten the window before cancellation is honoured
-                return await _client.SendAsync(_requestMessage, HttpCompletionOption.ResponseHeadersRead, sendToken).ConfigureAwait(false);
+                return await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, sendToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException ex)
             {

--- a/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
@@ -489,7 +489,7 @@ namespace Microsoft.OData.Client
             try
             {
                 // Use HttpCompletionOption.ResponseHeadersRead to shorten the window before cancellation is honoured
-                return await _client.SendAsync(_requestMessage, HttpCompletionOption.ResponseHeadersRead, sendToken);
+                return await _client.SendAsync(_requestMessage, HttpCompletionOption.ResponseHeadersRead, sendToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException ex)
             {

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
@@ -285,15 +285,14 @@ namespace Microsoft.OData.Client.Tests.Serialization
         }
 
         [Fact]
-        public async Task WhenTimeoutNotSet_HttpClientTimeoutStillApplies()
+        public void GetResponse_DoesNotDeadlock_UnderSingleThreadedSynchronizationContext()
         {
-            // Arrange
-            using (var handler = new MockDelayedHttpClientHandler("success", delayMilliseconds: 5000))
+            // Arrange - simulate a UI SynchronizationContext (WinForms/WPF) that does not pump messages.
+            // Without ConfigureAwait(false) on the internal SendAsync, this would deadlock because
+            // the continuation would try to marshal back to the blocked thread.
+            using (var handler = new MockHttpClientHandler("OK"))
             {
-                var httpClientFactory = new MockHttpClientFactory(handler, new MockHttpClientFactoryOptions
-                {
-                    Timeout = 1
-                });
+                var httpClientFactory = new MockHttpClientFactory(handler);
                 var args = new DataServiceClientRequestMessageArgs(
                     "GET",
                     new Uri("http://localhost"),
@@ -301,20 +300,56 @@ namespace Microsoft.OData.Client.Tests.Serialization
                     headers: new Dictionary<string, string>(),
                     httpClientFactory: httpClientFactory);
 
-                using (var request = new HttpClientRequestMessage(args))
-                {
-                    // Act
-                    Task<IODataResponseMessage> getResponseTask =
-                        Task.Run(() => Task.Factory.FromAsync(request.BeginGetResponse, request.EndGetResponse, null));
+                IODataResponseMessage response = null;
+                Exception caughtException = null;
 
-                    // Assert
-                    await Assert.ThrowsAsync<DataServiceTransportException>(async () =>
+                // Run on a dedicated thread with a non-pumping SynchronizationContext
+                var thread = new Thread(() =>
+                {
+                    SynchronizationContext.SetSynchronizationContext(new NonPumpingSynchronizationContext());
+                    try
                     {
-                        await getResponseTask;
-                    });
-                }
+                        using (var request = new HttpClientRequestMessage(args))
+                        {
+                            response = request.GetResponse();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        caughtException = ex;
+                    }
+                });
+
+                thread.IsBackground = true;
+                thread.Start();
+
+                // Wait with timeout - if it deadlocks, this will fail
+                bool completed = thread.Join(TimeSpan.FromSeconds(10));
+
+                // Assert
+                Assert.True(completed, "GetResponse() deadlocked under a single-threaded SynchronizationContext");
+                Assert.Null(caughtException);
+                Assert.NotNull(response);
             }
         }
 
+        /// <summary>
+        /// A SynchronizationContext that does not pump (simulates WinForms/WPF UI thread behavior).
+        /// Posts are queued but never executed, which causes deadlocks if await continuations
+        /// try to marshal back to this context.
+        /// </summary>
+        private sealed class NonPumpingSynchronizationContext : SynchronizationContext
+        {
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                // Intentionally do NOT execute the callback - simulates a blocked UI thread
+                // that cannot process posted messages.
+            }
+
+            public override void Send(SendOrPostCallback d, object state)
+            {
+                throw new NotSupportedException("Send is not supported on this context.");
+            }
+        }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
@@ -285,6 +285,38 @@ namespace Microsoft.OData.Client.Tests.Serialization
         }
 
         [Fact]
+        public async Task WhenTimeoutNotSet_HttpClientTimeoutStillApplies()
+        {
+            // Arrange
+            using (var handler = new MockDelayedHttpClientHandler("success", delayMilliseconds: 5000))
+            {
+                var httpClientFactory = new MockHttpClientFactory(handler, new MockHttpClientFactoryOptions
+                {
+                    Timeout = 1
+                });
+                var args = new DataServiceClientRequestMessageArgs(
+                    "GET",
+                    new Uri("http://localhost"),
+                    usePostTunneling: false,
+                    headers: new Dictionary<string, string>(),
+                    httpClientFactory: httpClientFactory);
+
+                using (var request = new HttpClientRequestMessage(args))
+                {
+                    // Act
+                    Task<IODataResponseMessage> getResponseTask =
+                        Task.Run(() => Task.Factory.FromAsync(request.BeginGetResponse, request.EndGetResponse, null));
+
+                    // Assert
+                    await Assert.ThrowsAsync<DataServiceTransportException>(async () =>
+                    {
+                        await getResponseTask;
+                    });
+                }
+            }
+        }
+
+        [Fact]
         public void GetResponse_DoesNotDeadlock_UnderSingleThreadedSynchronizationContext()
         {
             // Arrange - simulate a UI SynchronizationContext (WinForms/WPF) that does not pump messages.
@@ -334,9 +366,9 @@ namespace Microsoft.OData.Client.Tests.Serialization
         }
 
         /// <summary>
-        /// A SynchronizationContext that does not pump (simulates WinForms/WPF UI thread behavior).
-        /// Posts are queued but never executed, which causes deadlocks if await continuations
-        /// try to marshal back to this context.
+        /// A SynchronizationContext that discards posted callbacks (simulates WinForms/WPF UI thread behavior).
+        /// Posted continuations are never executed, which causes deadlocks if await continuations
+        /// try to marshal back to this context without ConfigureAwait(false).
         /// </summary>
         private sealed class NonPumpingSynchronizationContext : SynchronizationContext
         {

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
@@ -319,10 +319,11 @@ namespace Microsoft.OData.Client.Tests.Serialization
         [Fact]
         public void GetResponse_DoesNotDeadlock_UnderSingleThreadedSynchronizationContext()
         {
-            // Arrange - simulate a UI SynchronizationContext (WinForms/WPF) that does not pump messages.
-            // Without ConfigureAwait(false) on the internal SendAsync, this would deadlock because
-            // the continuation would try to marshal back to the blocked thread.
-            using (var handler = new MockHttpClientHandler("OK"))
+            // Arrange - use a handler that completes asynchronously (with a small delay)
+            // to ensure the await actually yields and attempts to post the continuation
+            // back to the SynchronizationContext. A synchronous Task.FromResult would not
+            // exercise the deadlock scenario.
+            using (var handler = new MockDelayedHttpClientHandler("OK", delayMilliseconds: 50))
             {
                 var httpClientFactory = new MockHttpClientFactory(handler);
                 var args = new DataServiceClientRequestMessageArgs(
@@ -358,6 +359,12 @@ namespace Microsoft.OData.Client.Tests.Serialization
                 // Wait with timeout - if it deadlocks, this will fail
                 bool completed = thread.Join(TimeSpan.FromSeconds(10));
 
+                if (!completed)
+                {
+                    // Interrupt the stuck thread to avoid leaving it running in the test process
+                    thread.Interrupt();
+                }
+
                 // Assert
                 Assert.True(completed, "GetResponse() deadlocked under a single-threaded SynchronizationContext");
                 Assert.Null(caughtException);
@@ -366,16 +373,17 @@ namespace Microsoft.OData.Client.Tests.Serialization
         }
 
         /// <summary>
-        /// A SynchronizationContext that discards posted callbacks (simulates WinForms/WPF UI thread behavior).
-        /// Posted continuations are never executed, which causes deadlocks if await continuations
-        /// try to marshal back to this context without ConfigureAwait(false).
+        /// A SynchronizationContext that discards posted callbacks without executing them.
+        /// This simulates the deadlock scenario where a blocked thread cannot pump its
+        /// message queue: continuations posted via Post() are lost, so any await without
+        /// ConfigureAwait(false) will hang indefinitely waiting for the continuation to run.
         /// </summary>
         private sealed class NonPumpingSynchronizationContext : SynchronizationContext
         {
             public override void Post(SendOrPostCallback d, object state)
             {
-                // Intentionally do NOT execute the callback - simulates a blocked UI thread
-                // that cannot process posted messages.
+                // Intentionally discard the callback — simulates a thread whose message
+                // queue is blocked and cannot process posted continuations.
             }
 
             public override void Send(SendOrPostCallback d, object state)


### PR DESCRIPTION
Add ConfigureAwait(false) to the HttpClient.SendAsync await in HttpClientRequestMessage.SendInternalAsync. Without this, calling GetResponse() from a thread with a non-pumping SynchronizationContext (WinForms/WPF UI thread) could deadlock because the continuation tried to marshal back to the blocked context.

Added a regression test that exercises GetResponse() under a simulated non-pumping SynchronizationContext to verify it completes without deadlocking.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3540.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
