### PR TITLE
Fix ExpressionLexer.ParseLiteral to terminate on ']' so collection-li…

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
@@ -1147,7 +1147,9 @@ namespace Microsoft.OData.UriParser
         }
 
         /// <summary>
-        /// Parses a literal be checking for delimiting characters '\0', ',',')' and ' '
+        /// Parses a literal by checking for delimiting characters '\0', ',', ')', ']' and ' '.
+        /// ']' is included so that the literal scanner stops at the end of a bracketed collection
+        /// (e.g. the last item of an 'X in [...]' expression).
         /// </summary>
         /// <param name="tokenPos">Index from which the substring starts</param>
         /// <returns>Substring from this.text that has parsed the literal and ends in one of above delimiting characters</returns>
@@ -1157,7 +1159,7 @@ namespace Microsoft.OData.UriParser
             {
                 this.NextChar();
             }
-            while (this.ch.HasValue && this.ch != ',' && this.ch != ')' && this.ch != ' ');
+            while (this.ch.HasValue && this.ch != ',' && this.ch != ')' && this.ch != ']' && this.ch != ' ');
 
             if (this.ch == null)
             {

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
@@ -1406,6 +1406,84 @@ namespace Microsoft.OData.Tests.UriParser
                 new ExpressionToken() { Kind = ExpressionTokenKind.GuidLiteral, Text = "ABCDEF12-ABCD-ABCD-ABCD-ABCDEFABCDEF".AsMemory() });
         }
 
+        // Regression: a GUID literal followed by ']' must still be recognized as a GUID,
+        // not have the closing bracket folded into the literal. Previously ParseLiteral only
+        // stopped at ',', ')', and ' ', so the GUID-detection path failed for any GUID that
+        // immediately preceded a ']' (notably the last item in 'X in [...]' collection literals).
+        [Fact]
+        public void ParseGuidLiteralFollowedByCloseBracket()
+        {
+            // Letter-starting GUID, the only element of a bracketed list.
+            ValidateTokenSequence(this.model, "[c2081e58-21a5-4a15-b0bd-fff03ebadd30]",
+                OpenBracketToken,
+                new ExpressionToken() { Kind = ExpressionTokenKind.GuidLiteral, Text = "c2081e58-21a5-4a15-b0bd-fff03ebadd30".AsMemory() },
+                CloseBracketToken);
+        }
+
+        [Fact]
+        public void ParseDigitStartingGuidLiteralFollowedByCloseBracket()
+        {
+            // Digit-starting GUID, the only element of a bracketed list. The lexer enters
+            // ParseFromDigit, then falls through to its TryParseGuid letter-fallback branch.
+            ValidateTokenSequence(this.model, "[0697576b-d616-4057-9d28-ed359775129e]",
+                OpenBracketToken,
+                new ExpressionToken() { Kind = ExpressionTokenKind.GuidLiteral, Text = "0697576b-d616-4057-9d28-ed359775129e".AsMemory() },
+                CloseBracketToken);
+        }
+
+        [Fact]
+        public void ParseDigitStartingGuidLiteralFollowedByComma()
+        {
+            // Digit-starting GUID is not the last element of a bracketed list.
+            ValidateTokenSequence(this.model, "[0697576b-d616-4057-9d28-ed359775129e,c2081e58-21a5-4a15-b0bd-fff03ebadd30]",
+                OpenBracketToken,
+                new ExpressionToken() { Kind = ExpressionTokenKind.GuidLiteral, Text = "0697576b-d616-4057-9d28-ed359775129e".AsMemory() },
+                CommaToken,
+                new ExpressionToken() { Kind = ExpressionTokenKind.GuidLiteral, Text = "c2081e58-21a5-4a15-b0bd-fff03ebadd30".AsMemory() },
+                CloseBracketToken);
+        }
+
+        [Fact]
+        public void ParseTwoGuidLiteralsWithLastDigitStartingInsideBrackets()
+        {
+            // Real-world failing case: letter-starting GUID first, digit-starting GUID last.
+            // Reported via Microsoft.Restier integration tests against OData 9.0.0-rc.
+            ValidateTokenSequence(this.model, "[c2081e58-21a5-4a15-b0bd-fff03ebadd30,0697576b-d616-4057-9d28-ed359775129e]",
+                OpenBracketToken,
+                new ExpressionToken() { Kind = ExpressionTokenKind.GuidLiteral, Text = "c2081e58-21a5-4a15-b0bd-fff03ebadd30".AsMemory() },
+                CommaToken,
+                new ExpressionToken() { Kind = ExpressionTokenKind.GuidLiteral, Text = "0697576b-d616-4057-9d28-ed359775129e".AsMemory() },
+                CloseBracketToken);
+        }
+
+        [Fact]
+        public void ParseDateOnlyLiteralFollowedByCloseBracket()
+        {
+            // Same ParseLiteral terminator issue would have broken Date literals at end of brackets.
+            ValidateTokenSequence(this.model, "[2025-06-16]",
+                OpenBracketToken,
+                new ExpressionToken() { Kind = ExpressionTokenKind.DateOnlyLiteral, Text = "2025-06-16".AsMemory() },
+                CloseBracketToken);
+        }
+
+        [Fact]
+        public void ParseDateTimeOffsetLiteralFollowedByCloseBracket()
+        {
+            ValidateTokenSequence(this.model, "[2025-06-16T11:22:33Z]",
+                OpenBracketToken,
+                new ExpressionToken() { Kind = ExpressionTokenKind.DateTimeOffsetLiteral, Text = "2025-06-16T11:22:33Z".AsMemory() },
+                CloseBracketToken);
+        }
+
+        [Fact]
+        public void ParseTimeOnlyLiteralFollowedByCloseBracket()
+        {
+            ValidateTokenSequence(this.model, "[08:20:15]",
+                OpenBracketToken,
+                new ExpressionToken() { Kind = ExpressionTokenKind.TimeOnlyLiteral, Text = "08:20:15".AsMemory() },
+                CloseBracketToken);
+        }
+
         // Type-prefixed literals
         [Fact]
         public void ParseDurationLiteralWithPrefix()

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
@@ -1104,6 +1104,40 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             Assert.IsType<FunctionCallToken>(inToken.Left);
         }
 
+        // Regression: bare GUID literals as the last item inside a bracketed 'in [...]'
+        // collection used to fail because ExpressionLexer.ParseLiteral terminated only on
+        // ',', ')', and ' ' — never on ']'. The closing bracket got folded into the literal,
+        // which broke Guid/DateOnly/DateTimeOffset/TimeOnly recognition.
+        [Fact]
+        public void ParseInOperatorWithBracketedGuidLiterals()
+        {
+            QueryToken token = this.testSubject.ParseFilter("Id in [c2081e58-21a5-4a15-b0bd-fff03ebadd30,0697576b-d616-4057-9d28-ed359775129e]");
+            Assert.NotNull(token);
+            var inToken = Assert.IsType<InToken>(token);
+            var collectionToken = Assert.IsType<CollectionLiteralToken>(inToken.Right);
+            Assert.Equal(2, collectionToken.Items.Count);
+        }
+
+        [Fact]
+        public void ParseInOperatorWithSingleDigitStartingGuidInBrackets()
+        {
+            QueryToken token = this.testSubject.ParseFilter("Id in [0697576b-d616-4057-9d28-ed359775129e]");
+            Assert.NotNull(token);
+            var inToken = Assert.IsType<InToken>(token);
+            var collectionToken = Assert.IsType<CollectionLiteralToken>(inToken.Right);
+            Assert.Single(collectionToken.Items);
+        }
+
+        [Fact]
+        public void ParseInOperatorWithSingleLetterStartingGuidInBrackets()
+        {
+            QueryToken token = this.testSubject.ParseFilter("Id in [c2081e58-21a5-4a15-b0bd-fff03ebadd30]");
+            Assert.NotNull(token);
+            var inToken = Assert.IsType<InToken>(token);
+            var collectionToken = Assert.IsType<CollectionLiteralToken>(inToken.Right);
+            Assert.Single(collectionToken.Items);
+        }
+
         #endregion
 
         #region Map/Object Parsing Tests


### PR DESCRIPTION
…teral items are recognized

ExpressionLexer.ParseLiteral previously terminated only on ',', ')', and ' '. When a Guid/DateOnly/DateTimeOffset/TimeOnly literal was the last item of a bracketed collection (X in [...]), the closing ']' was folded into the literal text, causing parse failures like 'Expression Token ] expected at position N'.

Add ']' as a terminator in ParseLiteral and add 10 regression tests covering Guid, DateOnly, DateTimeOffset, and TimeOnly literals in bracketed collections.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
