### PR TITLE
Fix #3505: Surface parsing exception for bad-format primitive literals

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriPrimitiveTypeParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriPrimitiveTypeParser.cs
@@ -186,76 +186,63 @@ namespace Microsoft.OData.UriParser
                     return false;
                 }
 
-                try
+                switch (targetTypeKind)
                 {
-                    switch (targetTypeKind)
-                    {
-                        case EdmPrimitiveTypeKind.Boolean:
-                            targetValue = text.ToBoolean();
-                            break;
-                        case EdmPrimitiveTypeKind.Byte:
-                            targetValue = text.ToByte();
-                            break;
-                        case EdmPrimitiveTypeKind.SByte:
-                            targetValue = text.ToSByte();
-                            break;
-                        case EdmPrimitiveTypeKind.Int16:
-                            targetValue = text.ToInt16();
-                            break;
-                        case EdmPrimitiveTypeKind.Int32:
-                            targetValue = text.ToInt32();
+                    case EdmPrimitiveTypeKind.Boolean:
+                        targetValue = text.ToBoolean();
+                        break;
+                    case EdmPrimitiveTypeKind.Byte:
+                        targetValue = text.ToByte();
+                        break;
+                    case EdmPrimitiveTypeKind.SByte:
+                        targetValue = text.ToSByte();
+                        break;
+                    case EdmPrimitiveTypeKind.Int16:
+                        targetValue = text.ToInt16();
+                        break;
+                    case EdmPrimitiveTypeKind.Int32:
+                        targetValue = text.ToInt32();
 
-                            break;
-                        case EdmPrimitiveTypeKind.Int64:
-                            UriParserHelper.TryRemoveLiteralSuffix(ExpressionConstants.LiteralSuffixInt64, ref text);
-                            targetValue = text.ToInt64();
-                            break;
-                        case EdmPrimitiveTypeKind.Single:
-                            UriParserHelper.TryRemoveLiteralSuffix(ExpressionConstants.LiteralSuffixSingle, ref text);
-                            targetValue = text.ToSingle();
-                            break;
-                        case EdmPrimitiveTypeKind.Double:
-                            UriParserHelper.TryRemoveLiteralSuffix(ExpressionConstants.LiteralSuffixDouble, ref text);
-                            targetValue = text.ToDouble();
-                            break;
-                        case EdmPrimitiveTypeKind.Decimal:
-                            UriParserHelper.TryRemoveLiteralSuffix(ExpressionConstants.LiteralSuffixDecimal, ref text);
-                            try
+                        break;
+                    case EdmPrimitiveTypeKind.Int64:
+                        UriParserHelper.TryRemoveLiteralSuffix(ExpressionConstants.LiteralSuffixInt64, ref text);
+                        targetValue = text.ToInt64();
+                        break;
+                    case EdmPrimitiveTypeKind.Single:
+                        UriParserHelper.TryRemoveLiteralSuffix(ExpressionConstants.LiteralSuffixSingle, ref text);
+                        targetValue = text.ToSingle();
+                        break;
+                    case EdmPrimitiveTypeKind.Double:
+                        UriParserHelper.TryRemoveLiteralSuffix(ExpressionConstants.LiteralSuffixDouble, ref text);
+                        targetValue = text.ToDouble();
+                        break;
+                    case EdmPrimitiveTypeKind.Decimal:
+                        UriParserHelper.TryRemoveLiteralSuffix(ExpressionConstants.LiteralSuffixDecimal, ref text);
+                        try
+                        {
+                            targetValue = text.ToDecimal();
+                        }
+                        catch (FormatException)
+                        {
+                            // we need to support exponential format for decimals since we used to support them in V1
+                            decimal result;
+                            if (decimal.TryParse(text, NumberStyles.Float, NumberFormatInfo.InvariantInfo, out result))
                             {
-                                targetValue = text.ToDecimal();
+                                targetValue = result;
                             }
-                            catch (FormatException)
+                            else
                             {
-                                // we need to support exponential format for decimals since we used to support them in V1
-                                decimal result;
-                                if (decimal.TryParse(text, NumberStyles.Float, NumberFormatInfo.InvariantInfo, out result))
-                                {
-                                    targetValue = result;
-                                }
-                                else
-                                {
-                                    targetValue = default(decimal);
-                                    return false;
-                                }
+                                targetValue = default(decimal);
+                                return false;
                             }
+                        }
 
-                            break;
-                        default:
-                            throw new ODataException(Error.Format(SRResources.General_InternalError, InternalErrorCodes.UriPrimitiveTypeParser_TryUriStringToPrimitive));
-                    }
+                        break;
+                    default:
+                        throw new ODataException(Error.Format(SRResources.General_InternalError, InternalErrorCodes.UriPrimitiveTypeParser_TryUriStringToPrimitive));
+                }
 
-                    return true;
-                }
-                catch (FormatException)
-                {
-                    targetValue = null;
-                    return false;
-                }
-                catch (OverflowException)
-                {
-                    targetValue = null;
-                    return false;
-                }
+                return true;
             }
 
             catch (FormatException primitiveParserException)

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralParserTests.cs
@@ -645,7 +645,9 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
 
             // Assert
             Assert.Null(output);
-            Assert.Null(exception);
+            // No custom parsers added; the built-in boolean parser cannot parse the non-conventional
+            // literal and surfaces a parsing exception (see issue #3505).
+            Assert.NotNull(exception);
         }
 
         [Fact]
@@ -992,7 +994,9 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             object output = DefaultUriLiteralParser.GetOrCreate(edmModel).ParseUriStringToType(CUSTOM_PARSER_BOOLEAN_VALID_VALUE_TRUE, booleanTypeReference, out exception);
 
             // Assert
-            Assert.Null(exception);
+            // The custom parser has been removed, so the built-in boolean parser now handles the value.
+            // It cannot parse the non-conventional literal and surfaces a parsing exception (see issue #3505).
+            Assert.NotNull(exception);
             Assert.Null(output);
         }
 
@@ -1008,7 +1012,8 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             object output = DefaultUriLiteralParser.GetOrCreate(edmModel).ParseUriStringToType(CUSTOM_PARSER_INT_VALID_VALUE, Int32TypeReference, out exception);
 
             // Assert
-            Assert.Null(exception);
+            // The built-in Int32 parser cannot parse the non-conventional literal and surfaces a parsing exception (see issue #3505).
+            Assert.NotNull(exception);
             Assert.Null(output);
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriPrimitiveTypeParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriPrimitiveTypeParserTests.cs
@@ -403,12 +403,36 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             Assert.Equal(new byte[] { 0x00, 0x01, 0x00, 0xff }, (byte[])output);
         }
 
+        [Theory]
+        [InlineData("2147483648")]  // Overflow
+        [InlineData("-2147483649")] // Overflow
+        [InlineData("notanumber")]  // Format exception
+        public void TryUriStringToPrimitiveWithInvalidInt32ShouldSetParsingException(string input)
+        {
+            UriLiteralParsingException exception;
+            Assert.False(this.TryParseUriStringToPrimitiveType(input, EdmCoreModel.Instance.GetInt32(false), out _, out exception));
+            Assert.NotNull(exception);
+        }
+
+        [Fact]
+        public void TryUriStringToPrimitiveWithInvalidBooleanShouldSetParsingException()
+        {
+            UriLiteralParsingException exception;
+            Assert.False(this.TryParseUriStringToPrimitiveType("notabool", EdmCoreModel.Instance.GetBoolean(false), out _, out exception));
+            Assert.NotNull(exception);
+        }
+
         #region Private Methods
 
         private bool TryParseUriStringToPrimitiveType(string text, IEdmTypeReference targetType, out object targetValue)
         {
             UriLiteralParsingException exception;
 
+            return UriPrimitiveTypeParser.TryParseUriStringToType(text.AsSpan(), targetType, out targetValue, out exception);
+        }
+
+        private bool TryParseUriStringToPrimitiveType(string text, IEdmTypeReference targetType, out object targetValue, out UriLiteralParsingException exception)
+        {
             return UriPrimitiveTypeParser.TryParseUriStringToType(text.AsSpan(), targetType, out targetValue, out exception);
         }
 


### PR DESCRIPTION
UriPrimitiveTypeParser.TryUriStringToPrimitive had inner catch blocks for FormatException and OverflowException that returned false while leaving the out parsingException null, before the outer catch blocks could construct a UriLiteralParsingException. This made callers unable to distinguish an unrecognized type from a recognized type with a bad-format value.

Remove the inner catch blocks so these exceptions propagate to the outer catch blocks that set a proper UriLiteralParsingException. Update tests that asserted the previous (incorrect) null-exception behavior and add coverage for invalid Int32/Boolean literals surfacing the exception.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
