### PR TITLE
Add AggregateLimit setting to prevent SO in ParseAggregateExpression

### DIFF
--- a/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.OData.UriParser.ODataUriParserSettings.AggregateLimit.get -> int
+Microsoft.OData.UriParser.ODataUriParserSettings.AggregateLimit.set -> void

--- a/src/Microsoft.OData.Core/SRResources.Designer.cs
+++ b/src/Microsoft.OData.Core/SRResources.Designer.cs
@@ -7032,6 +7032,15 @@ namespace Microsoft.OData.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The aggregate expression depth exceeded the maximum allowed depth of {0}. You can adjust the depth limit by setting the &apos;ODataUriParserSettings.AggregateLimit&apos; property..
+        /// </summary>
+        internal static string UriQueryExpressionParser_AggregateExpressionDepthLimitExceeded {
+            get {
+                return ResourceManager.GetString("UriQueryExpressionParser_AggregateExpressionDepthLimitExceeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unrecognized &apos;{0}&apos; literal &apos;{1}&apos; at &apos;{2}&apos; in &apos;{3}&apos;..
         /// </summary>
         internal static string UriQueryExpressionParser_UnrecognizedLiteral {

--- a/src/Microsoft.OData.Core/SRResources.resx
+++ b/src/Microsoft.OData.Core/SRResources.resx
@@ -1835,6 +1835,9 @@
   <data name="UriQueryExpressionParser_TooDeep" xml:space="preserve">
     <value>Recursion depth exceeded allowed limit.</value>
   </data>
+  <data name="UriQueryExpressionParser_AggregateExpressionDepthLimitExceeded" xml:space="preserve">
+    <value>The aggregate expression depth exceeded the maximum allowed depth of {0}. You can adjust the depth limit by setting the 'ODataUriParserSettings.AggregateLimit' property.</value>
+  </data>
   <data name="UriQueryExpressionParser_ExpressionExpected" xml:space="preserve">
     <value>Expression expected at position {0} in '{1}'.</value>
   </data>

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -425,7 +425,8 @@ namespace Microsoft.OData.UriParser
             UriQueryExpressionParser expressionParser = new UriQueryExpressionParser(
                 configuration.Model,
                 configuration.Settings.FilterLimit,
-                configuration.EnableCaseInsensitiveUriFunctionIdentifier);
+                configuration.EnableCaseInsensitiveUriFunctionIdentifier,
+                maxAggregateExpressionDepth: configuration.Settings.AggregateLimit);
             var applyTokens = expressionParser.ParseApply(apply.AsMemory());
 
             // Bind it to metadata

--- a/src/Microsoft.OData.Core/UriParser/ODataUriParserSettings.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataUriParserSettings.cs
@@ -39,6 +39,11 @@ namespace Microsoft.OData.UriParser
         internal const int DefaultSearchLimit = 100;
 
         /// <summary>
+        /// Default recursive call limit for aggregate expressions.
+        /// </summary>
+        internal const int DefaultAggregateLimit = 100;
+
+        /// <summary>
         /// the recursive depth of the Syntactic tree for a filter clause
         /// </summary>
         private int filterLimit;
@@ -74,6 +79,11 @@ namespace Microsoft.OData.UriParser
         private int searchLimit;
 
         /// <summary>
+        /// the maximum depth of the syntactic tree for aggregate expressions
+        /// </summary>
+        private int aggregateLimit;
+
+        /// <summary>
         /// Initializes a new instance of <see cref="ODataUriParserSettings"/> with default values.
         /// </summary>
         public ODataUriParserSettings()
@@ -83,6 +93,7 @@ namespace Microsoft.OData.UriParser
             this.PathLimit = DefaultPathLimit;
             this.SelectExpandLimit = DefaultSelectExpandLimit;
             this.SearchLimit = DefaultSearchLimit;
+            this.AggregateLimit = DefaultAggregateLimit;
 
             this.MaximumExpansionDepth = int.MaxValue;
             this.MaximumExpansionCount = int.MaxValue;
@@ -97,6 +108,7 @@ namespace Microsoft.OData.UriParser
                 OrderByLimit = this.OrderByLimit,
                 PathLimit = this.PathLimit,
                 SearchLimit = this.SearchLimit,
+                AggregateLimit = this.AggregateLimit,
                 MaximumExpansionDepth = this.MaximumExpansionDepth,
                 MaximumExpansionCount = this.MaximumExpansionCount,
                 EnableParsingKeyAsSegment = this.EnableParsingKeyAsSegment
@@ -295,6 +307,29 @@ namespace Microsoft.OData.UriParser
                 }
 
                 this.searchLimit = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum recursive depth for aggregate expressions, which limits the maximum depth of the tree that can be parsed by the
+        /// syntactic parser. This guarantees a set level of performance.
+        /// </summary>
+        /// <exception cref="ODataException">Throws if the input value is negative.</exception>
+        internal int AggregateLimit
+        {
+            get
+            {
+                return this.aggregateLimit;
+            }
+
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ODataException(SRResources.UriParser_NegativeLimit);
+                }
+
+                this.aggregateLimit = value;
             }
         }
     }

--- a/src/Microsoft.OData.Core/UriParser/ODataUriParserSettings.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataUriParserSettings.cs
@@ -315,7 +315,7 @@ namespace Microsoft.OData.UriParser
         /// syntactic parser. This guarantees a set level of performance.
         /// </summary>
         /// <exception cref="ODataException">Throws if the input value is negative.</exception>
-        internal int AggregateLimit
+        public int AggregateLimit
         {
             get
             {

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandOptionParser.cs
@@ -71,6 +71,7 @@ namespace Microsoft.OData.UriParser
             this.maxRecursionDepth = maxRecursionDepth;
             this.enableCaseInsensitiveBuiltinIdentifier = enableCaseInsensitiveBuiltinIdentifier;
             this.enableNoDollarQueryOptions = enableNoDollarQueryOptions;
+            this.MaxAggregateDepth = ODataUriParserSettings.DefaultAggregateLimit;
         }
 
         /// <summary>
@@ -108,6 +109,11 @@ namespace Microsoft.OData.UriParser
         /// The maximum depth for $search nested in $expand.
         /// </summary>
         internal int MaxSearchDepth { get; set; }
+
+        /// <summary>
+        /// The maximum depth for aggregate expressions nested in $expand.
+        /// </summary>
+        internal int MaxAggregateDepth { get; set; }
 
         /// <summary>
         /// Building off a PathSegmentToken, continue parsing any select options (nested $filter, $expand, etc)
@@ -680,7 +686,7 @@ namespace Microsoft.OData.UriParser
             this.lexer.NextToken();
             ReadOnlyMemory<char> applyText = UriParserHelper.ReadQueryOption(this.lexer);
 
-            UriQueryExpressionParser applyParser = new UriQueryExpressionParser(this.model, this.MaxOrderByDepth, enableCaseInsensitiveBuiltinIdentifier);
+            UriQueryExpressionParser applyParser = new UriQueryExpressionParser(this.model, this.MaxOrderByDepth, enableCaseInsensitiveBuiltinIdentifier, maxAggregateExpressionDepth: this.MaxAggregateDepth);
             return applyParser.ParseApply(applyText);
         }
     }

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandOptionParser.cs
@@ -590,7 +590,10 @@ namespace Microsoft.OData.UriParser
                 targetStructuredType,
                 this.maxRecursionDepth - 1,
                 this.enableCaseInsensitiveBuiltinIdentifier,
-                this.enableNoDollarQueryOptions);
+                this.enableNoDollarQueryOptions)
+            {
+                MaxAggregateDepth = this.MaxAggregateDepth
+            };
 
             return innerSelectParser.ParseSelect();
         }
@@ -629,7 +632,10 @@ namespace Microsoft.OData.UriParser
                 targetStructuredType,
                 this.maxRecursionDepth - 1,
                 this.enableCaseInsensitiveBuiltinIdentifier,
-                this.enableNoDollarQueryOptions);
+                this.enableNoDollarQueryOptions)
+            {
+                MaxAggregateDepth = this.MaxAggregateDepth
+            };
 
             return innerExpandParser.ParseExpand();
         }

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandParser.cs
@@ -95,6 +95,7 @@ namespace Microsoft.OData.UriParser
             this.MaxFilterDepth = maxRecursiveDepth;
             this.MaxOrderByDepth = maxRecursiveDepth;
             this.MaxSearchDepth = maxRecursiveDepth;
+            this.MaxAggregateDepth = ODataUriParserSettings.DefaultAggregateLimit;
 
             // Sets up our lexer. We don't turn useSemicolonDelimiter on since the parsing code for expand options,
             // which is the only thing that needs it, is in a different class that uses it's own lexer.
@@ -159,7 +160,8 @@ namespace Microsoft.OData.UriParser
                     {
                         MaxFilterDepth = MaxFilterDepth,
                         MaxOrderByDepth = MaxOrderByDepth,
-                        MaxSearchDepth = MaxSearchDepth
+                        MaxSearchDepth = MaxSearchDepth,
+                        MaxAggregateDepth = MaxAggregateDepth
                     };
                 }
 
@@ -186,6 +188,11 @@ namespace Microsoft.OData.UriParser
         /// The maximum depth for $search nested in $expand.
         /// </summary>
         internal int MaxSearchDepth { get; set; }
+
+        /// <summary>
+        /// The maximum depth for aggregate expressions nested in $expand.
+        /// </summary>
+        internal int MaxAggregateDepth { get; set; }
 
         /// <summary>
         /// Parses a full $select expression.

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandSyntacticParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandSyntacticParser.cs
@@ -38,7 +38,8 @@ namespace Microsoft.OData.UriParser
                 configuration.EnableCaseInsensitiveUriFunctionIdentifier,
                 configuration.EnableNoDollarQueryOptions)
             {
-                MaxPathDepth = configuration.Settings.PathLimit
+                MaxPathDepth = configuration.Settings.PathLimit,
+                MaxAggregateDepth = configuration.Settings.AggregateLimit
             };
             selectTree = selectParser.ParseSelect();
 

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandSyntacticParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandSyntacticParser.cs
@@ -54,7 +54,8 @@ namespace Microsoft.OData.UriParser
                 MaxPathDepth = configuration.Settings.PathLimit,
                 MaxFilterDepth = configuration.Settings.FilterLimit,
                 MaxOrderByDepth = configuration.Settings.OrderByLimit,
-                MaxSearchDepth = configuration.Settings.SearchLimit
+                MaxSearchDepth = configuration.Settings.SearchLimit,
+                MaxAggregateDepth = configuration.Settings.AggregateLimit
             };
             expandTree = expandParser.ParseExpand();
         }

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -114,6 +114,7 @@ namespace Microsoft.OData.UriParser
         {
             ExceptionUtils.CheckArgumentNotNull(model, "model");
             Debug.Assert(maxDepth >= 0, "maxDepth >= 0");
+            Debug.Assert(maxAggregateExpressionDepth >= 0, "maxAggregateExpressionDepth >= 0");
 
             this.model = model;
             this.maxDepth = maxDepth;

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -36,6 +36,11 @@ namespace Microsoft.OData.UriParser
         private readonly int maxDepth;
 
         /// <summary>
+        /// The maximum depth allowed for aggregate expression recursion.
+        /// </summary>
+        private readonly int maxAggregateExpressionDepth;
+
+        /// <summary>
         /// List of supported $apply keywords
         /// </summary>
         private static readonly string supportedKeywords = string.Join("|", new string[] { ExpressionConstants.KeywordAggregate, ExpressionConstants.KeywordFilter, ExpressionConstants.KeywordGroupBy, ExpressionConstants.KeywordCompute, ExpressionConstants.KeywordExpand });
@@ -104,7 +109,8 @@ namespace Microsoft.OData.UriParser
         /// <param name="maxDepth">The maximum depth of each part of the query - a recursion limit.</param>
         /// <param name="enableCaseInsensitiveBuiltinIdentifier">Whether to allow case insensitive for builtin identifier.</param>
         /// <param name="enableNoDollarQueryOptions">Whether to allow no-dollar query options.</param>
-        internal UriQueryExpressionParser(IEdmModel model, int maxDepth, bool enableCaseInsensitiveBuiltinIdentifier = false, bool enableNoDollarQueryOptions = false)
+        /// <param name="maxAggregateExpressionDepth">The maximum depth for aggregate expression recursion. Defaults to <see cref="ODataUriParserSettings.DefaultAggregateLimit"/>.</param>
+        internal UriQueryExpressionParser(IEdmModel model, int maxDepth, bool enableCaseInsensitiveBuiltinIdentifier = false, bool enableNoDollarQueryOptions = false, int maxAggregateExpressionDepth = ODataUriParserSettings.DefaultAggregateLimit)
         {
             ExceptionUtils.CheckArgumentNotNull(model, "model");
             Debug.Assert(maxDepth >= 0, "maxDepth >= 0");
@@ -113,6 +119,7 @@ namespace Microsoft.OData.UriParser
             this.maxDepth = maxDepth;
             this.enableCaseInsensitiveBuiltinIdentifier = enableCaseInsensitiveBuiltinIdentifier;
             this.enableNoDollarQueryOptions = enableNoDollarQueryOptions;
+            this.maxAggregateExpressionDepth = maxAggregateExpressionDepth;
         }
 
         /// <summary>
@@ -517,6 +524,12 @@ namespace Microsoft.OData.UriParser
 
         internal AggregateTokenBase ParseAggregateExpression()
         {
+            // Check depth limit before recursing
+            if (this.parseAggregateExpressionDepth >= this.maxAggregateExpressionDepth)
+            {
+                throw new ODataException(Error.Format(SRResources.UriQueryExpressionParser_AggregateExpressionDepthLimitExceeded, this.maxAggregateExpressionDepth));
+            }
+
             try
             {
                 this.parseAggregateExpressionDepth++;

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParseSettingsTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParseSettingsTests.cs
@@ -13,9 +13,25 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.Equal(ODataUriParserSettings.DefaultPathLimit, settings.PathLimit);
             Assert.Equal(ODataUriParserSettings.DefaultSelectExpandLimit, settings.SelectExpandLimit);
             Assert.Equal(ODataUriParserSettings.DefaultSearchLimit, settings.SearchLimit);
+            Assert.Equal(ODataUriParserSettings.DefaultAggregateLimit, settings.AggregateLimit);
             Assert.Equal(int.MaxValue, settings.MaximumExpansionDepth);
             Assert.Equal(int.MaxValue, settings.MaximumExpansionCount);
             Assert.True(settings.EnableParsingKeyAsSegment);
+        }
+
+        [Fact]
+        public void AggregateLimitCanBeSet()
+        {
+            var settings = new ODataUriParserSettings();
+            settings.AggregateLimit = 50;
+            Assert.Equal(50, settings.AggregateLimit);
+        }
+
+        [Fact]
+        public void AggregateLimitNegativeValueThrows()
+        {
+            var settings = new ODataUriParserSettings();
+            Assert.Throws<ODataException>(() => settings.AggregateLimit = -1);
         }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -2216,5 +2216,23 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.Single(transformations);
             Assert.IsType<AggregateTransformationNode>(transformations[0]);
         }
+
+        [Fact]
+        public void ParseNestedExpandWithApplyAggregateLimitShouldBeHonored()
+        {
+            // Verify that AggregateLimit is propagated to nested $expand parsing
+            // $expand=MyPaintings($apply=aggregate(Value with sum as TotalValue))
+            var uriParser = new ODataUriParser(
+                HardCodedTestModel.TestModel,
+                ServiceRoot,
+                new Uri("http://host/People?$expand=MyPaintings($apply=aggregate(Value with sum as TotalValue))"))
+            {
+                Settings = { AggregateLimit = 0 }
+            };
+
+            // AggregateLimit of 0 should reject even a simple aggregate inside nested $expand
+            Action parse = () => uriParser.ParseSelectAndExpand();
+            Assert.Throws<ODataException>(parse);
+        }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -2187,10 +2187,11 @@ namespace Microsoft.OData.Tests.UriParser
         public void ParseApplyWithAggregateLimitExceededShouldThrow()
         {
             // Set up a parser with a low AggregateLimit
+            // Entity-set aggregation syntax: aggregate(NavProp(NavProp(expr with method as alias)))
             var uriParser = new ODataUriParser(
                 HardCodedTestModel.TestModel,
                 ServiceRoot,
-                new Uri("http://host/People?$apply=aggregate(MyPaintings(aggregate(Owner(aggregate(MyPaintings(aggregate(Value with sum as Total)))))))"))
+                new Uri("http://host/People?$apply=aggregate(MyPaintings(Owner(MyPaintings(Value with sum as Total))))"))
             {
                 Settings = { AggregateLimit = 3 }
             };

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -2182,5 +2182,39 @@ namespace Microsoft.OData.Tests.UriParser
 
             return model;
         }
+
+        [Fact]
+        public void ParseApplyWithAggregateLimitExceededShouldThrow()
+        {
+            // Set up a parser with a low AggregateLimit
+            var uriParser = new ODataUriParser(
+                HardCodedTestModel.TestModel,
+                ServiceRoot,
+                new Uri("http://host/People?$apply=aggregate(MyPaintings(aggregate(Owner(aggregate(MyPaintings(aggregate(Value with sum as Total)))))))"))
+            {
+                Settings = { AggregateLimit = 3 }
+            };
+
+            // Parsing should throw because the nesting depth (4) exceeds the aggregate limit (3)
+            Action parse = () => uriParser.ParseApply();
+            Assert.Throws<ODataException>(parse);
+        }
+
+        [Fact]
+        public void ParseApplyWithAggregateWithinLimitShouldSucceed()
+        {
+            // Set up a parser with default AggregateLimit
+            var uriParser = new ODataUriParser(
+                HardCodedTestModel.TestModel,
+                ServiceRoot,
+                new Uri("http://host/People?$apply=aggregate(ID with sum as TotalId)"));
+
+            // Parsing should succeed for a simple aggregate within default limit
+            var applyClause = uriParser.ParseApply();
+            Assert.NotNull(applyClause);
+            var transformations = applyClause.Transformations.ToList();
+            Assert.Single(transformations);
+            Assert.IsType<AggregateTransformationNode>(transformations[0]);
+        }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -2197,7 +2197,7 @@ namespace Microsoft.OData.Tests.UriParser
 
             // Parsing should throw because the nesting depth (4) exceeds the aggregate limit (3)
             Action parse = () => uriParser.ParseApply();
-            Assert.Throws<ODataException>(parse);
+            parse.Throws<ODataException>(Error.Format(SRResources.UriQueryExpressionParser_AggregateExpressionDepthLimitExceeded, 3));
         }
 
         [Fact]
@@ -2232,7 +2232,7 @@ namespace Microsoft.OData.Tests.UriParser
 
             // AggregateLimit of 0 should reject even a simple aggregate inside nested $expand
             Action parse = () => uriParser.ParseSelectAndExpand();
-            Assert.Throws<ODataException>(parse);
+            parse.Throws<ODataException>(Error.Format(SRResources.UriQueryExpressionParser_AggregateExpressionDepthLimitExceeded, 0));
         }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
@@ -1421,5 +1421,51 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         }
 
         #endregion
+
+        #region ParseAggregateExpression depth limit
+
+        [Fact]
+        public void ParseAggregateExpressionExceedingDepthLimitShouldThrow()
+        {
+            // Create a parser with a very low aggregate depth limit
+            var parser = new UriQueryExpressionParser(HardCodedTestModel.TestModel, 50, maxAggregateExpressionDepth: 2);
+
+            // Build a deeply nested aggregate: aggregate(Products(aggregate(Items(aggregate(Price with sum as Total)))))
+            // This has 3 levels of nesting which exceeds the limit of 2
+            string apply = "aggregate(Products(aggregate(Items(aggregate(Price with sum as Total)))))";
+
+            Action parse = () => parser.ParseApply(apply);
+            parse.Throws<ODataException>(Error.Format(SRResources.UriQueryExpressionParser_AggregateExpressionDepthLimitExceeded, 2));
+        }
+
+        [Fact]
+        public void ParseAggregateExpressionWithinDepthLimitShouldSucceed()
+        {
+            // Create a parser with aggregate depth limit of 2
+            var parser = new UriQueryExpressionParser(HardCodedTestModel.TestModel, 50, maxAggregateExpressionDepth: 2);
+
+            // A single aggregate expression should succeed (depth = 1)
+            string apply = "aggregate(UnitPrice with sum as TotalPrice)";
+
+            IEnumerable<QueryToken> result = parser.ParseApply(apply);
+            Assert.NotNull(result);
+            Assert.Single(result);
+        }
+
+        [Fact]
+        public void ParseAggregateExpressionDefaultDepthLimitShouldBeApplied()
+        {
+            // Default parser should have the default aggregate limit
+            var parser = new UriQueryExpressionParser(HardCodedTestModel.TestModel, 50);
+
+            // A single aggregate expression should succeed with default limits
+            string apply = "aggregate(UnitPrice with sum as TotalPrice)";
+
+            IEnumerable<QueryToken> result = parser.ParseApply(apply);
+            Assert.NotNull(result);
+            Assert.Single(result);
+        }
+
+        #endregion
     }
 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
@@ -1430,9 +1430,9 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             // Create a parser with a very low aggregate depth limit
             var parser = new UriQueryExpressionParser(HardCodedTestModel.TestModel, 50, maxAggregateExpressionDepth: 2);
 
-            // Build a deeply nested aggregate: aggregate(Products(aggregate(Items(aggregate(Price with sum as Total)))))
+            // Build a deeply nested entity-set aggregate: aggregate(Products(Items(Price with sum as Total)))
             // This has 3 levels of nesting which exceeds the limit of 2
-            string apply = "aggregate(Products(aggregate(Items(aggregate(Price with sum as Total)))))";
+            string apply = "aggregate(Products(Items(Price with sum as Total)))";
 
             Action parse = () => parser.ParseApply(apply);
             parse.Throws<ODataException>(Error.Format(SRResources.UriQueryExpressionParser_AggregateExpressionDepthLimitExceeded, 2));

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
@@ -1453,9 +1453,9 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         }
 
         [Fact]
-        public void ParseAggregateExpressionDefaultDepthLimitShouldBeApplied()
+        public void ParseAggregateExpressionWithDefaultParserShouldSucceedForShallowExpression()
         {
-            // Default parser should have the default aggregate limit
+            // Default parser should have the default aggregate limit (100)
             var parser = new UriQueryExpressionParser(HardCodedTestModel.TestModel, 50);
 
             // A single aggregate expression should succeed with default limits
@@ -1464,6 +1464,18 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             IEnumerable<QueryToken> result = parser.ParseApply(apply);
             Assert.NotNull(result);
             Assert.Single(result);
+        }
+
+        [Fact]
+        public void ParseAggregateExpressionWithDepthLimitOfZeroShouldThrowImmediately()
+        {
+            // A limit of 0 should reject even the simplest aggregate
+            var parser = new UriQueryExpressionParser(HardCodedTestModel.TestModel, 50, maxAggregateExpressionDepth: 0);
+
+            string apply = "aggregate(UnitPrice with sum as TotalPrice)";
+
+            Action parse = () => parser.ParseApply(apply);
+            parse.Throws<ODataException>(Error.Format(SRResources.UriQueryExpressionParser_AggregateExpressionDepthLimitExceeded, 0));
         }
 
         #endregion


### PR DESCRIPTION
ParseAggregateExpression() has mutual recursion with ParseAggregateExpressions() via entity set aggregation (e.g., Products(aggregate(...))). The depth counter was tracked but never checked against a limit, allowing unbounded recursion.

Changes:
- Add AggregateLimit property to ODataUriParserSettings (default: 100)
- Add maxAggregateExpressionDepth parameter to UriQueryExpressionParser
- Check depth in ParseAggregateExpression() before recursing
- Thread the setting through ODataQueryOptionParser, SelectExpandParser, SelectExpandOptionParser, and SelectExpandSyntacticParser
- Add descriptive error message with the current limit value and guidance on how to configure it via ODataUriParserSettings.AggregateLimit
- Add unit tests for the depth guard and settings property

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
