### PR TITLE
Use ReadOnlySpan<char> to avoid string allocations in hot paths

### DIFF
--- a/src/Microsoft.OData.Core/Json/ODataJsonBatchBodyContentReaderStream.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonBatchBodyContentReaderStream.cs
@@ -307,22 +307,23 @@ namespace Microsoft.OData.Json
             }
 
             contentTypeHeader = contentTypeHeader.Trim();
-            int idx = contentTypeHeader.IndexOf(';', StringComparison.Ordinal);
-            string fullType = idx != -1
-                ? contentTypeHeader.Substring(0, idx)
-                : contentTypeHeader;
+            ReadOnlySpan<char> span = contentTypeHeader.AsSpan();
 
-            int idxSlash = fullType.IndexOf('/', StringComparison.Ordinal);
-            string type = null;
-            string subType = null;
+            int idx = span.IndexOf(';');
+            ReadOnlySpan<char> fullType = idx != -1 ? span.Slice(0, idx) : span;
+
+            int idxSlash = fullType.IndexOf('/');
+            string type;
+            string subType;
             if (idxSlash != -1)
             {
-                type = fullType.Substring(0, idxSlash);
-                subType = fullType.Substring(idxSlash + 1);
+                type = fullType.Slice(0, idxSlash).ToString();
+                subType = fullType.Slice(idxSlash + 1).ToString();
             }
             else
             {
-                type = fullType;
+                type = fullType.ToString();
+                subType = null;
             }
 
             return new ODataMediaType(type, subType);

--- a/src/Microsoft.OData.Core/Json/ODataJsonBatchReader.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonBatchReader.cs
@@ -187,7 +187,8 @@ namespace Microsoft.OData.Json
             int firstColon = url.IndexOf(':', StringComparison.Ordinal);
             if (queryOptionSeparator > 0 && firstColon > 0 && queryOptionSeparator < firstColon)
             {
-                url = url.Substring(0, queryOptionSeparator) + url.Substring(queryOptionSeparator).Replace(":", "%3A", StringComparison.Ordinal);
+                // Only replace colons in the query string portion, avoid allocating intermediate substring for the prefix
+                url = string.Concat(url.AsSpan(0, queryOptionSeparator), url.Substring(queryOptionSeparator).Replace(":", "%3A", StringComparison.Ordinal));
             }
 
             Uri requestUri = new Uri(url, UriKind.RelativeOrAbsolute);

--- a/src/Microsoft.OData.Core/Json/ODataJsonContextUriParser.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonContextUriParser.cs
@@ -337,13 +337,11 @@ namespace Microsoft.OData.Json
                     throw new ODataException(Error.Format(SRResources.ODataJsonContextUriParser_InvalidContextUrl, UriUtils.UriToString(this.parseResult.ContextUri)));
                 }
 
-                string previous = fragment.Substring(0, index + 1);
-
                 // Don't treat Collection(Edm.Type) as SelectExpand segment
-                if (!previous.Equals("Collection", StringComparison.Ordinal))
+                ReadOnlySpan<char> previous = fragment.AsSpan(0, index + 1);
+                if (!previous.Equals("Collection".AsSpan(), StringComparison.Ordinal))
                 {
-                    string selectExpandStr = fragment.Substring(index + 2);
-                    selectExpandStr = selectExpandStr.Substring(0, selectExpandStr.Length - 1);
+                    string selectExpandStr = fragment.Substring(index + 2, fragment.Length - index - 3);
 
                     // Do not treat Key as SelectExpand segment
                     if (KeyPattern.IsMatch(selectExpandStr))
@@ -352,7 +350,7 @@ namespace Microsoft.OData.Json
                     }
 
                     this.parseResult.SelectQueryOption = ExtractSelectQueryOption(selectExpandStr);
-                    fragment = previous;
+                    fragment = fragment.Substring(0, index + 1);
                 }
             }
 

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
@@ -293,12 +293,12 @@ namespace Microsoft.OData.MultipartMixed
 
             httpMethod = requestLine.Substring(0, firstSpaceIndex);               // Request - Http method
             string uriSegment = requestLine.Substring(firstSpaceIndex + 1, lastSpaceIndex - firstSpaceIndex - 1);      // Request - Request uri
-            string httpVersionSegment = requestLine.Substring(lastSpaceIndex + 1);             // Request - Http version
 
-            // Validate HttpVersion
-            if (string.CompareOrdinal(ODataConstants.HttpVersionInBatching, httpVersionSegment) != 0)
+            // Validate HttpVersion - use span comparison to avoid allocation on happy path
+            ReadOnlySpan<char> httpVersionSpan = requestLine.AsSpan(lastSpaceIndex + 1);
+            if (!httpVersionSpan.Equals(ODataConstants.HttpVersionInBatching.AsSpan(), StringComparison.Ordinal))
             {
-                throw new ODataException(Error.Format(SRResources.ODataBatchReaderStream_InvalidHttpVersionSpecified, httpVersionSegment, ODataConstants.HttpVersionInBatching));
+                throw new ODataException(Error.Format(SRResources.ODataBatchReaderStream_InvalidHttpVersionSpecified, requestLine.Substring(lastSpaceIndex + 1), ODataConstants.HttpVersionInBatching));
             }
 
             // NOTE: this method will throw if the method is not recognized.
@@ -346,19 +346,19 @@ namespace Microsoft.OData.MultipartMixed
                 throw new ODataException(Error.Format(SRResources.ODataBatchReaderStream_InvalidResponseLine, responseLine));
             }
 
-            string httpVersionSegment = responseLine.Substring(0, firstSpaceIndex);
-            string statusCodeSegment = responseLine.Substring(firstSpaceIndex + 1, secondSpaceIndex - firstSpaceIndex - 1);
-
-            // Validate HttpVersion
-            if (string.CompareOrdinal(ODataConstants.HttpVersionInBatching, httpVersionSegment) != 0)
+            // Validate HttpVersion - use span comparison to avoid allocation on happy path
+            ReadOnlySpan<char> httpVersionSpan = responseLine.AsSpan(0, firstSpaceIndex);
+            if (!httpVersionSpan.Equals(ODataConstants.HttpVersionInBatching.AsSpan(), StringComparison.Ordinal))
             {
-                throw new ODataException(Error.Format(SRResources.ODataBatchReaderStream_InvalidHttpVersionSpecified, httpVersionSegment, ODataConstants.HttpVersionInBatching));
+                throw new ODataException(Error.Format(SRResources.ODataBatchReaderStream_InvalidHttpVersionSpecified, responseLine.Substring(0, firstSpaceIndex), ODataConstants.HttpVersionInBatching));
             }
 
+            // Parse status code using span to avoid allocation on happy path
+            ReadOnlySpan<char> statusCodeSpan = responseLine.AsSpan(firstSpaceIndex + 1, secondSpaceIndex - firstSpaceIndex - 1);
             int intResult;
-            if (!Int32.TryParse(statusCodeSegment, out intResult))
+            if (!Int32.TryParse(statusCodeSpan, out intResult))
             {
-                throw new ODataException(Error.Format(SRResources.ODataBatchReaderStream_NonIntegerHttpStatusCode, statusCodeSegment));
+                throw new ODataException(Error.Format(SRResources.ODataBatchReaderStream_NonIntegerHttpStatusCode, responseLine.Substring(firstSpaceIndex + 1, secondSpaceIndex - firstSpaceIndex - 1)));
             }
 
             return intResult;

--- a/src/Microsoft.OData.Core/SelectedPropertiesNode.cs
+++ b/src/Microsoft.OData.Core/SelectedPropertiesNode.cs
@@ -502,10 +502,9 @@ namespace Microsoft.OData
             List<string> result = new List<string>();
             int parenBalance = 0;
             int startIdx = 0;
-            char[] chars = selectClause.ToCharArray();
-            for (int i = 0; i < chars.Length; i++)
+            for (int i = 0; i < selectClause.Length; i++)
             {
-                switch (chars[i])
+                switch (selectClause[i])
                 {
                     case '(':
                         ++parenBalance;
@@ -516,11 +515,10 @@ namespace Microsoft.OData
                     case ItemSeparator:
                         if (parenBalance == 0)
                         {
-                            string item = selectClause.Substring(startIdx, i - startIdx);
-                            if (item.Length != 0)
+                            if (i > startIdx)
                             {
                                 // Add non-empty item only.
-                                result.Add(item);
+                                result.Add(selectClause.Substring(startIdx, i - startIdx));
                             }
 
                             startIdx = i + 1;
@@ -530,10 +528,10 @@ namespace Microsoft.OData
                 }
             }
 
-            if (startIdx < chars.Length)
+            if (startIdx < selectClause.Length)
             {
                 // Add the last item, which is non-empty.
-                result.Add(selectClause.Substring(startIdx, chars.Length - startIdx));
+                result.Add(selectClause.Substring(startIdx, selectClause.Length - startIdx));
             }
 
             return result.ToArray();
@@ -613,7 +611,7 @@ namespace Microsoft.OData
             int idxLP = item.IndexOf('(', StringComparison.Ordinal);
             if (idxLP == -1
                 || !item.EndsWith(")", StringComparison.Ordinal)
-                || !IsNavigationPropertyToken(item.Substring(0, idxLP)))
+                || !IsNavigationPropertyToken(item.AsSpan(0, idxLP)))
             {
                 // selected item is not properly parenthesized, or is an operation token.
                 return false;
@@ -627,7 +625,7 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="token">The token to check.</param>
         /// <returns>true if token can be resolved to a navigation property; false otherwise.</returns>
-        private bool IsNavigationPropertyToken(string token)
+        private bool IsNavigationPropertyToken(ReadOnlySpan<char> token)
         {
             const char NameSpaceSeparator = '.';
 
@@ -638,32 +636,42 @@ namespace Microsoft.OData
              #4. otherwise, it's a navigation property
              */
 
-            // For better readability, set the value in if-else branches corresponding to decision tree above.
-            bool found;
-            if (token.IndexOf(NameSpaceSeparator, StringComparison.Ordinal) != -1)
+            // #1
+            if (token.IndexOf(NameSpaceSeparator) != -1)
             {
-                // #1
-                found = false;
-            }
-            else if (this.structuredType == null || this.structuredType.NavigationProperties().Any(_ => _.Name.Equals(token, StringComparison.Ordinal)))
-            {
-                // #2
-                // Note that action and function names in a contextUrl *SHOULD* always be qualified, 
-                // So if we can't validate against the structured type, should assume it's a nav prop
-                found = true;
-            }
-            else if (this.edmModel != null && this.edmModel.FindBoundOperations(this.structuredType).Any(op => op.Name.Equals(token, StringComparison.Ordinal)))
-            {
-                // #3
-                found = false;
-            }
-            else
-            {
-                // #4
-                found = true;
+                return false;
             }
 
-            return found;
+            // #2
+            // Note that action and function names in a contextUrl *SHOULD* always be qualified,
+            // So if we can't validate against the structured type, should assume it's a nav prop
+            if (this.structuredType == null)
+            {
+                return true;
+            }
+
+            foreach (var navProp in this.structuredType.NavigationProperties())
+            {
+                if (token.Equals(navProp.Name.AsSpan(), StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            // #3
+            if (this.edmModel != null)
+            {
+                foreach (var op in this.edmModel.FindBoundOperations(this.structuredType))
+                {
+                    if (token.Equals(op.Name.AsSpan(), StringComparison.Ordinal))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            // #4
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
Replace Substring calls with ReadOnlySpan<char>-based processing where the substring was only used for comparison or parsing, eliminating unnecessary heap allocations:

- SelectedPropertiesNode: Remove ToCharArray() allocation in GetTopLevelItems; change IsNavigationPropertyToken to accept ReadOnlySpan<char> so IsValidExpandToken avoids allocating a substring just for a navigation property name check.

- ODataJsonContextUriParser: Use span comparison against 'Collection' literal instead of allocating a substring; combine two Substring calls into one for select/expand extraction.

- ODataMultipartMixedBatchReader: Use span for HTTP version validation and Int32.TryParse(span) for status code parsing, avoiding string allocations on the happy path of every batch response.

- ODataJsonBatchBodyContentReaderStream: Parse content-type using span slicing, eliminating the intermediate 'fullType' string allocation.

- ODataJsonBatchReader: Use string.Concat(ReadOnlySpan, string) to avoid allocating an intermediate prefix substring during URL escaping.

All 11,433 unit tests pass.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
