### PR TITLE
Publish only nightly packages from the nightly pipeline

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -15,15 +15,6 @@ schedules:
     - main
     - dev-8.x
 
-parameters:
-  - name: PublishMode
-    displayName: Package publishing mode ('NightlyOnly' for nightly packages; 'ReleaseAndNightly' for both release and nightly packages)
-    type: string
-    default: NightlyOnly
-    values:
-    - NightlyOnly
-    - ReleaseAndNightly
-
 resources:
   repositories:
   - repository: self
@@ -42,13 +33,8 @@ variables:
 - group: OData-Shared
 - name: AZURE_ARTIFACTS_FEED
   value: "$(ODataFeed)"
-- ${{ if eq(parameters.PublishMode, 'NightlyOnly') }}:
-  - name: PackagesToPush
-    value: $(Build.ArtifactStagingDirectory)\Nuget-Release\*Nightly*nupkg
-
-- ${{ if eq(parameters.PublishMode, 'ReleaseAndNightly') }}: 
-  - name: PackagesToPush
-    value: '$(Build.ArtifactStagingDirectory)\Nuget-Release\*.nupkg;$(Build.ArtifactStagingDirectory)\Nuget-Release\*.snupkg'
+- name: PackagesToPush
+  value: $(Build.ArtifactStagingDirectory)\Nuget-Release\*Nightly*nupkg
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

Publish only nightly packages from the nightly pipeline

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
