### PR TITLE
Test #3510: Add coverage for non-SingleValueNode path in BindSegmentP…

### DIFF
--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ParameterAliasFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ParameterAliasFunctionalTests.cs
@@ -204,6 +204,33 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void ParsePath_CollectionStringAliasInBoundFunction_ProducesParameterAliasCollectionNodeParameterValue()
+        {
+            // Regression coverage for issue #3510: a collection-typed parameter supplied via a
+            // parameter alias binds to a ParameterAliasCollectionNode, which is NOT a SingleValueNode
+            // and therefore flows through the non-SingleValueNode branch of
+            // FunctionCallBinder.BindSegmentParameters.
+            const string relativeUri = "People(1)/Fully.Qualified.Namespace.OwnsTheseDogs(dogNames=@dogNames)?@dogNames=[\"Barky\",\"Junior\"]";
+            ParseUriAndVerify(
+                new Uri("http://gobbledygook/" + relativeUri),
+                (oDataPath, filterClause, orderByClause, selectExpandClause, aliasNodes) =>
+                {
+                    var parameters = oDataPath.LastSegment.ShouldBeOperationSegment(HardCodedTestModel.GetFunctionForOwnsTheseDogs()).Parameters;
+                    OperationSegmentParameter parameter = Assert.Single(parameters);
+                    Assert.Equal("dogNames", parameter.Name);
+
+                    ParameterAliasCollectionNode aliasCollectionNode = ((QueryNode)parameter.Value)
+                        .ShouldBeParameterAliasCollectionNode("@dogNames", EdmCoreModel.Instance.GetString(true));
+
+                    // The alias itself resolves to the collection literal.
+                    CollectionConstantNode constNode = Assert.IsType<CollectionConstantNode>(aliasNodes["@dogNames"]);
+                    Assert.Equal(2, constNode.Items.Count);
+                    constNode.Items.ElementAt(0).ShouldBeConstantQueryNode("Barky");
+                    constNode.Items.ElementAt(1).ShouldBeConstantQueryNode("Junior");
+                });
+        }
+
+        [Fact]
         public void ParsePath_IntArgumentOnShortParameter()
         {
             const string relativeUri = "People(1)/Fully.Qualified.Namespace.IsOlderThanShort(age=@age)?@age=1234";

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/PathFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/PathFunctionalTests.cs
@@ -569,6 +569,21 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void FunctionWithEmptyCollectionParameterInJsonWorks()
+        {
+            // Focused coverage for issue #3510: an empty collection literal still binds through the
+            // non-SingleValueNode branch of FunctionCallBinder.BindSegmentParameters and yields an
+            // empty CollectionConstantNode parameter value.
+            string parameterValue = "[]";
+            var result = PathFunctionalTestsUtil.RunParsePath($"People(1)/Fully.Qualified.Namespace.OwnsTheseDogs(dogNames={parameterValue})");
+            var parameters = result.LastSegment.ShouldBeOperationSegment(HardCodedTestModel.GetFunctionForOwnsTheseDogs()).Parameters;
+            var parameter = Assert.Single(parameters);
+            var collectionConstant = Assert.IsType<CollectionConstantNode>(parameter.Value);
+            Assert.Equal(parameterValue.AsMemory(), collectionConstant.LiteralText);
+            Assert.Empty(collectionConstant.Items);
+        }
+
+        [Fact]
         public void FunctionWithCollectionOfComplexParameterInJsonWorks()
         {
             string resource1 = "{\"Street\":\"NE 24th St.\",\"City\":\"Redmond\"}";


### PR DESCRIPTION
…arameters

FunctionCallBinder.BindSegmentParameters handles both SingleValueNode and non-SingleValueNode parameters, but the non-SingleValueNode branch lacked focused coverage. Add tests exercising collection-typed path operation parameters that flow through this branch:

- Collection parameter supplied via a parameter alias, which binds to a ParameterAliasCollectionNode (a non-SingleValueNode) and is verified as the resulting OperationSegmentParameter value.
- Empty collection literal producing an empty CollectionConstantNode value.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
