### PR TITLE
Push pkgs to internal feed

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -102,6 +102,14 @@ extends:
               packagesToPush: $(Build.ArtifactStagingDirectory)\Nuget-Release\*Nightly*.nupkg
               nuGetFeedType: external
               publishFeedCredentials: 'MyGet.org - ODL Feed'
+            - output: nuget
+              displayName: 'NuGet push - Packages to Internal Feed'
+              packageParentPath: '$(Build.ArtifactStagingDirectory)\Nuget-Release'
+              packagesToPush: $(Build.ArtifactStagingDirectory)\Nuget-Release\*.nupkg
+              nuGetFeedType: internal
+              publishVstsFeed: $(ODataPublishFeed)
+              allowPackageConflicts: true
+              publishPackageMetadata: true
         steps:
           - template: /nightly.yml@self
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

Push pkgs to internal feed

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
