### PR TITLE
Fix: Remove invalid schedules: none from pipeline YAML

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -1,5 +1,11 @@
 trigger: none
-schedules: none
+# schedules: 
+# - cron: 0 5 * * 1,2,3,4,5
+#   branches:
+#     include:
+#     - odl-9-new-writer
+#     - release/*
+#     - main
 resources:
   repositories:
   - repository: self


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

This PR fixes a pipeline YAML validation error caused by an invalid configuration:

```
/azure-pipelines-nightly.yml (Line: 2, Col: 12): Unexpected value 'none'
```

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
