### PR TITLE
Fix #3581: Add support for TimeOfDay for edm:key

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Parsers/LiteralParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/LiteralParser.cs
@@ -39,6 +39,7 @@ namespace Microsoft.OData.UriParser
             { typeof(String), new StringPrimitiveParser() },
             { typeof(Decimal), new DecimalPrimitiveParser() },
             { typeof(Date), new DatePrimitiveParser() },
+            { typeof(TimeOfDay), new TimeOfDayPrimitiveParser() },
 
             // Types without single-quotes or type markers
             { typeof(Boolean), DelegatingPrimitiveParser<bool>.WithoutMarkup(XmlConvert.ToBoolean) },
@@ -655,6 +656,36 @@ namespace Microsoft.OData.UriParser
                 Date? date;
                 bool isSucceed = EdmValueParser.TryParseDate(text, out date);
                 targetValue = date;
+                return isSucceed;
+            }
+        }
+
+        /// <summary>
+        /// Parser specific to the Edm.TimeOfDay type.
+        /// </summary>
+        private sealed class TimeOfDayPrimitiveParser : PrimitiveParser
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TimeOfDayPrimitiveParser"/> class.
+            /// </summary>
+            public TimeOfDayPrimitiveParser()
+                : base(typeof(TimeOfDay))
+            {
+            }
+
+            /// <summary>
+            /// Tries to convert the given text into this parser's expected type. Conversion only, formatting should already have been removed.
+            /// </summary>
+            /// <param name="text">The text to convert.</param>
+            /// <param name="targetValue">The target value.</param>
+            /// <returns>
+            /// Whether or not conversion was successful.
+            /// </returns>
+            internal override bool TryConvert(string text, out object targetValue)
+            {
+                TimeOfDay? timeOfDay;
+                bool isSucceed = EdmValueParser.TryParseTimeOfDay(text, out timeOfDay);
+                targetValue = timeOfDay;
                 return isSucceed;
             }
         }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -32,6 +32,38 @@ namespace Microsoft.OData.Tests.UriParser
         private readonly Uri ServiceRoot = new Uri("http://host");
         private readonly Uri FullUri = new Uri("http://host/People");
 
+        [Theory]
+        [InlineData(false)] // parentheses key delimiter: Appointments(13:20:00)
+        [InlineData(true)]  // key-as-segment delimiter:  Appointments/13:20:00
+        public void ParseUriWithTimeOfDayKeyReturnsValidKeySegment(bool keyAsSegment)
+        {
+            // Arrange
+            EdmModel model = new EdmModel();
+            EdmEntityType appointment = new EdmEntityType("NS", "Appointment");
+            IEdmStructuralProperty keyProperty = appointment.AddStructuralProperty("Time", EdmCoreModel.Instance.GetTimeOfDay(false));
+            appointment.AddKeys(keyProperty);
+            model.AddElement(appointment);
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Container");
+            container.AddEntitySet("Appointments", appointment);
+            model.AddElement(container);
+
+            string relativeUri = keyAsSegment ? "Appointments/13:20:00" : "Appointments(13:20:00)";
+            ODataUriParser parser = new ODataUriParser(model, ServiceRoot, new Uri("http://host/" + relativeUri));
+            if (keyAsSegment)
+            {
+                parser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Slash;
+            }
+
+            // Act
+            ODataPath path = parser.ParsePath();
+
+            // Assert
+            KeySegment segment = Assert.IsType<KeySegment>(path.LastSegment);
+            KeyValuePair<string, object> key = Assert.Single(segment.Keys);
+            Assert.Equal("Time", key.Key);
+            Assert.Equal(new TimeOfDay(13, 20, 0, 0), key.Value);
+        }
+
         [Fact]
         public void NestedFilterWithDerivedType()
         {

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/LIteralParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/LIteralParserTests.cs
@@ -75,5 +75,17 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             Assert.True(parser.TryParseLiteral(typeof(TimeOfDay), "13:20:00", out output));
             Assert.Equal(new TimeOfDay(13, 20, 00, 0), output);
         }
+
+        [Theory]
+        [InlineData("1:20 PM")] // 12-hour/culture-specific format is not a valid OData time-of-day literal
+        [InlineData("24:00:00")] // hours out of range
+        [InlineData("13:60:00")] // minutes out of range
+        [InlineData("not-a-time")]
+        public void TryParseLiteralWithInvalidTimeOfDayFormatShouldReturnFalse(string literal)
+        {
+            var parser = LiteralParser.ForKeys(false /*keyAsSegment*/);
+            object output;
+            Assert.False(parser.TryParseLiteral(typeof(TimeOfDay), literal, out output));
+        }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/LIteralParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/LIteralParserTests.cs
@@ -57,5 +57,23 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             Assert.True(parser.TryParseLiteral(typeof(Date), "2015-09-28", out output));
             Assert.Equal(new Date(2015, 09, 28), output);
         }
+
+        [Fact]
+        public void TryParseLiteralWithTimeOfDayForSlashKeyDelimiterShouldReturnValidTimeOfDay()
+        {
+            var parser = LiteralParser.ForKeys(true /*keyAsSegment*/);
+            object output;
+            Assert.True(parser.TryParseLiteral(typeof(TimeOfDay), "13:20:00", out output));
+            Assert.Equal(new TimeOfDay(13, 20, 00, 0), output);
+        }
+
+        [Fact]
+        public void TryParseLiteralWithTimeOfDayForParenthesesKeyDelimiterShouldReturnValidTimeOfDay()
+        {
+            var parser = LiteralParser.ForKeys(false /*keyAsSegment*/);
+            object output;
+            Assert.True(parser.TryParseLiteral(typeof(TimeOfDay), "13:20:00", out output));
+            Assert.Equal(new TimeOfDay(13, 20, 00, 0), output);
+        }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3581*

### Description

TimeOfDay parser is added as LiteralParser and tests are added.

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*