### PR TITLE
Fix #3583: dispose CancellationToken registrations in paging helpers

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -3640,11 +3640,20 @@ namespace Microsoft.OData.Client
             if (continuation != null)
             {
                 IAsyncResult beginLoadPropertyResult = this.BeginLoadProperty(entity, propertyName, continuation, null, null);
-                cancellationToken.Register(() => this.CancelRequest(beginLoadPropertyResult));
+
+                // Dispose the cancellation registration once the request completes so it is removed
+                // from the (potentially long-lived) token source, otherwise the captured async result
+                // is kept alive for every page, leaking memory (issue #3583).
+                CancellationTokenRegistration registration = cancellationToken.Register(() => this.CancelRequest(beginLoadPropertyResult));
                 var currentTask = Task<QueryOperationResponse>.Factory.FromAsync(beginLoadPropertyResult, this.EndLoadProperty);
 
                 return currentTask.ContinueWith(
-                    t => this.ContinuePageAsync(t.Result, entity, propertyName, cancellationToken), cancellationToken).Unwrap();
+                    t =>
+                    {
+                        registration.Dispose();
+                        return this.ContinuePageAsync(t.Result, entity, propertyName, cancellationToken);
+                    },
+                    cancellationToken).Unwrap();
             }
 
             var taskSource = new TaskCompletionSource<QueryOperationResponse>();

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -3647,13 +3647,19 @@ namespace Microsoft.OData.Client
                 CancellationTokenRegistration registration = cancellationToken.Register(() => this.CancelRequest(beginLoadPropertyResult));
                 var currentTask = Task<QueryOperationResponse>.Factory.FromAsync(beginLoadPropertyResult, this.EndLoadProperty);
 
+                // Schedule the disposal/continuation with CancellationToken.None so it always runs
+                // even when the token is already canceled; otherwise the continuation could be
+                // skipped and the registration would never be disposed (and stay rooted in a
+                // long-lived token source).
                 return currentTask.ContinueWith(
                     t =>
                     {
                         registration.Dispose();
                         return this.ContinuePageAsync(t.Result, entity, propertyName, cancellationToken);
                     },
-                    cancellationToken).Unwrap();
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default).Unwrap();
             }
 
             var taskSource = new TaskCompletionSource<QueryOperationResponse>();

--- a/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
@@ -553,13 +553,19 @@ namespace Microsoft.OData.Client
             if (continuation != null)
             {
                 var asyncResult = this.Context.BeginExecute(continuation, null, null);
-                cancellationToken.Register(() => this.Context.CancelRequest(asyncResult));
-                var currentTask = Task<IEnumerable<TElement>>.Factory.FromAsync(asyncResult, this.Context.EndExecute<TElement>);
-                var nextTask = currentTask.ContinueWith(t => ContinuePage(t.Result, cancellationToken), cancellationToken);
-                nextTask.Wait(cancellationToken);
-                foreach (var element in nextTask.Result)
+
+                // Dispose the cancellation registration once the request completes so it is removed
+                // from the (potentially long-lived) token source, otherwise the captured async result
+                // graph is kept alive for every page, leaking memory (issue #3583).
+                using (cancellationToken.Register(() => this.Context.CancelRequest(asyncResult)))
                 {
-                    yield return element;
+                    var currentTask = Task<IEnumerable<TElement>>.Factory.FromAsync(asyncResult, this.Context.EndExecute<TElement>);
+                    var nextTask = currentTask.ContinueWith(t => ContinuePage(t.Result, cancellationToken), cancellationToken);
+                    nextTask.Wait(cancellationToken);
+                    foreach (var element in nextTask.Result)
+                    {
+                        yield return element;
+                    }
                 }
             }
         }

--- a/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
@@ -554,18 +554,28 @@ namespace Microsoft.OData.Client
             {
                 var asyncResult = this.Context.BeginExecute(continuation, null, null);
 
-                // Dispose the cancellation registration once the request completes so it is removed
-                // from the (potentially long-lived) token source, otherwise the captured async result
-                // graph is kept alive for every page, leaking memory (issue #3583).
-                using (cancellationToken.Register(() => this.Context.CancelRequest(asyncResult)))
+                // Register cancellation for this page's request and dispose the registration as soon
+                // as that request completes. A using block cannot be used here because this is an
+                // iterator method: its scope would stay open for the entire enumeration, keeping every
+                // page's registration (and the captured async result graph) rooted in a potentially
+                // long-lived token source until enumeration ends (issue #3583).
+                CancellationTokenRegistration registration = cancellationToken.Register(() => this.Context.CancelRequest(asyncResult));
+                IEnumerable<TElement> nextPage;
+                try
                 {
                     var currentTask = Task<IEnumerable<TElement>>.Factory.FromAsync(asyncResult, this.Context.EndExecute<TElement>);
                     var nextTask = currentTask.ContinueWith(t => ContinuePage(t.Result, cancellationToken), cancellationToken);
                     nextTask.Wait(cancellationToken);
-                    foreach (var element in nextTask.Result)
-                    {
-                        yield return element;
-                    }
+                    nextPage = nextTask.Result;
+                }
+                finally
+                {
+                    registration.Dispose();
+                }
+
+                foreach (var element in nextPage)
+                {
+                    yield return element;
                 }
             }
         }

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/AsyncWasmCompatibilityTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/AsyncWasmCompatibilityTests.cs
@@ -209,6 +209,41 @@ namespace Microsoft.OData.Client.Tests.Serialization
                 () => context.Products.GetAllPagesAsync(cts.Token));
         }
 
+        [Fact]
+        public async Task GetAllPagesAsync_WithReusedCancellationToken_LeavesNoLingeringRegistrations()
+        {
+            // Regression test for issue #3583: repeatedly paging with a single, long-lived
+            // CancellationToken must not accumulate cancellation-token registrations. Each leaked
+            // registration keeps the request/response graph alive until the token source is disposed,
+            // so a long-running job that reuses one token would grow memory without bound.
+            // Arrange
+            int requestCount = 0;
+            var context = CreateContext();
+            context.Configurations.RequestPipeline.OnMessageCreating = (args) =>
+            {
+                requestCount++;
+                // Two pages per call: odd requests return page 1 (with next link), even return page 2.
+                string response = (requestCount % 2 == 1) ? ProductsPage1Response : ProductsPage2Response;
+                return new AsyncTestRequestMessage(args, response);
+            };
+
+            using var cts = new CancellationTokenSource();
+
+            // Act - simulate a long-running job that reuses the same token across many calls.
+            for (int i = 0; i < 5; i++)
+            {
+                var products = (await context.Products.GetAllPagesAsync(cts.Token)).ToList();
+                Assert.Equal(3, products.Count);
+            }
+
+            // Cancelling the shared token after all requests have completed must not reach into any
+            // completed request. A lingering registration would invoke CancelRequest here.
+            cts.Cancel();
+
+            // Assert
+            Assert.Equal(0, context.CancelRequestCount);
+        }
+
         #endregion
 
         #region EnumerateAllPagesAsync Tests
@@ -370,6 +405,18 @@ namespace Microsoft.OData.Client.Tests.Serialization
             }
 
             public DataServiceQuery<Product> Products { get; private set; }
+
+            /// <summary>
+            /// Number of times <see cref="CancelRequest"/> was invoked. Used by tests to detect
+            /// cancellation-token registrations that outlive a completed request (issue #3583).
+            /// </summary>
+            public int CancelRequestCount { get; private set; }
+
+            public override void CancelRequest(IAsyncResult asyncResult)
+            {
+                this.CancelRequestCount++;
+                base.CancelRequest(asyncResult);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
DataServiceQueryOfT.ContinuePage and DataServiceContext.ContinuePageAsync registered a cancellation callback per page via CancellationToken.Register but discarded the returned CancellationTokenRegistration, so it was never disposed. When a caller reuses a long-lived CancellationToken (e.g. a shared CancellationTokenSource across many paging calls in a long-running job), each page adds a callback that captures the async result graph and is only released when the token source is cancelled/disposed, causing memory to grow without bound.

- ContinuePage: scope the registration in a using block so it is disposed once the page request completes.
- ContinuePageAsync: capture the registration and dispose it in the task continuation once the request completes.

Add a regression test (AsyncWasmCompatibilityTests) that pages repeatedly with a single reused CancellationToken and asserts that cancelling the token afterwards invokes no CancelRequest callbacks (i.e. no registrations leaked).

Note: the reporter's GetAllPagesAsync path on dev-9.x already routes through the allocation-free async pipeline (GetAllPagesAsyncInternal), so this fixes the remaining occurrences of the same pattern and guards against regressions.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3583.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
