### PR TITLE
Fix async oversights from PR #3474: ConfigureAwait, exception wrapping, and pre-cancellation

### DIFF
--- a/src/Microsoft.OData.Client/BulkUpdateSaveResult.cs
+++ b/src/Microsoft.OData.Client/BulkUpdateSaveResult.cs
@@ -226,7 +226,7 @@ namespace Microsoft.OData.Client
 
             try
             {
-                this.batchResponseMessage = await this.RequestInfo.GetResponseAsync(bulkUpdateRequestMessage, false, cancellationToken);
+                this.batchResponseMessage = await this.RequestInfo.GetResponseAsync(bulkUpdateRequestMessage, false, cancellationToken).ConfigureAwait(false);
                 this.responseStream = this.batchResponseMessage.GetStream();
                 this.HandleBulkUpdateResponse(this.batchResponseMessage, responseStream);
             }

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -1879,7 +1879,7 @@ namespace Microsoft.OData.Client
         /// <param name="operationParameters">The operation parameters used.</param>
         public async virtual Task<OperationResponse> ExecuteAsync(Uri requestUri, string httpMethod, CancellationToken cancellationToken, params OperationParameter[] operationParameters)
         {
-            QueryOperationResponse<object> result = await ExecuteAsyncInternal<object>(requestUri, httpMethod, false, cancellationToken, operationParameters);
+            QueryOperationResponse<object> result = await ExecuteAsyncInternal<object>(requestUri, httpMethod, false, cancellationToken, operationParameters).ConfigureAwait(false);
             if (result.Any())
             {
                 throw new DataServiceClientException(SRResources.Context_ExecuteExpectedVoidResponse);

--- a/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
@@ -287,7 +287,7 @@ namespace Microsoft.OData.Client
         /// Pages are fetched on-demand as you iterate through the results.
         /// </summary>
         /// <remarks>
-        /// Use this method for large result sets or when you want to process the results incrementaly.
+        /// Use this method for large result sets or when you want to process the results incrementally.
         /// Network requests for additional pages are made as you iterate through the results.
         /// For small result sets where you need all results upfront, consider using <see cref="GetAllPagesAsync(CancellationToken)" /> instead.
         /// </remarks>

--- a/src/Microsoft.OData.Client/DeepInsertSaveResult.cs
+++ b/src/Microsoft.OData.Client/DeepInsertSaveResult.cs
@@ -147,7 +147,7 @@ namespace Microsoft.OData.Client
 
             try
             {
-                this.batchResponseMessage = await this.RequestInfo.GetResponseAsync(deepInsertRequestMessage, false, cancellationToken);
+                this.batchResponseMessage = await this.RequestInfo.GetResponseAsync(deepInsertRequestMessage, false, cancellationToken).ConfigureAwait(false);
                 this.responseStream = this.batchResponseMessage.GetStream();
             }
             catch (DataServiceTransportException ex)

--- a/src/Microsoft.OData.Client/QueryResult.cs
+++ b/src/Microsoft.OData.Client/QueryResult.cs
@@ -270,9 +270,9 @@ namespace Microsoft.OData.Client
                     this.Request.SetRequestStream(this.requestContentStream);
                 }
 
-                IODataResponseMessage response = await this.RequestInfo.GetResponseAsync(this.Request, true, cancellationToken);
+                IODataResponseMessage response = await this.RequestInfo.GetResponseAsync(this.Request, true, cancellationToken).ConfigureAwait(false);
                 this.SetHttpWebResponse(Util.NullCheck(response, InternalError.InvalidGetResponse));
-                await this.ProcessResponseStreamAsync(cancellationToken);
+                await this.ProcessResponseStreamAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -770,7 +770,7 @@ namespace Microsoft.OData.Client
 
                 Byte[] buffer = this.GetAsyncResponseStreamCopyBuffer();
 
-                long copied = await WebUtil.CopyStreamAsync(stream, copy, buffer, cancellationToken);
+                long copied = await WebUtil.CopyStreamAsync(stream, copy, buffer, cancellationToken).ConfigureAwait(false);
 
                 this.FinalizeStreamCopy(copy, copied);
                 this.PutAsyncResponseStreamCopyBuffer(buffer);

--- a/src/Microsoft.OData.Client/Serialization/DataServiceClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/DataServiceClientRequestMessage.cs
@@ -154,6 +154,10 @@ namespace Microsoft.OData.Client
                 return Task.FromCanceled<IODataResponseMessage>(cancellationToken);
             }
 
+            // cancellationToken is not forwarded to GetResponse() because the synchronous GetResponse()
+            // does not accept a cancellation token. Cancellation is only honoured before the call starts.
+            // Subclasses that override GetResponseAsync (e.g. HttpClientRequestMessage) can honour the
+            // token throughout the full async operation.
             try
             {
                 return Task.FromResult(GetResponse());

--- a/src/Microsoft.OData.Client/Serialization/DataServiceClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/DataServiceClientRequestMessage.cs
@@ -149,6 +149,11 @@ namespace Microsoft.OData.Client
         /// <returns>A task that represents the asynchronous operation. The task result contains the response message.</returns>
         public virtual Task<IODataResponseMessage> GetResponseAsync(CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<IODataResponseMessage>(cancellationToken);
+            }
+
             try
             {
                 return Task.FromResult(GetResponse());

--- a/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
@@ -513,7 +513,7 @@ namespace Microsoft.OData.Client
             try
             {
                 // Use HttpCompletionOption.ResponseHeadersRead to shorten the window before cancellation is honoured
-                return await _client.SendAsync(_requestMessage, HttpCompletionOption.ResponseHeadersRead, sendToken).ConfigureAwait(false);
+                return await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, sendToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException ex)
             {

--- a/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
@@ -513,7 +513,7 @@ namespace Microsoft.OData.Client
             try
             {
                 // Use HttpCompletionOption.ResponseHeadersRead to shorten the window before cancellation is honoured
-                return await _client.SendAsync(_requestMessage, HttpCompletionOption.ResponseHeadersRead, sendToken);
+                return await _client.SendAsync(_requestMessage, HttpCompletionOption.ResponseHeadersRead, sendToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException ex)
             {
@@ -523,9 +523,10 @@ namespace Microsoft.OData.Client
                     throw;
                 }
 
-                // Wrap internal timeout / abort as DataServiceTransportException
-                // Currently, only abort or per-request timeout can trigger cancellation (no external token linked)
-                throw new DataServiceTransportException(response: null, ex);
+                // Wrap internal timeout / abort as DataServiceTransportException.
+                // The inner exception must be an InvalidOperationException for compatibility with
+                // WebUtil.GetHttpWebResponse, which casts InnerException to InvalidOperationException.
+                throw new DataServiceTransportException(response: null, new InvalidOperationException(ex.Message, ex));
             }
             finally
             {

--- a/src/Microsoft.OData.Client/WebUtil.cs
+++ b/src/Microsoft.OData.Client/WebUtil.cs
@@ -74,13 +74,13 @@ namespace Microsoft.OData.Client
         /// <summary>copy from one stream to another</summary>
         /// <param name="input">input stream</param>
         /// <param name="output">output stream</param>
-        /// <param name="buffer">reusable buffer</param>
+        /// <param name="buffer">reusable buffer; must be non-null and non-empty</param>
         /// <returns>count of copied bytes</returns>
         internal static long CopyStream(Stream input, Stream output, byte[] buffer)
         {
             Debug.Assert(input != null, "null input stream");
             Debug.Assert(output != null, "null output stream");
-            Debug.Assert(buffer == null || buffer.Length > 0, "null or empty buffer");
+            Debug.Assert(buffer != null && buffer.Length > 0, "null or empty buffer");
 
             long total = 0;
 
@@ -99,19 +99,17 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <param name="input">Input stream to read from.</param>
         /// <param name="output">Output stream to write to.</param>
-        /// <param name="buffer">Buffer to use for copying. If null, a new buffer will be created.</param>
+        /// <param name="buffer">Buffer to use for copying; must be non-null and non-empty. The caller owns the buffer lifecycle to allow reuse across calls.</param>
         /// <param name="cancellationToken">Cancellation token to observe.</param>
         /// <returns>
         /// A task that represents the asynchronous copy operation.
-        /// The task result contains a tuple with:
-        /// - BytesCopied: The total number of bytes copied
-        /// - Buffer: The buffer used for copying (either the provided buffer or a newly created one)
+        /// The task result contains the total number of bytes copied.
         /// </returns>
         internal static async Task<long> CopyStreamAsync(Stream input, Stream output, byte[] buffer, CancellationToken cancellationToken = default)
         {
             Debug.Assert(input != null, "null input stream");
             Debug.Assert(output != null, "null output stream");
-            Debug.Assert(buffer == null || buffer.Length > 0, "null or empty buffer");
+            Debug.Assert(buffer != null && buffer.Length > 0, "null or empty buffer");
 
             long total = 0;
             int count;

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/DataServiceClientRequestMessageTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/DataServiceClientRequestMessageTests.cs
@@ -1,0 +1,112 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="DataServiceClientRequestMessageTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.OData;
+using Xunit;
+
+namespace Microsoft.OData.Client.Tests.Serialization
+{
+    public class DataServiceClientRequestMessageTests
+    {
+        /// <summary>
+        /// Minimal concrete subclass of <see cref="DataServiceClientRequestMessage"/> for testing
+        /// the default <see cref="DataServiceClientRequestMessage.GetResponseAsync"/> implementation.
+        /// </summary>
+        private class TestRequestMessage : DataServiceClientRequestMessage
+        {
+            private readonly Func<IODataResponseMessage> _getResponse;
+            public int GetResponseCallCount { get; private set; }
+
+            public TestRequestMessage(Func<IODataResponseMessage> getResponse)
+                : base("GET")
+            {
+                _getResponse = getResponse;
+            }
+
+            public override IEnumerable<KeyValuePair<string, string>> Headers => Array.Empty<KeyValuePair<string, string>>();
+            public override Uri Url { get; set; } = new Uri("http://localhost");
+            public override string Method { get; set; } = "GET";
+            public override int Timeout { get; set; }
+            public override bool SendChunked { get; set; }
+            public override string GetHeader(string headerName) => null;
+            public override void SetHeader(string headerName, string headerValue) { }
+            public override Stream GetStream() => Stream.Null;
+            public override void Abort() { }
+            public override IAsyncResult BeginGetRequestStream(AsyncCallback callback, object state) => throw new NotImplementedException();
+            public override Stream EndGetRequestStream(IAsyncResult asyncResult) => throw new NotImplementedException();
+            public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state) => throw new NotImplementedException();
+            public override IODataResponseMessage EndGetResponse(IAsyncResult asyncResult) => throw new NotImplementedException();
+
+            public override IODataResponseMessage GetResponse()
+            {
+                GetResponseCallCount++;
+                return _getResponse();
+            }
+        }
+
+        [Fact]
+        public async Task GetResponseAsync_WithPreCancelledToken_ReturnsCancelledTaskWithoutCallingGetResponse()
+        {
+            // Arrange
+            var message = new TestRequestMessage(() => throw new Exception("GetResponse should not be called"));
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // Act
+            Task<IODataResponseMessage> task = message.GetResponseAsync(cts.Token);
+
+            // Assert
+            Assert.True(task.IsCanceled);
+            Assert.Equal(0, message.GetResponseCallCount);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+        }
+
+        [Fact]
+        public async Task GetResponseAsync_WithNonCancelledToken_CallsGetResponseAndReturnsResult()
+        {
+            // Arrange
+            var expectedResponse = new TestODataResponseMessage();
+            var message = new TestRequestMessage(() => expectedResponse);
+
+            // Act
+            IODataResponseMessage result = await message.GetResponseAsync(CancellationToken.None);
+
+            // Assert
+            Assert.Same(expectedResponse, result);
+            Assert.Equal(1, message.GetResponseCallCount);
+        }
+
+        [Fact]
+        public async Task GetResponseAsync_WhenGetResponseThrows_ReturnsFailedTask()
+        {
+            // Arrange
+            var expectedException = new InvalidOperationException("transport error");
+            var message = new TestRequestMessage(() => throw expectedException);
+
+            // Act
+            Task<IODataResponseMessage> task = message.GetResponseAsync(CancellationToken.None);
+
+            // Assert
+            Assert.True(task.IsFaulted);
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => task);
+            Assert.Same(expectedException, ex);
+        }
+
+        private class TestODataResponseMessage : IODataResponseMessage
+        {
+            public IEnumerable<KeyValuePair<string, string>> Headers => Array.Empty<KeyValuePair<string, string>>();
+            public int StatusCode { get; set; } = 200;
+            public string GetHeader(string headerName) => null;
+            public void SetHeader(string headerName, string headerValue) { }
+            public Stream GetStream() => Stream.Null;
+        }
+    }
+}

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
@@ -316,5 +316,92 @@ namespace Microsoft.OData.Client.Tests.Serialization
             }
         }
 
+        [Fact]
+        public async Task GetResponseAsync_WhenAborted_ThrowsDataServiceTransportExceptionWithInvalidOperationExceptionInner()
+        {
+            // Arrange
+            using (var handler = new MockUnresponsiveHttpClientHandler())
+            {
+                var httpClientFactory = new MockHttpClientFactory(handler);
+                var args = new DataServiceClientRequestMessageArgs(
+                    "GET",
+                    new Uri("http://localhost"),
+                    usePostTunneling: false,
+                    headers: new Dictionary<string, string>(),
+                    httpClientFactory: httpClientFactory);
+
+                using (var request = new HttpClientRequestMessage(args))
+                {
+                    handler.OnRequestStarted = () => request.Abort();
+
+                    // Act
+                    var ex = await Assert.ThrowsAsync<DataServiceTransportException>(
+                        () => request.GetResponseAsync(CancellationToken.None));
+
+                    // Assert: InnerException must be InvalidOperationException so that
+                    // WebUtil.GetHttpWebResponse can cast it without InvalidCastException.
+                    Assert.IsType<InvalidOperationException>(ex.InnerException);
+                    // The original OperationCanceledException is preserved as the cause.
+                    Assert.IsAssignableFrom<OperationCanceledException>(ex.InnerException.InnerException);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GetResponseAsync_WhenTimedOut_ThrowsDataServiceTransportExceptionWithInvalidOperationExceptionInner()
+        {
+            // Arrange
+            using (var handler = new MockUnresponsiveHttpClientHandler())
+            {
+                var httpClientFactory = new MockHttpClientFactory(handler);
+                var args = new DataServiceClientRequestMessageArgs(
+                    "GET",
+                    new Uri("http://localhost"),
+                    usePostTunneling: false,
+                    headers: new Dictionary<string, string>(),
+                    httpClientFactory: httpClientFactory);
+
+                using (var request = new HttpClientRequestMessage(args))
+                {
+                    request.Timeout = 1;
+
+                    // Act
+                    var ex = await Assert.ThrowsAsync<DataServiceTransportException>(
+                        () => request.GetResponseAsync(CancellationToken.None));
+
+                    // Assert: InnerException must be InvalidOperationException so that
+                    // WebUtil.GetHttpWebResponse can cast it without InvalidCastException.
+                    Assert.IsType<InvalidOperationException>(ex.InnerException);
+                    Assert.IsAssignableFrom<OperationCanceledException>(ex.InnerException.InnerException);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GetResponseAsync_WhenExternalTokenCancelled_PropagatesOperationCanceledException()
+        {
+            // Arrange
+            using (var handler = new MockUnresponsiveHttpClientHandler())
+            {
+                var httpClientFactory = new MockHttpClientFactory(handler);
+                var args = new DataServiceClientRequestMessageArgs(
+                    "GET",
+                    new Uri("http://localhost"),
+                    usePostTunneling: false,
+                    headers: new Dictionary<string, string>(),
+                    httpClientFactory: httpClientFactory);
+
+                using (var request = new HttpClientRequestMessage(args))
+                using (var cts = new CancellationTokenSource())
+                {
+                    handler.OnRequestStarted = () => cts.Cancel();
+
+                    // Act & Assert: external cancellation must not be wrapped in DataServiceTransportException.
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                        () => request.GetResponseAsync(cts.Token));
+                }
+            }
+        }
+
     }
 }

--- a/test/UnitTests/Microsoft.OData.Client.Tests/WebUtilTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/WebUtilTests.cs
@@ -1,0 +1,118 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="WebUtilTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.OData.Client.Tests
+{
+    public class WebUtilTests
+    {
+        [Fact]
+        public async Task CopyStreamAsync_CopiesAllBytes()
+        {
+            // Arrange
+            byte[] data = Encoding.UTF8.GetBytes("Hello, OData!");
+            using var input = new MemoryStream(data);
+            using var output = new MemoryStream();
+            byte[] buffer = new byte[WebUtil.DefaultBufferSizeForStreamCopy];
+
+            // Act
+            long bytesCopied = await WebUtil.CopyStreamAsync(input, output, buffer);
+
+            // Assert
+            Assert.Equal(data.Length, bytesCopied);
+            Assert.Equal(data, output.ToArray());
+        }
+
+        [Fact]
+        public async Task CopyStreamAsync_WithSmallBuffer_CopiesAllBytes()
+        {
+            // Arrange — buffer smaller than the data to exercise multiple read iterations
+            byte[] data = Encoding.UTF8.GetBytes("Hello, OData!");
+            using var input = new MemoryStream(data);
+            using var output = new MemoryStream();
+            byte[] buffer = new byte[4];
+
+            // Act
+            long bytesCopied = await WebUtil.CopyStreamAsync(input, output, buffer);
+
+            // Assert
+            Assert.Equal(data.Length, bytesCopied);
+            Assert.Equal(data, output.ToArray());
+        }
+
+        [Fact]
+        public async Task CopyStreamAsync_WithEmptyInput_ReturnsZero()
+        {
+            // Arrange
+            using var input = new MemoryStream(new byte[0]);
+            using var output = new MemoryStream();
+            byte[] buffer = new byte[WebUtil.DefaultBufferSizeForStreamCopy];
+
+            // Act
+            long bytesCopied = await WebUtil.CopyStreamAsync(input, output, buffer);
+
+            // Assert
+            Assert.Equal(0, bytesCopied);
+            Assert.Equal(0, output.Length);
+        }
+
+        [Fact]
+        public async Task CopyStreamAsync_WhenCancelled_ThrowsOperationCanceledException()
+        {
+            // Arrange
+            byte[] data = new byte[1024];
+            using var input = new MemoryStream(data);
+            using var output = new MemoryStream();
+            byte[] buffer = new byte[4]; // small buffer to ensure multiple iterations
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // Act & Assert
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => WebUtil.CopyStreamAsync(input, output, buffer, cts.Token));
+        }
+
+        [Fact]
+        public void CopyStream_CopiesAllBytes()
+        {
+            // Arrange
+            byte[] data = Encoding.UTF8.GetBytes("Hello, OData!");
+            using var input = new MemoryStream(data);
+            using var output = new MemoryStream();
+            byte[] buffer = new byte[WebUtil.DefaultBufferSizeForStreamCopy];
+
+            // Act
+            long bytesCopied = WebUtil.CopyStream(input, output, buffer);
+
+            // Assert
+            Assert.Equal(data.Length, bytesCopied);
+            Assert.Equal(data, output.ToArray());
+        }
+
+        [Fact]
+        public void CopyStream_WithSmallBuffer_CopiesAllBytes()
+        {
+            // Arrange — buffer smaller than the data to exercise multiple read iterations
+            byte[] data = Encoding.UTF8.GetBytes("Hello, OData!");
+            using var input = new MemoryStream(data);
+            using var output = new MemoryStream();
+            byte[] buffer = new byte[4];
+
+            // Act
+            long bytesCopied = WebUtil.CopyStream(input, output, buffer);
+
+            // Assert
+            Assert.Equal(data.Length, bytesCopied);
+            Assert.Equal(data, output.ToArray());
+        }
+    }
+}


### PR DESCRIPTION
## Issues

Addresses async oversights not caught during review of #3474.

## Changes

### `HttpClientRequestMessage.SendInternalAsync`
- Added `.ConfigureAwait(false)` to the `_client.SendAsync(...)` call.
- Wrapped the caught `OperationCanceledException` in `new InvalidOperationException(ex.Message, ex)` before constructing `DataServiceTransportException`. `WebUtil.GetHttpWebResponse` hard-casts `DataServiceTransportException.InnerException` to `InvalidOperationException`; passing an `OperationCanceledException` directly would cause an `InvalidCastException` on the async path.

### Missing `ConfigureAwait(false)` calls
Added `.ConfigureAwait(false)` to all new `await` expressions that were missing it in library code:
- `QueryResult.ExecuteQueryAsync` - `GetResponseAsync` and `ProcessResponseStreamAsync` calls
- `QueryResult.ProcessResponseStreamAsync` - `WebUtil.CopyStreamAsync` call
- `BulkUpdateSaveResult.BulkUpdateRequestAsync`
- `DeepInsertSaveResult.DeepInsertRequestAsync`
- `DataServiceContext.ExecuteAsync(Uri, httpMethod, CancellationToken, params)`

### `DataServiceClientRequestMessage.GetResponseAsync`
Added an early `Task.FromCanceled` return when the token is already cancelled, preventing a redundant `GetResponse()` call on a pre-cancelled token.

### `WebUtil.CopyStream` / `CopyStreamAsync`
- Tightened `Debug.Assert` from `buffer == null || buffer.Length > 0` to `buffer != null && buffer.Length > 0`, enforcing caller responsibility for buffer allocation. All existing callers already allocate before passing, supporting buffer reuse via `PutAsyncResponseStreamCopyBuffer`.
- Updated doc comments on both methods to document the non-null contract explicitly.
- Removed the incorrect doc claim on `CopyStreamAsync` that null would create a new buffer.

### Doc typo
Fixed `incrementaly` to `incrementally` in `DataServiceQueryOfT`.

## Tests

- **`HttpClientRequestMessageTests`** - 3 new tests: `InnerException` is `InvalidOperationException` on abort, `InnerException` is `InvalidOperationException` on timeout, external cancellation propagates as `OperationCanceledException` (not wrapped).
- **`DataServiceClientRequestMessageTests`** (new file) - pre-cancelled token returns cancelled task without calling `GetResponse()`; happy path; faulted task on exception.
- **`WebUtilTests`** (new file) - `CopyStreamAsync` and `CopyStream`: full copy, small-buffer multi-iteration, empty input, cancellation.