### PR TITLE
Fix codegen: update TFM to net10.0, fix DateOnly/TimeOnly types (#3553)

### DIFF
--- a/buildandtest.yml
+++ b/buildandtest.yml
@@ -40,3 +40,19 @@ steps:
     arguments: '--configuration $(buildConfiguration) --settings $(Build.SourcesDirectory)\test.runsettings --no-build'
     projects: |
       $(Build.SourcesDirectory)\sln\OData.Pipeline.sln
+
+- task: DotNetCoreCLI@2
+  displayName: 'Build CodeGen Tests'
+  inputs:
+    command: 'build'
+    arguments: '--configuration $(BuildConfiguration)'
+    projects: |
+      $(Build.SourcesDirectory)\test\FunctionalTests\Tests\DataServices\UnitTests\DesignT4UnitTests\Microsoft.OData.Service.Design.T4.UnitTests.csproj
+
+- task: DotNetCoreCLI@2
+  displayName: 'Test CodeGen'
+  inputs:
+    command: 'test'
+    arguments: '--configuration $(buildConfiguration) --no-build'
+    projects: |
+      $(Build.SourcesDirectory)\test\FunctionalTests\Tests\DataServices\UnitTests\DesignT4UnitTests\Microsoft.OData.Service.Design.T4.UnitTests.csproj

--- a/buildandtest.yml
+++ b/buildandtest.yml
@@ -53,6 +53,6 @@ steps:
   displayName: 'Test CodeGen'
   inputs:
     command: 'test'
-    arguments: '--configuration $(buildConfiguration) --no-build'
+    arguments: '--configuration $(BuildConfiguration) --no-build'
     projects: |
       $(Build.SourcesDirectory)\test\FunctionalTests\Tests\DataServices\UnitTests\DesignT4UnitTests\Microsoft.OData.Service.Design.T4.UnitTests.csproj

--- a/sln/OData.CodeGen.sln
+++ b/sln/OData.CodeGen.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2010
@@ -15,6 +16,12 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libraries", "libraries", "{A2309D09-659A-4810-A2C0-B248470F0AED}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.OData.Client", "..\src\Microsoft.OData.Client\Microsoft.OData.Client.csproj", "{D1567C63-4A0D-4E18-A14E-79699B9BFFFF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.OData.Service.Design.T4.UnitTests", "..\test\FunctionalTests\Tests\DataServices\UnitTests\DesignT4UnitTests\Microsoft.OData.Service.Design.T4.UnitTests.csproj", "{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.OData.TestCommon", "..\test\Common\Microsoft.OData.TestCommon\Microsoft.OData.TestCommon.csproj", "{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Data.Web.Design.T4", "..\src\CodeGen\Microsoft.Data.Web.Design.T4.csproj", "{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -115,6 +122,60 @@ Global
 		{D1567C63-4A0D-4E18-A14E-79699B9BFFFF}.Release|x64.Build.0 = Release|x64
 		{D1567C63-4A0D-4E18-A14E-79699B9BFFFF}.Release|x86.ActiveCfg = Release|x86
 		{D1567C63-4A0D-4E18-A14E-79699B9BFFFF}.Release|x86.Build.0 = Release|x86
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Cover|Any CPU.ActiveCfg = Debug|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Cover|Any CPU.Build.0 = Debug|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Cover|x64.ActiveCfg = Debug|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Cover|x64.Build.0 = Debug|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Cover|x86.ActiveCfg = Debug|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Cover|x86.Build.0 = Debug|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Debug|x64.Build.0 = Debug|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Debug|x86.Build.0 = Debug|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Release|x64.ActiveCfg = Release|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Release|x64.Build.0 = Release|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Release|x86.ActiveCfg = Release|Any CPU
+		{301A178E-30C8-414F-A6CA-F4D86D6EAAD6}.Release|x86.Build.0 = Release|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Cover|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Cover|Any CPU.Build.0 = Debug|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Cover|x64.ActiveCfg = Debug|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Cover|x64.Build.0 = Debug|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Cover|x86.ActiveCfg = Debug|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Cover|x86.Build.0 = Debug|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Debug|x64.Build.0 = Debug|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Debug|x86.Build.0 = Debug|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Release|x64.ActiveCfg = Release|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Release|x64.Build.0 = Release|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Release|x86.ActiveCfg = Release|Any CPU
+		{2E2C85FA-29E8-4875-A5AA-1F100F1ED460}.Release|x86.Build.0 = Release|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Cover|Any CPU.ActiveCfg = Debug|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Cover|Any CPU.Build.0 = Debug|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Cover|x64.ActiveCfg = Debug|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Cover|x64.Build.0 = Debug|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Cover|x86.ActiveCfg = Debug|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Cover|x86.Build.0 = Debug|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Debug|x64.Build.0 = Debug|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Debug|x86.Build.0 = Debug|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Release|x64.ActiveCfg = Release|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Release|x64.Build.0 = Release|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Release|x86.ActiveCfg = Release|Any CPU
+		{1FFF4EE9-A444-4184-9C98-2BE3C34C5CC9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/CodeGen/Microsoft.Data.Web.Design.T4.csproj
+++ b/src/CodeGen/Microsoft.Data.Web.Design.T4.csproj
@@ -7,7 +7,7 @@
     <ConditionalAPTCA_L2>true</ConditionalAPTCA_L2>
     <DocumentationFile>$(AssemblyName).xml</DocumentationFile>
     <RestorePackages>true</RestorePackages>
-    <TargetFrameworks>net48</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <ShouldGenerateAssemblyAttributeFile>false</ShouldGenerateAssemblyAttributeFile>
@@ -18,22 +18,12 @@
   <Import Project="..\Build.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.TextTemplating.Interfaces.10.0" Version="10.0.30320" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" /> 
+    <PackageReference Include="Microsoft.VisualStudio.TextTemplating.Interfaces.10.0" Version="17.0.32112.339" />
+    <PackageReference Include="System.CodeDom" Version="9.0.4" />
   </ItemGroup>
   
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
     <ProjectReference Include="$(EnlistmentRoot)\src\Microsoft.OData.Edm\Microsoft.OData.Edm.csproj" />
- 
   </ItemGroup>
   <!-- Source files -->
   <ItemGroup>

--- a/src/CodeGen/ODataT4CodeGenerator.cs
+++ b/src/CodeGen/ODataT4CodeGenerator.cs
@@ -1024,7 +1024,8 @@ public class CodeGenerationContext
                 tmp.FindDeclaredTerm(AlternateKeysVocabularyConstants.AlternateKeys) != null ||
                 tmp.FindDeclaredTerm("Org.OData.Authorization.V1.Authorizations") != null ||
                 tmp.FindDeclaredTerm("Org.OData.Validation.V1.DerivedTypeConstraint") != null ||
-                tmp.FindDeclaredTerm("Org.OData.Community.V1.UrlEscapeFunction") != null)
+                tmp.FindDeclaredTerm("Org.OData.Community.V1.UrlEscapeFunction") != null ||
+                tmp.FindDeclaredTerm("Org.OData.Measures.V1.ISOCurrency") != null)
             {
                 continue;
             }
@@ -3217,10 +3218,10 @@ public sealed class ODataClientCSharpTemplate : ODataClientTemplate
     internal override string GeometryMultiPolygonTypeName { get { return "global::Microsoft.Spatial.GeometryMultiPolygon"; } }
     internal override string GeometryMultiLineStringTypeName { get { return "global::Microsoft.Spatial.GeometryMultiLineString"; } }
     internal override string GeometryMultiPointTypeName { get { return "global::Microsoft.Spatial.GeometryMultiPoint"; } }
-    internal override string DateTypeName { get { return "global::Microsoft.OData.Edm.Date"; } }
+    internal override string DateTypeName { get { return "global::System.DateOnly"; } }
     internal override string DateTimeOffsetTypeName { get { return "global::System.DateTimeOffset"; } }
     internal override string DurationTypeName { get { return "global::System.TimeSpan"; } }
-    internal override string TimeOfDayTypeName { get { return "global::Microsoft.OData.Edm.TimeOfDay"; } }
+    internal override string TimeOfDayTypeName { get { return "global::System.TimeOnly"; } }
     internal override string XmlConvertClassName { get { return "global::System.Xml.XmlConvert"; } }
     internal override string EnumTypeName { get { return "global::System.Enum"; } }
     internal override string FixPattern { get { return "@{0}"; } }
@@ -5253,10 +5254,10 @@ public sealed class ODataClientVBTemplate : ODataClientTemplate
     internal override string GeometryMultiPolygonTypeName { get { return "Global.Microsoft.Spatial.GeometryMultiPolygon"; } }
     internal override string GeometryMultiLineStringTypeName { get { return "Global.Microsoft.Spatial.GeometryMultiLineString"; } }
     internal override string GeometryMultiPointTypeName { get { return "Global.Microsoft.Spatial.GeometryMultiPoint"; } }
-    internal override string DateTypeName { get { return "Global.Microsoft.OData.Edm.Date"; } }
+    internal override string DateTypeName { get { return "Global.System.DateOnly"; } }
     internal override string DateTimeOffsetTypeName { get { return "Global.System.DateTimeOffset"; } }
     internal override string DurationTypeName { get { return "Global.System.TimeSpan"; } }
-    internal override string TimeOfDayTypeName { get { return "Global.Microsoft.OData.Edm.TimeOfDay"; } }
+    internal override string TimeOfDayTypeName { get { return "Global.System.TimeOnly"; } }
     internal override string XmlConvertClassName { get { return "Global.System.Xml.XmlConvert"; } }
     internal override string EnumTypeName { get { return "Global.System.Enum"; } }
     internal override string FixPattern { get { return "[{0}]"; } }

--- a/src/CodeGen/ODataT4CodeGenerator.ttinclude
+++ b/src/CodeGen/ODataT4CodeGenerator.ttinclude
@@ -916,7 +916,8 @@ public class CodeGenerationContext
                 tmp.FindDeclaredTerm(AlternateKeysVocabularyConstants.AlternateKeys) != null ||
                 tmp.FindDeclaredTerm("Org.OData.Authorization.V1.Authorizations") != null ||
                 tmp.FindDeclaredTerm("Org.OData.Validation.V1.DerivedTypeConstraint") != null ||
-                tmp.FindDeclaredTerm("Org.OData.Community.V1.UrlEscapeFunction") != null)
+                tmp.FindDeclaredTerm("Org.OData.Community.V1.UrlEscapeFunction") != null ||
+                tmp.FindDeclaredTerm("Org.OData.Measures.V1.ISOCurrency") != null)
             {
                 continue;
             }
@@ -3109,10 +3110,10 @@ public sealed class ODataClientCSharpTemplate : ODataClientTemplate
     internal override string GeometryMultiPolygonTypeName { get { return "global::Microsoft.Spatial.GeometryMultiPolygon"; } }
     internal override string GeometryMultiLineStringTypeName { get { return "global::Microsoft.Spatial.GeometryMultiLineString"; } }
     internal override string GeometryMultiPointTypeName { get { return "global::Microsoft.Spatial.GeometryMultiPoint"; } }
-    internal override string DateTypeName { get { return "global::Microsoft.OData.Edm.Date"; } }
+    internal override string DateTypeName { get { return "global::System.DateOnly"; } }
     internal override string DateTimeOffsetTypeName { get { return "global::System.DateTimeOffset"; } }
     internal override string DurationTypeName { get { return "global::System.TimeSpan"; } }
-    internal override string TimeOfDayTypeName { get { return "global::Microsoft.OData.Edm.TimeOfDay"; } }
+    internal override string TimeOfDayTypeName { get { return "global::System.TimeOnly"; } }
     internal override string XmlConvertClassName { get { return "global::System.Xml.XmlConvert"; } }
     internal override string EnumTypeName { get { return "global::System.Enum"; } }
     internal override string FixPattern { get { return "@{0}"; } }
@@ -4224,10 +4225,10 @@ public sealed class ODataClientVBTemplate : ODataClientTemplate
     internal override string GeometryMultiPolygonTypeName { get { return "Global.Microsoft.Spatial.GeometryMultiPolygon"; } }
     internal override string GeometryMultiLineStringTypeName { get { return "Global.Microsoft.Spatial.GeometryMultiLineString"; } }
     internal override string GeometryMultiPointTypeName { get { return "Global.Microsoft.Spatial.GeometryMultiPoint"; } }
-    internal override string DateTypeName { get { return "Global.Microsoft.OData.Edm.Date"; } }
+    internal override string DateTypeName { get { return "Global.System.DateOnly"; } }
     internal override string DateTimeOffsetTypeName { get { return "Global.System.DateTimeOffset"; } }
     internal override string DurationTypeName { get { return "Global.System.TimeSpan"; } }
-    internal override string TimeOfDayTypeName { get { return "Global.Microsoft.OData.Edm.TimeOfDay"; } }
+    internal override string TimeOfDayTypeName { get { return "Global.System.TimeOnly"; } }
     internal override string XmlConvertClassName { get { return "Global.System.Xml.XmlConvert"; } }
     internal override string EnumTypeName { get { return "Global.System.Enum"; } }
     internal override string FixPattern { get { return "[{0}]"; } }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/CodeGen/MergedFunctionalTest.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/CodeGen/MergedFunctionalTest.cs
@@ -2719,8 +2719,8 @@ namespace MergedFunctionalTest
                     string nonNullableStringProp, 
                     global::System.TimeSpan nonNullableDurationProp, 
                     global::System.DateTimeOffset nonNullableDateTimeOffsetProp, 
-                    global::Microsoft.OData.Edm.Date nonNullableDateProp, 
-                    global::Microsoft.OData.Edm.TimeOfDay nonNullableTimeOfDayProp, 
+                    global::System.DateOnly nonNullableDateProp, 
+                    global::System.TimeOnly nonNullableTimeOfDayProp, 
                     global::Microsoft.OData.Client.DataServiceStreamLink nonNullableStreamProp, 
                     sbyte nonNullableSByteProp, 
                     global::Microsoft.Spatial.Geography nonNullableGeography, 
@@ -3649,7 +3649,7 @@ namespace MergedFunctionalTest
         /// There are no comments for Property NonNullableDateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::Microsoft.OData.Edm.Date NonNullableDateProp
+        public global::System.DateOnly NonNullableDateProp
         {
             get
             {
@@ -3663,14 +3663,14 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::Microsoft.OData.Edm.Date _NonNullableDateProp;
-        partial void OnNonNullableDatePropChanging(global::Microsoft.OData.Edm.Date value);
+        private global::System.DateOnly _NonNullableDateProp;
+        partial void OnNonNullableDatePropChanging(global::System.DateOnly value);
         partial void OnNonNullableDatePropChanged();
         /// <summary>
         /// There are no comments for Property ExplicitlyNullableDateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.Date> ExplicitlyNullableDateProp
+        public global::System.Nullable<global::System.DateOnly> ExplicitlyNullableDateProp
         {
             get
             {
@@ -3684,14 +3684,14 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.Date> _ExplicitlyNullableDateProp;
-        partial void OnExplicitlyNullableDatePropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Date> value);
+        private global::System.Nullable<global::System.DateOnly> _ExplicitlyNullableDateProp;
+        partial void OnExplicitlyNullableDatePropChanging(global::System.Nullable<global::System.DateOnly> value);
         partial void OnExplicitlyNullableDatePropChanged();
         /// <summary>
         /// There are no comments for Property NullableDateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.Date> NullableDateProp
+        public global::System.Nullable<global::System.DateOnly> NullableDateProp
         {
             get
             {
@@ -3705,14 +3705,14 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.Date> _NullableDateProp;
-        partial void OnNullableDatePropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Date> value);
+        private global::System.Nullable<global::System.DateOnly> _NullableDateProp;
+        partial void OnNullableDatePropChanging(global::System.Nullable<global::System.DateOnly> value);
         partial void OnNullableDatePropChanged();
         /// <summary>
         /// There are no comments for Property NonNullableTimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::Microsoft.OData.Edm.TimeOfDay NonNullableTimeOfDayProp
+        public global::System.TimeOnly NonNullableTimeOfDayProp
         {
             get
             {
@@ -3726,14 +3726,14 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::Microsoft.OData.Edm.TimeOfDay _NonNullableTimeOfDayProp;
-        partial void OnNonNullableTimeOfDayPropChanging(global::Microsoft.OData.Edm.TimeOfDay value);
+        private global::System.TimeOnly _NonNullableTimeOfDayProp;
+        partial void OnNonNullableTimeOfDayPropChanging(global::System.TimeOnly value);
         partial void OnNonNullableTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property ExplicitlyNullableTimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> ExplicitlyNullableTimeOfDayProp
+        public global::System.Nullable<global::System.TimeOnly> ExplicitlyNullableTimeOfDayProp
         {
             get
             {
@@ -3747,14 +3747,14 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> _ExplicitlyNullableTimeOfDayProp;
-        partial void OnExplicitlyNullableTimeOfDayPropChanging(global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> value);
+        private global::System.Nullable<global::System.TimeOnly> _ExplicitlyNullableTimeOfDayProp;
+        partial void OnExplicitlyNullableTimeOfDayPropChanging(global::System.Nullable<global::System.TimeOnly> value);
         partial void OnExplicitlyNullableTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property NullableTimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> NullableTimeOfDayProp
+        public global::System.Nullable<global::System.TimeOnly> NullableTimeOfDayProp
         {
             get
             {
@@ -3768,8 +3768,8 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> _NullableTimeOfDayProp;
-        partial void OnNullableTimeOfDayPropChanging(global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> value);
+        private global::System.Nullable<global::System.TimeOnly> _NullableTimeOfDayProp;
+        partial void OnNullableTimeOfDayPropChanging(global::System.Nullable<global::System.TimeOnly> value);
         partial void OnNullableTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property NonNullableStreamProp in the schema.
@@ -5311,7 +5311,7 @@ namespace MergedFunctionalTest
         /// There are no comments for Property BagOfDate in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Date> BagOfDate
+        public global::System.Collections.ObjectModel.Collection<global::System.DateOnly> BagOfDate
         {
             get
             {
@@ -5325,14 +5325,14 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Date> _BagOfDate = new global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Date>();
-        partial void OnBagOfDateChanging(global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Date> value);
+        private global::System.Collections.ObjectModel.Collection<global::System.DateOnly> _BagOfDate = new global::System.Collections.ObjectModel.Collection<global::System.DateOnly>();
+        partial void OnBagOfDateChanging(global::System.Collections.ObjectModel.Collection<global::System.DateOnly> value);
         partial void OnBagOfDateChanged();
         /// <summary>
         /// There are no comments for Property BagOfTimeOfDay in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.TimeOfDay> BagOfTimeOfDay
+        public global::System.Collections.ObjectModel.Collection<global::System.TimeOnly> BagOfTimeOfDay
         {
             get
             {
@@ -5346,8 +5346,8 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.TimeOfDay> _BagOfTimeOfDay = new global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.TimeOfDay>();
-        partial void OnBagOfTimeOfDayChanging(global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.TimeOfDay> value);
+        private global::System.Collections.ObjectModel.Collection<global::System.TimeOnly> _BagOfTimeOfDay = new global::System.Collections.ObjectModel.Collection<global::System.TimeOnly>();
+        partial void OnBagOfTimeOfDayChanging(global::System.Collections.ObjectModel.Collection<global::System.TimeOnly> value);
         partial void OnBagOfTimeOfDayChanged();
         /// <summary>
         /// There are no comments for Property BagOfStream in the schema.
@@ -6122,7 +6122,7 @@ namespace MergedFunctionalTest
         /// There are no comments for Property DateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::Microsoft.OData.Edm.Date DateProp
+        public global::System.DateOnly DateProp
         {
             get
             {
@@ -6136,14 +6136,14 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::Microsoft.OData.Edm.Date _DateProp = global::Microsoft.OData.Edm.Date.Parse("2014-10-08");
-        partial void OnDatePropChanging(global::Microsoft.OData.Edm.Date value);
+        private global::System.DateOnly _DateProp = global::System.DateOnly.Parse("2014-10-08");
+        partial void OnDatePropChanging(global::System.DateOnly value);
         partial void OnDatePropChanged();
         /// <summary>
         /// There are no comments for Property TimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::Microsoft.OData.Edm.TimeOfDay TimeOfDayProp
+        public global::System.TimeOnly TimeOfDayProp
         {
             get
             {
@@ -6157,8 +6157,8 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::Microsoft.OData.Edm.TimeOfDay _TimeOfDayProp = global::Microsoft.OData.Edm.TimeOfDay.Parse("12:34:56");
-        partial void OnTimeOfDayPropChanging(global::Microsoft.OData.Edm.TimeOfDay value);
+        private global::System.TimeOnly _TimeOfDayProp = global::System.TimeOnly.Parse("12:34:56");
+        partial void OnTimeOfDayPropChanging(global::System.TimeOnly value);
         partial void OnTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property GeographyProp in the schema.

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/CodeGen/MergedFunctionalTest.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/CodeGen/MergedFunctionalTest.vb
@@ -2545,8 +2545,8 @@ Namespace MergedFunctionalTest
                     ByVal nonNullableStringProp As String,  _
                     ByVal nonNullableDurationProp As Global.System.TimeSpan,  _
                     ByVal nonNullableDateTimeOffsetProp As Global.System.DateTimeOffset,  _
-                    ByVal nonNullableDateProp As Global.Microsoft.OData.Edm.Date,  _
-                    ByVal nonNullableTimeOfDayProp As Global.Microsoft.OData.Edm.TimeOfDay,  _
+                    ByVal nonNullableDateProp As Global.System.DateOnly,  _
+                    ByVal nonNullableTimeOfDayProp As Global.System.TimeOnly,  _
                     ByVal nonNullableStreamProp As Global.Microsoft.OData.Client.DataServiceStreamLink,  _
                     ByVal nonNullableSByteProp As SByte,  _
                     ByVal nonNullableGeography As Global.Microsoft.Spatial.Geography,  _
@@ -3432,7 +3432,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property NonNullableDateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property NonNullableDateProp() As Global.Microsoft.OData.Edm.Date
+        Public Property NonNullableDateProp() As Global.System.DateOnly
             Get
                 Return Me._NonNullableDateProp
             End Get
@@ -3443,8 +3443,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _NonNullableDateProp As Global.Microsoft.OData.Edm.Date
-        Partial Private Sub OnNonNullableDatePropChanging(ByVal value As Global.Microsoft.OData.Edm.Date)
+        Private _NonNullableDateProp As Global.System.DateOnly
+        Partial Private Sub OnNonNullableDatePropChanging(ByVal value As Global.System.DateOnly)
         End Sub
         Partial Private Sub OnNonNullableDatePropChanged()
         End Sub
@@ -3452,7 +3452,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property ExplicitlyNullableDateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property ExplicitlyNullableDateProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
+        Public Property ExplicitlyNullableDateProp() As Global.System.Nullable(Of Global.System.DateOnly)
             Get
                 Return Me._ExplicitlyNullableDateProp
             End Get
@@ -3463,8 +3463,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _ExplicitlyNullableDateProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
-        Partial Private Sub OnExplicitlyNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date))
+        Private _ExplicitlyNullableDateProp As Global.System.Nullable(Of Global.System.DateOnly)
+        Partial Private Sub OnExplicitlyNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.System.DateOnly))
         End Sub
         Partial Private Sub OnExplicitlyNullableDatePropChanged()
         End Sub
@@ -3472,7 +3472,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property NullableDateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property NullableDateProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
+        Public Property NullableDateProp() As Global.System.Nullable(Of Global.System.DateOnly)
             Get
                 Return Me._NullableDateProp
             End Get
@@ -3483,8 +3483,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _NullableDateProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
-        Partial Private Sub OnNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date))
+        Private _NullableDateProp As Global.System.Nullable(Of Global.System.DateOnly)
+        Partial Private Sub OnNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.System.DateOnly))
         End Sub
         Partial Private Sub OnNullableDatePropChanged()
         End Sub
@@ -3492,7 +3492,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property NonNullableTimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property NonNullableTimeOfDayProp() As Global.Microsoft.OData.Edm.TimeOfDay
+        Public Property NonNullableTimeOfDayProp() As Global.System.TimeOnly
             Get
                 Return Me._NonNullableTimeOfDayProp
             End Get
@@ -3503,8 +3503,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _NonNullableTimeOfDayProp As Global.Microsoft.OData.Edm.TimeOfDay
-        Partial Private Sub OnNonNullableTimeOfDayPropChanging(ByVal value As Global.Microsoft.OData.Edm.TimeOfDay)
+        Private _NonNullableTimeOfDayProp As Global.System.TimeOnly
+        Partial Private Sub OnNonNullableTimeOfDayPropChanging(ByVal value As Global.System.TimeOnly)
         End Sub
         Partial Private Sub OnNonNullableTimeOfDayPropChanged()
         End Sub
@@ -3512,7 +3512,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property ExplicitlyNullableTimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property ExplicitlyNullableTimeOfDayProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
+        Public Property ExplicitlyNullableTimeOfDayProp() As Global.System.Nullable(Of Global.System.TimeOnly)
             Get
                 Return Me._ExplicitlyNullableTimeOfDayProp
             End Get
@@ -3523,8 +3523,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _ExplicitlyNullableTimeOfDayProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
-        Partial Private Sub OnExplicitlyNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay))
+        Private _ExplicitlyNullableTimeOfDayProp As Global.System.Nullable(Of Global.System.TimeOnly)
+        Partial Private Sub OnExplicitlyNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.System.TimeOnly))
         End Sub
         Partial Private Sub OnExplicitlyNullableTimeOfDayPropChanged()
         End Sub
@@ -3532,7 +3532,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property NullableTimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property NullableTimeOfDayProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
+        Public Property NullableTimeOfDayProp() As Global.System.Nullable(Of Global.System.TimeOnly)
             Get
                 Return Me._NullableTimeOfDayProp
             End Get
@@ -3543,8 +3543,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _NullableTimeOfDayProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
-        Partial Private Sub OnNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay))
+        Private _NullableTimeOfDayProp As Global.System.Nullable(Of Global.System.TimeOnly)
+        Partial Private Sub OnNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.System.TimeOnly))
         End Sub
         Partial Private Sub OnNullableTimeOfDayPropChanged()
         End Sub
@@ -5018,7 +5018,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property BagOfDate in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property BagOfDate() As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Date)
+        Public Property BagOfDate() As Global.System.Collections.ObjectModel.Collection(Of Global.System.DateOnly)
             Get
                 Return Me._BagOfDate
             End Get
@@ -5029,8 +5029,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _BagOfDate As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Date) = New Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Date)()
-        Partial Private Sub OnBagOfDateChanging(ByVal value As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Date))
+        Private _BagOfDate As Global.System.Collections.ObjectModel.Collection(Of Global.System.DateOnly) = New Global.System.Collections.ObjectModel.Collection(Of Global.System.DateOnly)()
+        Partial Private Sub OnBagOfDateChanging(ByVal value As Global.System.Collections.ObjectModel.Collection(Of Global.System.DateOnly))
         End Sub
         Partial Private Sub OnBagOfDateChanged()
         End Sub
@@ -5038,7 +5038,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property BagOfTimeOfDay in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property BagOfTimeOfDay() As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.TimeOfDay)
+        Public Property BagOfTimeOfDay() As Global.System.Collections.ObjectModel.Collection(Of Global.System.TimeOnly)
             Get
                 Return Me._BagOfTimeOfDay
             End Get
@@ -5049,8 +5049,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _BagOfTimeOfDay As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.TimeOfDay) = New Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.TimeOfDay)()
-        Partial Private Sub OnBagOfTimeOfDayChanging(ByVal value As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.TimeOfDay))
+        Private _BagOfTimeOfDay As Global.System.Collections.ObjectModel.Collection(Of Global.System.TimeOnly) = New Global.System.Collections.ObjectModel.Collection(Of Global.System.TimeOnly)()
+        Partial Private Sub OnBagOfTimeOfDayChanging(ByVal value As Global.System.Collections.ObjectModel.Collection(Of Global.System.TimeOnly))
         End Sub
         Partial Private Sub OnBagOfTimeOfDayChanged()
         End Sub
@@ -5794,7 +5794,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property DateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property DateProp() As Global.Microsoft.OData.Edm.Date
+        Public Property DateProp() As Global.System.DateOnly
             Get
                 Return Me._DateProp
             End Get
@@ -5805,8 +5805,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _DateProp As Global.Microsoft.OData.Edm.Date = Global.Microsoft.OData.Edm.Date.Parse("2014-10-08")
-        Partial Private Sub OnDatePropChanging(ByVal value As Global.Microsoft.OData.Edm.Date)
+        Private _DateProp As Global.System.DateOnly = Global.System.DateOnly.Parse("2014-10-08")
+        Partial Private Sub OnDatePropChanging(ByVal value As Global.System.DateOnly)
         End Sub
         Partial Private Sub OnDatePropChanged()
         End Sub
@@ -5814,7 +5814,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property TimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property TimeOfDayProp() As Global.Microsoft.OData.Edm.TimeOfDay
+        Public Property TimeOfDayProp() As Global.System.TimeOnly
             Get
                 Return Me._TimeOfDayProp
             End Get
@@ -5825,8 +5825,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _TimeOfDayProp As Global.Microsoft.OData.Edm.TimeOfDay = Global.Microsoft.OData.Edm.TimeOfDay.Parse("12:34:56")
-        Partial Private Sub OnTimeOfDayPropChanging(ByVal value As Global.Microsoft.OData.Edm.TimeOfDay)
+        Private _TimeOfDayProp As Global.System.TimeOnly = Global.System.TimeOnly.Parse("12:34:56")
+        Partial Private Sub OnTimeOfDayPropChanging(ByVal value As Global.System.TimeOnly)
         End Sub
         Partial Private Sub OnTimeOfDayPropChanged()
         End Sub

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/CodeGen/MergedFunctionalTestDSC.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/CodeGen/MergedFunctionalTestDSC.cs
@@ -2912,8 +2912,8 @@ namespace MergedFunctionalTest.DSC
                     string nonNullableStringProp, 
                     global::System.TimeSpan nonNullableDurationProp, 
                     global::System.DateTimeOffset nonNullableDateTimeOffsetProp, 
-                    global::Microsoft.OData.Edm.Date nonNullableDateProp, 
-                    global::Microsoft.OData.Edm.TimeOfDay nonNullableTimeOfDayProp, 
+                    global::System.DateOnly nonNullableDateProp, 
+                    global::System.TimeOnly nonNullableTimeOfDayProp, 
                     global::Microsoft.OData.Client.DataServiceStreamLink nonNullableStreamProp, 
                     sbyte nonNullableSByteProp, 
                     global::Microsoft.Spatial.Geography nonNullableGeography, 
@@ -3883,7 +3883,7 @@ namespace MergedFunctionalTest.DSC
         /// There are no comments for Property NonNullableDateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::Microsoft.OData.Edm.Date NonNullableDateProp
+        public global::System.DateOnly NonNullableDateProp
         {
             get
             {
@@ -3898,14 +3898,14 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::Microsoft.OData.Edm.Date _NonNullableDateProp;
-        partial void OnNonNullableDatePropChanging(global::Microsoft.OData.Edm.Date value);
+        private global::System.DateOnly _NonNullableDateProp;
+        partial void OnNonNullableDatePropChanging(global::System.DateOnly value);
         partial void OnNonNullableDatePropChanged();
         /// <summary>
         /// There are no comments for Property ExplicitlyNullableDateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.Date> ExplicitlyNullableDateProp
+        public global::System.Nullable<global::System.DateOnly> ExplicitlyNullableDateProp
         {
             get
             {
@@ -3920,14 +3920,14 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.Date> _ExplicitlyNullableDateProp;
-        partial void OnExplicitlyNullableDatePropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Date> value);
+        private global::System.Nullable<global::System.DateOnly> _ExplicitlyNullableDateProp;
+        partial void OnExplicitlyNullableDatePropChanging(global::System.Nullable<global::System.DateOnly> value);
         partial void OnExplicitlyNullableDatePropChanged();
         /// <summary>
         /// There are no comments for Property NullableDateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.Date> NullableDateProp
+        public global::System.Nullable<global::System.DateOnly> NullableDateProp
         {
             get
             {
@@ -3942,14 +3942,14 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.Date> _NullableDateProp;
-        partial void OnNullableDatePropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Date> value);
+        private global::System.Nullable<global::System.DateOnly> _NullableDateProp;
+        partial void OnNullableDatePropChanging(global::System.Nullable<global::System.DateOnly> value);
         partial void OnNullableDatePropChanged();
         /// <summary>
         /// There are no comments for Property NonNullableTimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::Microsoft.OData.Edm.TimeOfDay NonNullableTimeOfDayProp
+        public global::System.TimeOnly NonNullableTimeOfDayProp
         {
             get
             {
@@ -3964,14 +3964,14 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::Microsoft.OData.Edm.TimeOfDay _NonNullableTimeOfDayProp;
-        partial void OnNonNullableTimeOfDayPropChanging(global::Microsoft.OData.Edm.TimeOfDay value);
+        private global::System.TimeOnly _NonNullableTimeOfDayProp;
+        partial void OnNonNullableTimeOfDayPropChanging(global::System.TimeOnly value);
         partial void OnNonNullableTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property ExplicitlyNullableTimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> ExplicitlyNullableTimeOfDayProp
+        public global::System.Nullable<global::System.TimeOnly> ExplicitlyNullableTimeOfDayProp
         {
             get
             {
@@ -3986,14 +3986,14 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> _ExplicitlyNullableTimeOfDayProp;
-        partial void OnExplicitlyNullableTimeOfDayPropChanging(global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> value);
+        private global::System.Nullable<global::System.TimeOnly> _ExplicitlyNullableTimeOfDayProp;
+        partial void OnExplicitlyNullableTimeOfDayPropChanging(global::System.Nullable<global::System.TimeOnly> value);
         partial void OnExplicitlyNullableTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property NullableTimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> NullableTimeOfDayProp
+        public global::System.Nullable<global::System.TimeOnly> NullableTimeOfDayProp
         {
             get
             {
@@ -4008,8 +4008,8 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> _NullableTimeOfDayProp;
-        partial void OnNullableTimeOfDayPropChanging(global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> value);
+        private global::System.Nullable<global::System.TimeOnly> _NullableTimeOfDayProp;
+        partial void OnNullableTimeOfDayPropChanging(global::System.Nullable<global::System.TimeOnly> value);
         partial void OnNullableTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property NonNullableStreamProp in the schema.
@@ -5640,7 +5640,7 @@ namespace MergedFunctionalTest.DSC
         /// There are no comments for Property BagOfDate in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Date> BagOfDate
+        public global::System.Collections.ObjectModel.ObservableCollection<global::System.DateOnly> BagOfDate
         {
             get
             {
@@ -5655,14 +5655,14 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Date> _BagOfDate = new global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Date>();
-        partial void OnBagOfDateChanging(global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Date> value);
+        private global::System.Collections.ObjectModel.ObservableCollection<global::System.DateOnly> _BagOfDate = new global::System.Collections.ObjectModel.ObservableCollection<global::System.DateOnly>();
+        partial void OnBagOfDateChanging(global::System.Collections.ObjectModel.ObservableCollection<global::System.DateOnly> value);
         partial void OnBagOfDateChanged();
         /// <summary>
         /// There are no comments for Property BagOfTimeOfDay in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.TimeOfDay> BagOfTimeOfDay
+        public global::System.Collections.ObjectModel.ObservableCollection<global::System.TimeOnly> BagOfTimeOfDay
         {
             get
             {
@@ -5677,8 +5677,8 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.TimeOfDay> _BagOfTimeOfDay = new global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.TimeOfDay>();
-        partial void OnBagOfTimeOfDayChanging(global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.TimeOfDay> value);
+        private global::System.Collections.ObjectModel.ObservableCollection<global::System.TimeOnly> _BagOfTimeOfDay = new global::System.Collections.ObjectModel.ObservableCollection<global::System.TimeOnly>();
+        partial void OnBagOfTimeOfDayChanging(global::System.Collections.ObjectModel.ObservableCollection<global::System.TimeOnly> value);
         partial void OnBagOfTimeOfDayChanged();
         /// <summary>
         /// There are no comments for Property BagOfStream in the schema.
@@ -6505,7 +6505,7 @@ namespace MergedFunctionalTest.DSC
         /// There are no comments for Property DateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::Microsoft.OData.Edm.Date DateProp
+        public global::System.DateOnly DateProp
         {
             get
             {
@@ -6520,14 +6520,14 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::Microsoft.OData.Edm.Date _DateProp = global::Microsoft.OData.Edm.Date.Parse("2014-10-08");
-        partial void OnDatePropChanging(global::Microsoft.OData.Edm.Date value);
+        private global::System.DateOnly _DateProp = global::System.DateOnly.Parse("2014-10-08");
+        partial void OnDatePropChanging(global::System.DateOnly value);
         partial void OnDatePropChanged();
         /// <summary>
         /// There are no comments for Property TimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public global::Microsoft.OData.Edm.TimeOfDay TimeOfDayProp
+        public global::System.TimeOnly TimeOfDayProp
         {
             get
             {
@@ -6542,8 +6542,8 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::Microsoft.OData.Edm.TimeOfDay _TimeOfDayProp = global::Microsoft.OData.Edm.TimeOfDay.Parse("12:34:56");
-        partial void OnTimeOfDayPropChanging(global::Microsoft.OData.Edm.TimeOfDay value);
+        private global::System.TimeOnly _TimeOfDayProp = global::System.TimeOnly.Parse("12:34:56");
+        partial void OnTimeOfDayPropChanging(global::System.TimeOnly value);
         partial void OnTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property GeographyProp in the schema.

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/CodeGen/MergedFunctionalTestDSC.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/CodeGen/MergedFunctionalTestDSC.vb
@@ -2730,8 +2730,8 @@ Namespace MergedFunctionalTest.DSC
                     ByVal nonNullableStringProp As String,  _
                     ByVal nonNullableDurationProp As Global.System.TimeSpan,  _
                     ByVal nonNullableDateTimeOffsetProp As Global.System.DateTimeOffset,  _
-                    ByVal nonNullableDateProp As Global.Microsoft.OData.Edm.Date,  _
-                    ByVal nonNullableTimeOfDayProp As Global.Microsoft.OData.Edm.TimeOfDay,  _
+                    ByVal nonNullableDateProp As Global.System.DateOnly,  _
+                    ByVal nonNullableTimeOfDayProp As Global.System.TimeOnly,  _
                     ByVal nonNullableStreamProp As Global.Microsoft.OData.Client.DataServiceStreamLink,  _
                     ByVal nonNullableSByteProp As SByte,  _
                     ByVal nonNullableGeography As Global.Microsoft.Spatial.Geography,  _
@@ -3658,7 +3658,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property NonNullableDateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property NonNullableDateProp() As Global.Microsoft.OData.Edm.Date
+        Public Property NonNullableDateProp() As Global.System.DateOnly
             Get
                 Return Me._NonNullableDateProp
             End Get
@@ -3670,8 +3670,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _NonNullableDateProp As Global.Microsoft.OData.Edm.Date
-        Partial Private Sub OnNonNullableDatePropChanging(ByVal value As Global.Microsoft.OData.Edm.Date)
+        Private _NonNullableDateProp As Global.System.DateOnly
+        Partial Private Sub OnNonNullableDatePropChanging(ByVal value As Global.System.DateOnly)
         End Sub
         Partial Private Sub OnNonNullableDatePropChanged()
         End Sub
@@ -3679,7 +3679,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property ExplicitlyNullableDateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property ExplicitlyNullableDateProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
+        Public Property ExplicitlyNullableDateProp() As Global.System.Nullable(Of Global.System.DateOnly)
             Get
                 Return Me._ExplicitlyNullableDateProp
             End Get
@@ -3691,8 +3691,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _ExplicitlyNullableDateProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
-        Partial Private Sub OnExplicitlyNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date))
+        Private _ExplicitlyNullableDateProp As Global.System.Nullable(Of Global.System.DateOnly)
+        Partial Private Sub OnExplicitlyNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.System.DateOnly))
         End Sub
         Partial Private Sub OnExplicitlyNullableDatePropChanged()
         End Sub
@@ -3700,7 +3700,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property NullableDateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property NullableDateProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
+        Public Property NullableDateProp() As Global.System.Nullable(Of Global.System.DateOnly)
             Get
                 Return Me._NullableDateProp
             End Get
@@ -3712,8 +3712,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _NullableDateProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
-        Partial Private Sub OnNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date))
+        Private _NullableDateProp As Global.System.Nullable(Of Global.System.DateOnly)
+        Partial Private Sub OnNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.System.DateOnly))
         End Sub
         Partial Private Sub OnNullableDatePropChanged()
         End Sub
@@ -3721,7 +3721,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property NonNullableTimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property NonNullableTimeOfDayProp() As Global.Microsoft.OData.Edm.TimeOfDay
+        Public Property NonNullableTimeOfDayProp() As Global.System.TimeOnly
             Get
                 Return Me._NonNullableTimeOfDayProp
             End Get
@@ -3733,8 +3733,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _NonNullableTimeOfDayProp As Global.Microsoft.OData.Edm.TimeOfDay
-        Partial Private Sub OnNonNullableTimeOfDayPropChanging(ByVal value As Global.Microsoft.OData.Edm.TimeOfDay)
+        Private _NonNullableTimeOfDayProp As Global.System.TimeOnly
+        Partial Private Sub OnNonNullableTimeOfDayPropChanging(ByVal value As Global.System.TimeOnly)
         End Sub
         Partial Private Sub OnNonNullableTimeOfDayPropChanged()
         End Sub
@@ -3742,7 +3742,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property ExplicitlyNullableTimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property ExplicitlyNullableTimeOfDayProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
+        Public Property ExplicitlyNullableTimeOfDayProp() As Global.System.Nullable(Of Global.System.TimeOnly)
             Get
                 Return Me._ExplicitlyNullableTimeOfDayProp
             End Get
@@ -3754,8 +3754,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _ExplicitlyNullableTimeOfDayProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
-        Partial Private Sub OnExplicitlyNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay))
+        Private _ExplicitlyNullableTimeOfDayProp As Global.System.Nullable(Of Global.System.TimeOnly)
+        Partial Private Sub OnExplicitlyNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.System.TimeOnly))
         End Sub
         Partial Private Sub OnExplicitlyNullableTimeOfDayPropChanged()
         End Sub
@@ -3763,7 +3763,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property NullableTimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property NullableTimeOfDayProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
+        Public Property NullableTimeOfDayProp() As Global.System.Nullable(Of Global.System.TimeOnly)
             Get
                 Return Me._NullableTimeOfDayProp
             End Get
@@ -3775,8 +3775,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _NullableTimeOfDayProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
-        Partial Private Sub OnNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay))
+        Private _NullableTimeOfDayProp As Global.System.Nullable(Of Global.System.TimeOnly)
+        Partial Private Sub OnNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.System.TimeOnly))
         End Sub
         Partial Private Sub OnNullableTimeOfDayPropChanged()
         End Sub
@@ -5338,7 +5338,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property BagOfDate in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property BagOfDate() As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Date)
+        Public Property BagOfDate() As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.System.DateOnly)
             Get
                 Return Me._BagOfDate
             End Get
@@ -5350,8 +5350,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _BagOfDate As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Date) = New Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Date)()
-        Partial Private Sub OnBagOfDateChanging(ByVal value As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Date))
+        Private _BagOfDate As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.System.DateOnly) = New Global.System.Collections.ObjectModel.ObservableCollection(Of Global.System.DateOnly)()
+        Partial Private Sub OnBagOfDateChanging(ByVal value As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.System.DateOnly))
         End Sub
         Partial Private Sub OnBagOfDateChanged()
         End Sub
@@ -5359,7 +5359,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property BagOfTimeOfDay in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property BagOfTimeOfDay() As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.TimeOfDay)
+        Public Property BagOfTimeOfDay() As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.System.TimeOnly)
             Get
                 Return Me._BagOfTimeOfDay
             End Get
@@ -5371,8 +5371,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _BagOfTimeOfDay As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.TimeOfDay) = New Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.TimeOfDay)()
-        Partial Private Sub OnBagOfTimeOfDayChanging(ByVal value As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.TimeOfDay))
+        Private _BagOfTimeOfDay As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.System.TimeOnly) = New Global.System.Collections.ObjectModel.ObservableCollection(Of Global.System.TimeOnly)()
+        Partial Private Sub OnBagOfTimeOfDayChanging(ByVal value As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.System.TimeOnly))
         End Sub
         Partial Private Sub OnBagOfTimeOfDayChanged()
         End Sub
@@ -6167,7 +6167,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property DateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property DateProp() As Global.Microsoft.OData.Edm.Date
+        Public Property DateProp() As Global.System.DateOnly
             Get
                 Return Me._DateProp
             End Get
@@ -6179,8 +6179,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _DateProp As Global.Microsoft.OData.Edm.Date = Global.Microsoft.OData.Edm.Date.Parse("2014-10-08")
-        Partial Private Sub OnDatePropChanging(ByVal value As Global.Microsoft.OData.Edm.Date)
+        Private _DateProp As Global.System.DateOnly = Global.System.DateOnly.Parse("2014-10-08")
+        Partial Private Sub OnDatePropChanging(ByVal value As Global.System.DateOnly)
         End Sub
         Partial Private Sub OnDatePropChanged()
         End Sub
@@ -6188,7 +6188,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property TimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Public Property TimeOfDayProp() As Global.Microsoft.OData.Edm.TimeOfDay
+        Public Property TimeOfDayProp() As Global.System.TimeOnly
             Get
                 Return Me._TimeOfDayProp
             End Get
@@ -6200,8 +6200,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.4.0")>  _
-        Private _TimeOfDayProp As Global.Microsoft.OData.Edm.TimeOfDay = Global.Microsoft.OData.Edm.TimeOfDay.Parse("12:34:56")
-        Partial Private Sub OnTimeOfDayPropChanging(ByVal value As Global.Microsoft.OData.Edm.TimeOfDay)
+        Private _TimeOfDayProp As Global.System.TimeOnly = Global.System.TimeOnly.Parse("12:34:56")
+        Partial Private Sub OnTimeOfDayPropChanging(ByVal value As Global.System.TimeOnly)
         End Sub
         Partial Private Sub OnTimeOfDayPropChanged()
         End Sub

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/Microsoft.OData.Service.Design.T4.UnitTests.csproj
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/Microsoft.OData.Service.Design.T4.UnitTests.csproj
@@ -3,10 +3,11 @@
     <AssemblyAttributeClsCompliant>false</AssemblyAttributeClsCompliant>
  
     <AssemblyName>Microsoft.OData.Client.Design.T4.UnitTests</AssemblyName>
+    <RootNamespace>Microsoft.OData.Client.Design.T4.UnitTests</RootNamespace>
  
     <SignAssemblyAttribute>false</SignAssemblyAttribute>
     <RestorePackages>true</RestorePackages>
-    <TargetFrameworks>net48</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <ShouldGenerateAssemblyAttributeFile>false</ShouldGenerateAssemblyAttributeFile>
@@ -18,13 +19,11 @@
 
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.1.0" />
-    <PackageReference Include="EntityFramework" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="Microsoft.VisualStudio.TextTemplating.Interfaces.10.0" Version="10.0.30320" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="Microsoft.VisualStudio.TextTemplating.Interfaces.10.0" Version="17.0.32112.339" />
    </ItemGroup>
   
   <ItemGroup>
@@ -40,7 +39,6 @@
     <Compile Include="UtilsTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(EnlistmentRoot)\test\FunctionalTests\Service\Microsoft.OData.Service.csproj" /> 
     <ProjectReference Include="$(EnlistmentRoot)\src\Microsoft.OData.Core\Microsoft.OData.Core.csproj" /> 
     <ProjectReference Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\Microsoft.OData.Client.csproj" /> 
     <ProjectReference Include="$(EnlistmentRoot)\src\CodeGen\Microsoft.Data.Web.Design.T4.csproj" /> 

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/Microsoft.OData.Service.Design.T4.UnitTests.csproj
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/Microsoft.OData.Service.Design.T4.UnitTests.csproj
@@ -20,6 +20,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataT4CodeGeneratorTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataT4CodeGeneratorTests.cs
@@ -5,7 +5,7 @@
 //---------------------------------------------------------------------
 
 using System;
-using System.CodeDom.Compiler;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -14,11 +14,12 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Xml;
 using FluentAssertions;
-using Microsoft.CSharp;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.Spatial;
-using Microsoft.VisualBasic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.OData.Client.Design.T4.UnitTests
@@ -452,6 +453,11 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
 
         private static string CodeGenWithT4TemplateFromCommandline(string edmx, string namespacePrefix, bool isCSharp, bool useDataServiceCollection)
         {
+            if (!File.Exists(T4TransformToolPath))
+            {
+                Assert.Inconclusive("TextTransform.exe not found at: " + T4TransformToolPath + ". This test requires Visual Studio to be installed.");
+            }
+
             File.WriteAllText(EdmxTestInputFile, edmx);
 
             ODataT4CodeGenerator.LanguageOption option;
@@ -519,40 +525,74 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
 
         private static void GeneratedCodeShouldCompile(string source, bool isCSharp)
         {
-            CompilerParameters compilerOptions = new CompilerParameters
+            var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+            var metadataReferences = new List<MetadataReference>();
+
+            // Add OData assembly references
+            var referenceAssemblies = new[]
             {
-                GenerateExecutable = false,
-                GenerateInMemory = true,
-                IncludeDebugInformation = false,
-                TreatWarningsAsErrors = true,
-                WarningLevel = 4,
-                ReferencedAssemblies =
-                {
-                    typeof(DataServiceContext).Assembly.Location,
-                    typeof(IEdmModel).Assembly.Location,
-                    typeof(GeographyPoint).Assembly.Location,
-                    typeof(ODataVersion).Assembly.Location,
-                    DataFxAssemblyRef.File.System,
-                    DataFxAssemblyRef.File.SystemCore,
-                    DataFxAssemblyRef.File.SystemIO,
-                    DataFxAssemblyRef.File.SystemRuntime,
-                    DataFxAssemblyRef.File.SystemXml,
-                    DataFxAssemblyRef.File.SystemXmlReaderWriter
-                }
+                typeof(DataServiceContext).Assembly,
+                typeof(IEdmModel).Assembly,
+                typeof(GeographyPoint).Assembly,
+                typeof(ODataVersion).Assembly,
+                typeof(object).Assembly,
+                typeof(Uri).Assembly,
+                typeof(System.Linq.Enumerable).Assembly,
+                typeof(System.Collections.ObjectModel.ObservableCollection<>).Assembly,
+                typeof(System.ComponentModel.INotifyPropertyChanged).Assembly,
+                typeof(System.Xml.XmlReader).Assembly,
             };
 
-            CodeDomProvider codeProvider = null;
+            foreach (var asm in referenceAssemblies)
+            {
+                metadataReferences.Add(MetadataReference.CreateFromFile(asm.Location));
+            }
+
+            // Add essential runtime references
+            var runtimeRefs = new[] { "System.Runtime.dll", "System.Collections.dll", "netstandard.dll", "System.Xml.dll", "System.IO.dll", "System.Xml.ReaderWriter.dll", "System.Private.Xml.dll", "System.Text.Json.dll" };
+            foreach (var runtimeRef in runtimeRefs)
+            {
+                var path = Path.Combine(runtimeDir, runtimeRef);
+                if (File.Exists(path))
+                {
+                    metadataReferences.Add(MetadataReference.CreateFromFile(path));
+                }
+            }
+
+            IEnumerable<Diagnostic> diagnostics;
             if (isCSharp)
             {
-                codeProvider = new CSharpCodeProvider();
+                var syntaxTree = CSharpSyntaxTree.ParseText(source);
+                var compilation = CSharpCompilation.Create(
+                    "TestAssembly",
+                    new[] { syntaxTree },
+                    metadataReferences,
+                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+                diagnostics = compilation.GetDiagnostics();
             }
             else
             {
-                codeProvider = new VBCodeProvider();
+                // Add VB runtime for VisualBasic compilation
+                foreach (var vbDll in new[] { "Microsoft.VisualBasic.dll", "Microsoft.VisualBasic.Core.dll" })
+                {
+                    var vbPath = Path.Combine(runtimeDir, vbDll);
+                    if (File.Exists(vbPath))
+                    {
+                        metadataReferences.Add(MetadataReference.CreateFromFile(vbPath));
+                    }
+                }
+
+                var syntaxTree = VisualBasicSyntaxTree.ParseText(source);
+                var compilation = VisualBasicCompilation.Create(
+                    "TestAssembly",
+                    new[] { syntaxTree },
+                    metadataReferences,
+                    new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, rootNamespace: ""));
+                diagnostics = compilation.GetDiagnostics();
             }
 
-            var results = codeProvider.CompileAssemblyFromSource(compilerOptions, source);
-            results.Errors.Should().BeEmpty();
+            var errors = diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
+            errors.Should().BeEmpty("Generated code should compile without errors, but got:\n" + string.Join("\n", errors.Select(e => e.ToString())));
         }
     }
 }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataT4CodeGeneratorTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataT4CodeGeneratorTests.cs
@@ -567,7 +567,8 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
                     "TestAssembly",
                     new[] { syntaxTree },
                     metadataReferences,
-                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                        .WithGeneralDiagnosticOption(ReportDiagnostic.Error));
                 diagnostics = compilation.GetDiagnostics();
             }
             else
@@ -587,12 +588,13 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
                     "TestAssembly",
                     new[] { syntaxTree },
                     metadataReferences,
-                    new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, rootNamespace: ""));
+                    new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, rootNamespace: "")
+                        .WithGeneralDiagnosticOption(ReportDiagnostic.Error));
                 diagnostics = compilation.GetDiagnostics();
             }
 
-            var errors = diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
-            errors.Should().BeEmpty("Generated code should compile without errors, but got:\n" + string.Join("\n", errors.Select(e => e.ToString())));
+            var errors = diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error || d.Severity == DiagnosticSeverity.Warning).ToList();
+            errors.Should().BeEmpty("Generated code should compile without errors or warnings, but got:\n" + string.Join("\n", errors.Select(e => e.ToString())));
         }
     }
 }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/UtilsTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/UtilsTests.cs
@@ -563,15 +563,47 @@ namespace Microsoft.OData.Service.Design.UnitTests
         }
 
         [TestMethod]
-        public void GetClrTypeNameDateShouldBeGlobalMicrosoftODataEdmLibraryDate()
+        public void GetClrTypeNameDateShouldBeGlobalSystemDateOnly()
         {
-            ODataT4CodeGenerator.Utils.GetClrTypeName(new EdmPrimitiveType(EdmPrimitiveTypeKind.Date), template).Should().Be("global::Microsoft.OData.Edm.Date");
+            ODataT4CodeGenerator.Utils.GetClrTypeName(new EdmPrimitiveType(EdmPrimitiveTypeKind.Date), template).Should().Be("global::System.DateOnly");
         }
 
         [TestMethod]
-        public void GetClrTypeNameTimeOfDayShouldBeGlobalMicrosoftODataEdmLibraryTimeOfDay()
+        public void GetClrTypeNameTimeOfDayShouldBeGlobalSystemTimeOnly()
         {
-            ODataT4CodeGenerator.Utils.GetClrTypeName(new EdmPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay), template).Should().Be("global::Microsoft.OData.Edm.TimeOfDay");
+            ODataT4CodeGenerator.Utils.GetClrTypeName(new EdmPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay), template).Should().Be("global::System.TimeOnly");
+        }
+
+        [TestMethod]
+        public void GetClrTypeNameNullableDateShouldBeGlobalSystemNullableOfDateOnly()
+        {
+            EdmPrimitiveType edmPrimitiveType = new EdmPrimitiveType(EdmPrimitiveTypeKind.Date);
+            IEdmTypeReference edmTypeReference = new EdmTypeReferenceForTest(edmPrimitiveType, true);
+            ODataT4CodeGenerator.Utils.GetClrTypeName(edmTypeReference, false, template, context).Should().Be("global::System.Nullable<global::System.DateOnly>");
+        }
+
+        [TestMethod]
+        public void GetClrTypeNameNullableTimeOfDayShouldBeGlobalSystemNullableOfTimeOnly()
+        {
+            EdmPrimitiveType edmPrimitiveType = new EdmPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay);
+            IEdmTypeReference edmTypeReference = new EdmTypeReferenceForTest(edmPrimitiveType, true);
+            ODataT4CodeGenerator.Utils.GetClrTypeName(edmTypeReference, false, template, context).Should().Be("global::System.Nullable<global::System.TimeOnly>");
+        }
+
+        [TestMethod]
+        public void GetClrTypeNameNonNullableDateShouldBeGlobalSystemDateOnly()
+        {
+            EdmPrimitiveType edmPrimitiveType = new EdmPrimitiveType(EdmPrimitiveTypeKind.Date);
+            IEdmTypeReference edmTypeReference = new EdmTypeReferenceForTest(edmPrimitiveType, false);
+            ODataT4CodeGenerator.Utils.GetClrTypeName(edmTypeReference, false, template, context).Should().Be("global::System.DateOnly");
+        }
+
+        [TestMethod]
+        public void GetClrTypeNameNonNullableTimeOfDayShouldBeGlobalSystemTimeOnly()
+        {
+            EdmPrimitiveType edmPrimitiveType = new EdmPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay);
+            IEdmTypeReference edmTypeReference = new EdmTypeReferenceForTest(edmPrimitiveType, false);
+            ODataT4CodeGenerator.Utils.GetClrTypeName(edmTypeReference, false, template, context).Should().Be("global::System.TimeOnly");
         }
 
         [TestMethod]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

 Fixes: #3553 (https://github.com/odata/odata.net/issues/3553)
 
 It seems we never run the Code Gen tests in dev-9x.
 
 So, this PR is also to fix the CodeGen project and test running issues.
 
*This pull request fixes #3553.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
