### PR TITLE
Fix product build warnings (CA2007, CA1307, CS0419)

### DIFF
--- a/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
@@ -925,7 +925,7 @@ namespace Microsoft.OData.Json
             static async Task AwaitReadInternalAsync(BufferingJsonReader thisParam, Task<bool> readInternalTask)
             {
                 await readInternalTask.ConfigureAwait(false);
-                await thisParam.DetectAndTryReadInStreamErrorAsync();
+                await thisParam.DetectAndTryReadInStreamErrorAsync().ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.OData.Core/Json/JsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/JsonReader.cs
@@ -2195,7 +2195,7 @@ namespace Microsoft.OData.Json
             {
                 await GetOrAwait(pendingPostColonWhitespaceTask).ConfigureAwait(false);
 
-                return await ContinueAfterColonWhitespaceAsync(thisParam);
+                return await ContinueAfterColonWhitespaceAsync(thisParam).ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.OData.Core/Json/ODataJsonValueSerializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonValueSerializer.cs
@@ -725,12 +725,12 @@ namespace Microsoft.OData.Json
             Stream stream = await this.JsonWriter.StartStreamValueScopeAsync().ConfigureAwait(false);
             await streamValue.Stream.CopyToAsync(stream).ConfigureAwait(false);
             await stream.FlushAsync().ConfigureAwait(false);
-            await stream.DisposeAsync();
+            await stream.DisposeAsync().ConfigureAwait(false);
             await this.JsonWriter.EndStreamValueScopeAsync().ConfigureAwait(false);
 
             if (!streamValue.LeaveOpen)
             {
-                await streamValue.Stream.DisposeAsync();
+                await streamValue.Stream.DisposeAsync().ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
@@ -115,7 +115,7 @@ namespace Microsoft.OData.Json
 
             if (this.textWriter != null)
             {
-                await this.textWriter.DisposeAsync();
+                await this.textWriter.DisposeAsync().ConfigureAwait(false);
             }
 
             await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
@@ -173,7 +173,7 @@ namespace Microsoft.OData.Json
             /// <returns>A task representing the asynchronous flush operation.</returns>
             public override async Task FlushAsync()
             {
-                await this.jsonWriter.FlushAsync();
+                await this.jsonWriter.FlushAsync().ConfigureAwait(false);
             }
 
             /// <summary>

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -1134,7 +1134,7 @@ namespace Microsoft.OData.Json
             }
             else if (value.Length > bufferWriter.FreeCapacity || value.Length > chunkSize)
             {
-                await WriteStringValueInChunksAsync(value.AsMemory());
+                await WriteStringValueInChunksAsync(value.AsMemory()).ConfigureAwait(false);
             }
             else
             {
@@ -1186,7 +1186,7 @@ namespace Microsoft.OData.Json
                 }
 
                 // Flush the buffer if needed
-                await this.DrainBufferIfThresholdReachedAsync();
+                await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
             }
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
@@ -1207,7 +1207,7 @@ namespace Microsoft.OData.Json
             }
             else if (value.Length > bufferWriter.FreeCapacity || value.Length > chunkSize)
             {
-                await WriteByteValueInChunksAsync(value);
+                await WriteByteValueInChunksAsync(value).ConfigureAwait(false);
             }
             else
             {

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -96,7 +96,7 @@ namespace Microsoft.OData
         /// <summary>
         /// Returns <paramref name="source"/> as an <see cref="IReadOnlyList{T}"/>, materializing the
         /// sequence to an array when it isn't already a known collection. Used to avoid re-enumerating
-        /// the LINQ iterator returned by <see cref="ExtensionMethods.GetDerivedTypeConstraints"/>.
+        /// the LINQ iterator returned by <see cref="ExtensionMethods.GetDerivedTypeConstraints(IEdmModel, IEdmNavigationSource)"/>.
         /// </summary>
         private static IReadOnlyList<string> MaterializeOrNull(IEnumerable<string> source)
         {

--- a/src/Microsoft.OData.Edm/Schema/EdmPathExpression.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmPathExpression.cs
@@ -55,7 +55,7 @@ namespace Microsoft.OData.Edm
                     throw new ArgumentException(SRResources.PathSegmentMustNotBeNull, nameof(pathSegments));
                 }
 
-                if (segment.IndexOf('/') >= 0)
+                if (segment.IndexOf('/', StringComparison.Ordinal) >= 0)
                 {
                     throw new ArgumentException(SRResources.PathSegmentMustNotContainSlash);
                 }


### PR DESCRIPTION
Resolve the 11 warnings reported for src\ projects in the CI build:

- CA2007 (9x): add ConfigureAwait(false) to awaited tasks in Microsoft.OData.Core Json readers/writers (BufferingJsonReader, JsonReader, ODataJsonValueSerializer, ODataUtf8JsonWriter and its TextWriter partial).
- CS0419: disambiguate the ambiguous cref to ExtensionMethods.GetDerivedTypeConstraints in ODataWriterCore doc comment by qualifying the (IEdmModel, IEdmNavigationSource) overload.
- CA1307: pass StringComparison.Ordinal to string.IndexOf(char) in EdmPathExpression.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
