### PR TITLE
Fix #3570: Support empty collection when using Contains

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/ExpressionWriter.cs
+++ b/src/Microsoft.OData.Client/ALinq/ExpressionWriter.cs
@@ -578,12 +578,8 @@ namespace Microsoft.OData.Client
                     listExpr.Append(uriLiteral);
                 }
 
-                // Contains cannot be used with an empty static collection
-                if (listExpr.Length == 0)
-                {
-                    throw new InvalidOperationException(SRResources.ALinq_ContainsNotValidOnEmptyCollection);
-                }
-
+                // An empty collection is translated to the empty 'in' collection literal, e.g. "Name in ()",
+                // which the OData query parser supports and evaluates to no matches.
                 listExpr.Insert(0, UriHelper.LEFTPAREN);
                 listExpr.Append(UriHelper.RIGHTPAREN);
 

--- a/src/Microsoft.OData.Client/SRResources.Designer.cs
+++ b/src/Microsoft.OData.Client/SRResources.Designer.cs
@@ -286,15 +286,6 @@ namespace Microsoft.OData.Client {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Contains method cannot be used with an empty collection..
-        /// </summary>
-        internal static string ALinq_ContainsNotValidOnEmptyCollection {
-            get {
-                return ResourceManager.GetString("ALinq_ContainsNotValidOnEmptyCollection", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Could not convert constant {0} expression to string..
         /// </summary>
         internal static string ALinq_CouldNotConvert {

--- a/src/Microsoft.OData.Client/SRResources.resx
+++ b/src/Microsoft.OData.Client/SRResources.resx
@@ -671,9 +671,6 @@
   <data name="ALinq_TypeTokenWithNoTrailingNavProp" xml:space="preserve">
     <value>Found an illegal type token '{0}' without a trailing navigation property. </value>
   </data>
-  <data name="ALinq_ContainsNotValidOnEmptyCollection" xml:space="preserve">
-    <value>The Contains method cannot be used with an empty collection.</value>
-  </data>
   <data name="ALinq_AggregationMethodNotSupported" xml:space="preserve">
     <value>The aggregation method '{0}' is not supported.</value>
   </data>

--- a/test/UnitTests/Microsoft.OData.Client.Tests/DataServiceQueryProviderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/DataServiceQueryProviderTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.OData.Client.Tests
         }
 
         [Fact]
-        public void ThrowsForEnumerableContainsWithEmptyCollection()
+        public void TranslatesEnumerableContainsWithEmptyCollectionToEmptyInOperator()
         {
             // Arrange
             var sut = new DataServiceQueryProvider(dsc);
@@ -118,14 +118,14 @@ namespace Microsoft.OData.Client.Tests
                 .Where(product => Enumerable.Empty<string>().Contains(product.Name));
 
             // Act
-            var exception = Assert.ThrowsAny<InvalidOperationException>(() => sut.Translate(products.Expression));
+            var queryComponents = sut.Translate(products.Expression);
 
             // Assert
-            Assert.Equal(SRResources.ALinq_ContainsNotValidOnEmptyCollection, exception.Message);
+            Assert.Equal(@"http://root/Products?$filter=Name in ()", queryComponents.Uri.ToString());
         }
 
         [Fact]
-        public void ThrowsForEnumerableContainsWithEmptyEnumCollection()
+        public void TranslatesEnumerableContainsWithEmptyEnumCollectionToEmptyInOperator()
         {
             // Arrange
             var sut = new DataServiceQueryProvider(dsc);
@@ -133,10 +133,10 @@ namespace Microsoft.OData.Client.Tests
                 .Where(product => Enumerable.Empty<Color>().Contains(product.Color));
 
             // Act
-            var exception = Assert.ThrowsAny<InvalidOperationException>(() => sut.Translate(products.Expression));
+            var queryComponents = sut.Translate(products.Expression);
 
             // Assert
-            Assert.Equal(SRResources.ALinq_ContainsNotValidOnEmptyCollection, exception.Message);
+            Assert.Equal(@"http://root/Products?$filter=Color in ()", queryComponents.Uri.ToString());
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Resources/SRResourcesTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Resources/SRResourcesTests.cs
@@ -39,7 +39,6 @@ public class SRResourcesTests
     [InlineData("ALinq_CollectionPropertyNotSupportedInWhere", new object[] { "Value" })]
     [InlineData("ALinq_ConditionalNotSupported", new object[] { })]
     [InlineData("ALinq_ConstantNotSupported", new object[] { "Value" })]
-    [InlineData("ALinq_ContainsNotValidOnEmptyCollection", new object[] { })]
     [InlineData("ALinq_CouldNotConvert", new object[] { "Value" })]
     [InlineData("ALinq_ExpressionCannotEndWithTypeAs", new object[] { "Value", "Value" })]
     [InlineData("ALinq_ExpressionNotSupportedInProjection", new object[] { "Value", "Value" })]


### PR DESCRIPTION
LINQ queries such as 'skus.Contains(x.Sku)' translate to an OData 'in' filter. When the source collection is empty, the client threw InvalidOperationException (ALinq_ContainsNotValidOnEmptyCollection) instead of producing a valid query.

Emit the empty 'in' collection literal (e.g. 'Name in ()') for an empty collection. The OData query parser already supports this form and evaluates it to no matches, so the query now returns an empty result set instead of failing.

Updated the two client tests that asserted the old throwing behavior to verify the new 'in ()' translation.




<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
