### PR TITLE
Fix #3583: dispose CancellationToken registration in ContinuePageAsync

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -3755,11 +3755,26 @@ namespace Microsoft.OData.Client
             if (continuation != null)
             {
                 IAsyncResult beginLoadPropertyResult = this.BeginLoadProperty(entity, propertyName, continuation, null, null);
-                cancellationToken.Register(() => this.CancelRequest(beginLoadPropertyResult));
+
+                // Dispose the cancellation registration once the request completes so it is removed
+                // from the (potentially long-lived) token source, otherwise the captured async result
+                // is kept alive for every page, leaking memory (issue #3583).
+                CancellationTokenRegistration registration = cancellationToken.Register(() => this.CancelRequest(beginLoadPropertyResult));
                 var currentTask = Task<QueryOperationResponse>.Factory.FromAsync(beginLoadPropertyResult, this.EndLoadProperty);
 
+                // Schedule the disposal/continuation with CancellationToken.None so it always runs
+                // even when the token is already canceled; otherwise the continuation could be
+                // skipped and the registration would never be disposed (and stay rooted in a
+                // long-lived token source).
                 return currentTask.ContinueWith(
-                    t => this.ContinuePageAsync(t.Result, entity, propertyName, cancellationToken), cancellationToken).Unwrap();
+                    t =>
+                    {
+                        registration.Dispose();
+                        return this.ContinuePageAsync(t.Result, entity, propertyName, cancellationToken);
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default).Unwrap();
             }
 
             var taskSource = new TaskCompletionSource<QueryOperationResponse>();

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/AsyncWasmCompatibilityTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/AsyncWasmCompatibilityTests.cs
@@ -1,0 +1,471 @@
+//---------------------------------------------------------------------
+// <copyright file="AsyncWasmCompatibilityTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.OData.Edm.Csdl;
+using Xunit;
+
+namespace Microsoft.OData.Client.Tests.Serialization
+{
+    /// <summary>
+    /// Tests for the async-native WASM compatibility path that eliminates Task.Wait() blocking.
+    /// These tests verify that GetResponseAsync, ExecuteAsync, GetAllPagesAsync, and
+    /// EnumerateAllPagesAsync work correctly through the new async pipeline.
+    /// </summary>
+    public class AsyncWasmCompatibilityTests
+    {
+        private const string ServiceRoot = "http://localhost:9090";
+
+        private const string Edmx = @"<edmx:Edmx xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"" Version=""4.0"">
+  <edmx:DataServices>
+    <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""Test"">
+      <EntityType Name=""Product"">
+        <Key>
+          <PropertyRef Name=""Id"" />
+        </Key>
+        <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""Name"" Type=""Edm.String"" />
+      </EntityType>
+    </Schema>
+    <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""Default"">
+      <EntityContainer Name=""Container"">
+        <EntitySet Name=""Products"" EntityType=""Test.Product"" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+
+        private const string ProductsResponse = @"{
+    ""@odata.context"": ""http://localhost:9090/$metadata#Products"",
+    ""value"": [
+        { ""Id"": 1, ""Name"": ""Widget"" },
+        { ""Id"": 2, ""Name"": ""Gadget"" }
+    ]
+}";
+
+        private const string ProductsPage1Response = @"{
+    ""@odata.context"": ""http://localhost:9090/$metadata#Products"",
+    ""value"": [
+        { ""Id"": 1, ""Name"": ""Widget"" },
+        { ""Id"": 2, ""Name"": ""Gadget"" }
+    ],
+    ""@odata.nextLink"": ""http://localhost:9090/Products?$skip=2""
+}";
+
+        private const string ProductsPage2Response = @"{
+    ""@odata.context"": ""http://localhost:9090/$metadata#Products"",
+    ""value"": [
+        { ""Id"": 3, ""Name"": ""Doohickey"" }
+    ]
+}";
+
+        #region GetResponseAsync Tests
+
+        [Fact]
+        public async Task GetResponseAsync_ReturnsResponse_WithoutBlocking()
+        {
+            // Arrange
+            var context = CreateContext();
+            SetupRequestPipeline(context, ProductsResponse);
+
+            // Act
+            var query = context.Products;
+            var results = await query.ExecuteAsync();
+
+            // Assert
+            var products = results.ToList();
+            Assert.Equal(2, products.Count);
+            Assert.Equal("Widget", products[0].Name);
+            Assert.Equal("Gadget", products[1].Name);
+        }
+
+        [Fact]
+        public async Task GetResponseAsync_SupportsCancellation()
+        {
+            // Arrange
+            var context = CreateContext();
+            SetupRequestPipeline(context, ProductsResponse);
+            var cts = new CancellationTokenSource();
+            cts.Cancel(); // Pre-cancel
+
+            // Act & Assert
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => context.Products.ExecuteAsync(cts.Token));
+        }
+
+        [Fact]
+        public async Task GetResponseAsync_WithHttpClientFactory_UsesAsyncPath()
+        {
+            // Arrange - MockHttpClientHandler returns proper OData JSON response
+            using var handler = new MockHttpClientHandler(request =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(ProductsResponse, Encoding.UTF8, "application/json")
+                };
+                return response;
+            });
+            var factory = new MockHttpClientFactory(handler);
+
+            var context = CreateContext();
+            context.HttpClientFactory = factory;
+
+            // Act
+            var results = await context.Products.ExecuteAsync();
+
+            // Assert
+            var products = results.ToList();
+            Assert.Equal(2, products.Count);
+            Assert.Equal(1, factory.NumCalls);
+            Assert.Single(handler.Requests);
+            Assert.Contains("Products", handler.Requests[0]);
+        }
+
+        #endregion
+
+        #region ExecuteAsync (DataServiceQuery) Tests
+
+        [Fact]
+        public async Task ExecuteAsync_WithCancellationToken_ReturnsResults()
+        {
+            // Arrange
+            var context = CreateContext();
+            SetupRequestPipeline(context, ProductsResponse);
+
+            // Act
+            var results = await context.Products.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            Assert.Equal(2, results.Count());
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ForFunction_UsesContextExecuteAsync()
+        {
+            // Arrange - simulate function call via ExecuteAsync on context
+            var context = CreateContext();
+            SetupRequestPipeline(context, ProductsResponse);
+
+            // Act - use Context.ExecuteAsync directly (the function path)
+            var results = await context.ExecuteAsync<Product>(
+                new Uri($"{ServiceRoot}/Products"), CancellationToken.None);
+
+            // Assert
+            Assert.Equal(2, results.Count());
+        }
+
+        #endregion
+
+        #region GetAllPagesAsync Tests
+
+        [Fact]
+        public async Task GetAllPagesAsync_IteratesAllPages()
+        {
+            // Arrange
+            int requestCount = 0;
+            var context = CreateContext();
+            context.Configurations.RequestPipeline.OnMessageCreating = (args) =>
+            {
+                requestCount++;
+                string response = requestCount == 1 ? ProductsPage1Response : ProductsPage2Response;
+                return new AsyncTestRequestMessage(args, response);
+            };
+
+            // Act
+            var results = await context.Products.GetAllPagesAsync();
+
+            // Assert
+            var products = results.ToList();
+            Assert.Equal(3, products.Count);
+            Assert.Equal("Widget", products[0].Name);
+            Assert.Equal("Gadget", products[1].Name);
+            Assert.Equal("Doohickey", products[2].Name);
+            Assert.Equal(2, requestCount);
+        }
+
+        [Fact]
+        public async Task GetAllPagesAsync_WithCancellation_Throws()
+        {
+            // Arrange
+            var context = CreateContext();
+            SetupRequestPipeline(context, ProductsPage1Response);
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // Act & Assert
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => context.Products.GetAllPagesAsync(cts.Token));
+        }
+
+        [Fact]
+        public async Task GetAllPagesAsync_WithReusedCancellationToken_LeavesNoLingeringRegistrations()
+        {
+            // Regression test for issue #3583: repeatedly paging with a single, long-lived
+            // CancellationToken must not accumulate cancellation-token registrations. Each leaked
+            // registration keeps the request/response graph alive until the token source is disposed,
+            // so a long-running job that reuses one token would grow memory without bound.
+            // Arrange
+            int requestCount = 0;
+            var context = CreateContext();
+            context.Configurations.RequestPipeline.OnMessageCreating = (args) =>
+            {
+                requestCount++;
+                // Two pages per call: odd requests return page 1 (with next link), even return page 2.
+                string response = (requestCount % 2 == 1) ? ProductsPage1Response : ProductsPage2Response;
+                return new AsyncTestRequestMessage(args, response);
+            };
+
+            using var cts = new CancellationTokenSource();
+
+            // Act - simulate a long-running job that reuses the same token across many calls.
+            for (int i = 0; i < 5; i++)
+            {
+                var products = (await context.Products.GetAllPagesAsync(cts.Token)).ToList();
+                Assert.Equal(3, products.Count);
+            }
+
+            // Cancelling the shared token after all requests have completed must not reach into any
+            // completed request. A lingering registration would invoke CancelRequest here.
+            cts.Cancel();
+
+            // Assert
+            Assert.Equal(0, context.CancelRequestCount);
+        }
+
+        #endregion
+
+        #region EnumerateAllPagesAsync Tests
+
+        [Fact]
+        public async Task EnumerateAllPagesAsync_YieldsElementsLazily()
+        {
+            // Arrange
+            int requestCount = 0;
+            var context = CreateContext();
+            context.Configurations.RequestPipeline.OnMessageCreating = (args) =>
+            {
+                requestCount++;
+                string response = requestCount == 1 ? ProductsPage1Response : ProductsPage2Response;
+                return new AsyncTestRequestMessage(args, response);
+            };
+
+            // Act
+            var elements = new List<Product>();
+            await foreach (var product in context.Products.EnumerateAllPagesAsync())
+            {
+                elements.Add(product);
+            }
+
+            // Assert
+            Assert.Equal(3, elements.Count);
+            Assert.Equal("Doohickey", elements[2].Name);
+            Assert.Equal(2, requestCount);
+        }
+
+        [Fact]
+        public async Task EnumerateAllPagesAsync_SupportsCancellation()
+        {
+            // Arrange
+            var context = CreateContext();
+            SetupRequestPipeline(context, ProductsPage1Response);
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // Act & Assert
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            {
+                await foreach (var _ in context.Products.EnumerateAllPagesAsync(cts.Token))
+                {
+                    // Should not reach here
+                }
+            });
+        }
+
+        #endregion
+
+        #region DataServiceContext.ExecuteAsync Tests
+
+        [Fact]
+        public async Task Context_ExecuteAsync_WithHttpMethod_ReturnsResults()
+        {
+            // Arrange
+            var context = CreateContext();
+            SetupRequestPipeline(context, ProductsResponse);
+
+            // Act
+            var results = await context.ExecuteAsync<Product>(
+                new Uri($"{ServiceRoot}/Products"), "GET", true, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(2, results.Count());
+        }
+
+        [Fact]
+        public async Task Context_ExecuteAsync_Continuation_ReturnsNextPage()
+        {
+            // Arrange
+            int requestCount = 0;
+            var context = CreateContext();
+            context.Configurations.RequestPipeline.OnMessageCreating = (args) =>
+            {
+                requestCount++;
+                string response = requestCount == 1 ? ProductsPage1Response : ProductsPage2Response;
+                return new AsyncTestRequestMessage(args, response);
+            };
+
+            // Get first page
+            var firstPage = (QueryOperationResponse<Product>)await context.Products.ExecuteAsync();
+            var firstPageResults = firstPage.ToList();
+            Assert.Equal(2, firstPageResults.Count);
+
+            var continuation = firstPage.GetContinuation();
+            Assert.NotNull(continuation);
+
+            // Act
+            var nextPage = await context.ExecuteAsync(continuation, CancellationToken.None);
+
+            // Assert
+            var products = nextPage.ToList();
+            Assert.Single(products);
+            Assert.Equal("Doohickey", products[0].Name);
+        }
+
+        #endregion
+
+        #region DataServiceQuerySingle.GetValueAsync Tests
+
+        [Fact]
+        public async Task GetValueAsync_ReturnsEntity_WithAsyncPath()
+        {
+            // Arrange
+            string singleProductResponse = @"{
+    ""@odata.context"": ""http://localhost:9090/$metadata#Products/$entity"",
+    ""Id"": 1,
+    ""Name"": ""Widget""
+}";
+            var context = CreateContext();
+            SetupRequestPipeline(context, singleProductResponse);
+
+            var querySingle = new DataServiceQuerySingle<Product>(context, "Products(1)");
+
+            // Act
+            var product = await querySingle.GetValueAsync(CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(product);
+            Assert.Equal(1, product.Id);
+            Assert.Equal("Widget", product.Name);
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private TestContainer CreateContext()
+        {
+            return new TestContainer(new Uri(ServiceRoot));
+        }
+
+        private void SetupRequestPipeline(DataServiceContext context, string response)
+        {
+            context.Configurations.RequestPipeline.OnMessageCreating = (args) =>
+                new AsyncTestRequestMessage(args, response);
+        }
+
+        #endregion
+
+        #region Test Types
+
+        [Key("Id")]
+        public class Product
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class TestContainer : DataServiceContext
+        {
+            public TestContainer(Uri serviceRoot) : base(serviceRoot, ODataProtocolVersion.V4)
+            {
+                Format.LoadServiceModel = () => CsdlReader.Parse(XmlReader.Create(new StringReader(Edmx)));
+                Format.UseJson();
+                Products = base.CreateQuery<Product>("Products");
+            }
+
+            public DataServiceQuery<Product> Products { get; private set; }
+
+            /// <summary>
+            /// Number of times <see cref="CancelRequest"/> was invoked. Used by tests to detect
+            /// cancellation-token registrations that outlive a completed request (issue #3583).
+            /// </summary>
+            public int CancelRequestCount { get; private set; }
+
+            public override void CancelRequest(IAsyncResult asyncResult)
+            {
+                this.CancelRequestCount++;
+                base.CancelRequest(asyncResult);
+            }
+        }
+
+        /// <summary>
+        /// A test request message that overrides GetResponseAsync to verify the async path works
+        /// without making real HTTP calls (simulating a WASM-compatible environment).
+        /// </summary>
+        private class AsyncTestRequestMessage : HttpClientRequestMessage
+        {
+            private readonly string _response;
+
+            public AsyncTestRequestMessage(DataServiceClientRequestMessageArgs args, string response)
+                : base(args)
+            {
+                _response = response;
+            }
+
+            public override IODataResponseMessage GetResponse()
+            {
+                return CreateMockResponse();
+            }
+
+            public override Task<IODataResponseMessage> GetResponseAsync(CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return Task.FromResult(GetResponse());
+            }
+
+            public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
+            {
+                var tcs = new TaskCompletionSource<bool>(state);
+                tcs.TrySetResult(true);
+                callback(tcs.Task);
+                return tcs.Task;
+            }
+
+            public override IODataResponseMessage EndGetResponse(IAsyncResult asyncResult)
+            {
+                return GetResponse();
+            }
+
+            private IODataResponseMessage CreateMockResponse()
+            {
+                return new HttpWebResponseMessage(
+                    new Dictionary<string, string> { { "Content-Type", "application/json;charset=utf-8" } },
+                    200,
+                    () => new MemoryStream(Encoding.UTF8.GetBytes(_response)));
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/AsyncWasmCompatibilityTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/AsyncWasmCompatibilityTests.cs
@@ -399,7 +399,14 @@ namespace Microsoft.OData.Client.Tests.Serialization
         {
             public TestContainer(Uri serviceRoot) : base(serviceRoot, ODataProtocolVersion.V4)
             {
-                Format.LoadServiceModel = () => CsdlReader.Parse(XmlReader.Create(new StringReader(Edmx)));
+                Format.LoadServiceModel = () =>
+                {
+                    using (StringReader stringReader = new StringReader(Edmx))
+                    using (XmlReader xmlReader = XmlReader.Create(stringReader))
+                    {
+                        return CsdlReader.Parse(xmlReader);
+                    }
+                };
                 Format.UseJson();
                 Products = base.CreateQuery<Product>("Products");
             }
@@ -410,11 +417,13 @@ namespace Microsoft.OData.Client.Tests.Serialization
             /// Number of times <see cref="CancelRequest"/> was invoked. Used by tests to detect
             /// cancellation-token registrations that outlive a completed request (issue #3583).
             /// </summary>
-            public int CancelRequestCount { get; private set; }
+            public int CancelRequestCount => Volatile.Read(ref this.cancelRequestCount);
+
+            private int cancelRequestCount;
 
             public override void CancelRequest(IAsyncResult asyncResult)
             {
-                this.CancelRequestCount++;
+                Interlocked.Increment(ref this.cancelRequestCount);
                 base.CancelRequest(asyncResult);
             }
         }
@@ -446,9 +455,9 @@ namespace Microsoft.OData.Client.Tests.Serialization
 
             public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
             {
-                var tcs = new TaskCompletionSource<bool>(state);
+                var tcs = new TaskCompletionSource<bool>(state, TaskCreationOptions.RunContinuationsAsynchronously);
                 tcs.TrySetResult(true);
-                callback(tcs.Task);
+                callback?.Invoke(tcs.Task);
                 return tcs.Task;
             }
 


### PR DESCRIPTION
Port the DataServiceContext.ContinuePageAsync portion of the dev-9.x fix (#3585) to the 8.x line. ContinuePageAsync registered a cancellation callback per page via CancellationToken.Register but discarded the returned CancellationTokenRegistration, so it was never disposed. When a caller reuses a long-lived CancellationToken across many paging calls, each page adds a callback that captures the async result graph and is only released when the token source is cancelled/disposed, causing memory to grow without bound.

Capture the registration and dispose it in the continuation, scheduled with CancellationToken.None (ExecuteSynchronously) so it always runs even when the token is already canceled.

Add the AsyncWasmCompatibilityTests harness with a regression test that pages repeatedly with a single reused CancellationToken and asserts that cancelling the token afterwards invokes no CancelRequest callbacks (no leaked registrations).

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3583.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
