### PR TITLE
Add configurable client property naming convention

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/ExpressionWriter.cs
+++ b/src/Microsoft.OData.Client/ALinq/ExpressionWriter.cs
@@ -507,7 +507,7 @@ namespace Microsoft.OData.Client
             else
             {
                 var member = m.Expression.Type.GetMember(m.Member.Name).First();
-                this.builder.Append(ClientTypeUtil.GetServerDefinedName(member));
+                this.builder.Append(this.context.GetServerDefinedName(member));
             }
 
             return m;

--- a/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
@@ -358,7 +358,7 @@ namespace Microsoft.OData.Client
 
                     keyValuesFromPredicates.Add(property, constantValue);
                     keyPredicates.Add(predicate);
-                    expToPropertyNameMap.Add(predicate, ClientTypeUtil.GetServerDefinedName(property));
+                    expToPropertyNameMap.Add(predicate, edmModel.GetServerDefinedName(property));
                 }
                 else
                 {
@@ -1844,7 +1844,7 @@ namespace Microsoft.OData.Client
                     Expression boundTarget;
                     if (MatchNonPrivateReadableProperty(me, out pi, out boundTarget))
                     {
-                        string propertyName = ClientTypeUtil.GetServerDefinedName(pi);
+                        string propertyName = context.GetServerDefinedName(pi);
 
                         NonSystemToken newPropertyToAdd = new NonSystemToken(propertyName, null, null);
                         if (propertyPath == null)

--- a/src/Microsoft.OData.Client/ALinq/SelectExpandPathBuilder.cs
+++ b/src/Microsoft.OData.Client/ALinq/SelectExpandPathBuilder.cs
@@ -184,7 +184,7 @@ namespace Microsoft.OData.Client
                 null :
                 UriHelper.GetEntityTypeNameForUriAndValidateMaxProtocolVersion(convertedSourceType, context, ref this.uriVersion);
 
-            string propertyServerDefinedName = ClientTypeUtil.GetServerDefinedName(pi);
+            string propertyServerDefinedName = context.GetServerDefinedName(pi);
 
             string propertyName = convertedSourceType != null ?
                 String.Join(UriHelper.FORWARDSLASH.ToString(), new string[] { convertedSourceTypeName, propertyServerDefinedName }) :

--- a/src/Microsoft.OData.Client/ALinq/UriWriter.cs
+++ b/src/Microsoft.OData.Client/ALinq/UriWriter.cs
@@ -296,7 +296,7 @@ namespace Microsoft.OData.Client
 
             if (rse.KeyPredicateConjuncts.Count > 0)
             {
-                this.context.UrlKeyDelimiter.AppendKeyExpression(rse.GetKeyProperties(), kvp => ClientTypeUtil.GetServerDefinedName(kvp.Key), kvp => kvp.Value.Value, this.uriBuilder);
+                this.context.UrlKeyDelimiter.AppendKeyExpression(rse.GetKeyProperties(), kvp => this.context.GetServerDefinedName(kvp.Key), kvp => kvp.Value.Value, this.uriBuilder);
             }
 
             if (rse.IsOperationInvocation)

--- a/src/Microsoft.OData.Client/Annotation/AnnotationHelper.cs
+++ b/src/Microsoft.OData.Client/Annotation/AnnotationHelper.cs
@@ -293,7 +293,7 @@ namespace Microsoft.OData.Client.Annotation
                 return edmValueAnnotation;
             }
 
-            var severSidePropertyName = ClientTypeUtil.GetServerDefinedName(propertyInfo);
+            var severSidePropertyName = context.GetServerDefinedName(propertyInfo);
             if (string.IsNullOrEmpty(severSidePropertyName))
             {
                 return null;
@@ -658,7 +658,7 @@ namespace Microsoft.OData.Client.Annotation
             /// <returns>True if the property is found, else false.</returns>
             internal bool TryGetClientPropertyInfo(Type type, string propertyName, out PropertyInfo propertyInfo)
             {
-                propertyInfo = ClientTypeUtil.GetClientPropertyInfo(type, propertyName, this.dataServiceContext.UndeclaredPropertyBehavior);
+                propertyInfo = this.dataServiceContext.Model.GetClientPropertyInfo(type, propertyName, this.dataServiceContext.UndeclaredPropertyBehavior);
                 return propertyInfo != null;
             }
 
@@ -719,7 +719,7 @@ namespace Microsoft.OData.Client.Annotation
                     var clientTypeAnnotation = edmModel.GetClientTypeAnnotation(edmType);
                     if (clientTypeAnnotation != null)
                     {
-                        var propertyInfo = ClientTypeUtil.GetClientPropertyInfo(clientTypeAnnotation.ElementType, propertyName, this.dataServiceContext.UndeclaredPropertyBehavior);
+                        var propertyInfo = this.dataServiceContext.Model.GetClientPropertyInfo(clientTypeAnnotation.ElementType, propertyName, this.dataServiceContext.UndeclaredPropertyBehavior);
                         if (propertyInfo != null)
                         {
                             var annotation = GetOrInsertCachedMetadataAnnotationForPropertyInfo(this.dataServiceContext, propertyInfo, termName, qualifier);

--- a/src/Microsoft.OData.Client/ClientEdmModel.cs
+++ b/src/Microsoft.OData.Client/ClientEdmModel.cs
@@ -43,6 +43,9 @@ namespace Microsoft.OData.Client
         /// <summary>The max protocol version this Edm model is created for.</summary>
         private readonly ODataProtocolVersion maxProtocolVersion;
 
+        /// <summary>Optional resolver for mapping CLR property names to server-defined names.</summary>
+        private readonly Func<PropertyInfo, string> resolvePropertyName;
+
         /// <summary>Referenced core model.</summary>
         private readonly IEnumerable<IEdmModel> coreModel = new IEdmModel[] { EdmCoreModel.Instance };
 
@@ -51,9 +54,66 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <param name="maxProtocolVersion">The protocol version this Edm model is created for.</param>
         internal ClientEdmModel(ODataProtocolVersion maxProtocolVersion)
+            : this(maxProtocolVersion, null)
+        {
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="maxProtocolVersion">The protocol version this Edm model is created for.</param>
+        /// <param name="resolvePropertyName">Optional resolver for server-defined property names.</param>
+        internal ClientEdmModel(ODataProtocolVersion maxProtocolVersion, Func<PropertyInfo, string> resolvePropertyName)
         {
             this.maxProtocolVersion = maxProtocolVersion;
+            this.resolvePropertyName = resolvePropertyName;
             this.EdmStructuredSchemaElements = new ConcurrentEdmSchemaDictionary();
+        }
+
+        /// <summary>Gets the server-defined name for a CLR member.</summary>
+        /// <param name="memberInfo">Member to resolve.</param>
+        /// <returns>Server-defined name.</returns>
+        internal string GetServerDefinedName(MemberInfo memberInfo)
+        {
+            PropertyInfo propertyInfo = memberInfo as PropertyInfo;
+            return propertyInfo == null
+                ? ClientTypeUtil.GetServerDefinedName(memberInfo)
+                : ClientTypeUtil.GetServerDefinedName(propertyInfo, this.resolvePropertyName);
+        }
+
+        /// <summary>Gets client property information for a server-defined name.</summary>
+        /// <param name="type">CLR type containing the property.</param>
+        /// <param name="serverDefinedName">Server-defined property name.</param>
+        /// <param name="undeclaredPropertyBehavior">Behavior for undeclared properties.</param>
+        /// <returns>The matching property, or null.</returns>
+        internal PropertyInfo GetClientPropertyInfo(Type type, string serverDefinedName, UndeclaredPropertyBehavior undeclaredPropertyBehavior)
+        {
+            if (this.resolvePropertyName == null)
+            {
+                return ClientTypeUtil.GetClientPropertyInfo(type, serverDefinedName, undeclaredPropertyBehavior);
+            }
+
+            PropertyInfo[] matchingProperties = ClientTypeUtil.GetPropertiesOnType(type, declaredOnly: false)
+                .Where(property => string.Equals(this.GetServerDefinedName(property), serverDefinedName, StringComparison.Ordinal))
+                .Take(2)
+                .ToArray();
+            if (matchingProperties.Length > 1)
+            {
+                throw Client.Error.InvalidOperation(Error.Format(
+                    SRResources.ClientType_PropertyNameResolverCollision,
+                    matchingProperties[0].Name,
+                    matchingProperties[1].Name,
+                    type,
+                    serverDefinedName));
+            }
+
+            PropertyInfo propertyInfo = matchingProperties.SingleOrDefault();
+            if (propertyInfo == null && undeclaredPropertyBehavior == UndeclaredPropertyBehavior.ThrowException)
+            {
+                throw Client.Error.InvalidOperation(Error.Format(SRResources.ClientType_MissingProperty, type.ToString(), serverDefinedName));
+            }
+
+            return propertyInfo;
         }
 
         /// <summary>
@@ -454,7 +514,9 @@ namespace Microsoft.OData.Client
                             // This will leave entityType intact in case of an exception during loading.
                             List<IEdmProperty> loadedProperties = new List<IEdmProperty>();
                             List<IEdmStructuralProperty> loadedKeyProperties = new List<IEdmStructuralProperty>();
-                            foreach (PropertyInfo property in ClientTypeUtil.GetPropertiesOnType(type, /*declaredOnly*/edmBaseType != null).OrderBy(p => p.Name))
+                            PropertyInfo[] properties = ClientTypeUtil.GetPropertiesOnType(type, /*declaredOnly*/edmBaseType != null).OrderBy(p => p.Name).ToArray();
+                            this.ValidatePropertyNames(type, properties);
+                            foreach (PropertyInfo property in properties)
                             {
                                 IEdmProperty edmProperty = this.CreateEdmProperty((EdmStructuredType)entityType, property);
                                 loadedProperties.Add(edmProperty);
@@ -477,7 +539,7 @@ namespace Microsoft.OData.Client
                             List<IEdmStructuralProperty> orderedloadedKeyProperties = new List<IEdmStructuralProperty>();
                             foreach (var orderedKey in keyProperties)
                             {
-                                string serverDefinedName = ClientTypeUtil.GetServerDefinedName(orderedKey);
+                                string serverDefinedName = this.GetServerDefinedName(orderedKey);
                                 IEdmStructuralProperty keyProperty = loadedKeyProperties.FirstOrDefault(k => k.Name == serverDefinedName);
 
                                 if (keyProperty != null)
@@ -524,7 +586,9 @@ namespace Microsoft.OData.Client
                             // Create properties without modifying the complexType.
                             // This will leave complexType intact in case of an exception during loading.
                             List<IEdmProperty> loadedProperties = new List<IEdmProperty>();
-                            foreach (PropertyInfo property in ClientTypeUtil.GetPropertiesOnType(type, /*declaredOnly*/edmBaseType != null).OrderBy(p => p.Name))
+                            PropertyInfo[] properties = ClientTypeUtil.GetPropertiesOnType(type, /*declaredOnly*/edmBaseType != null).OrderBy(p => p.Name).ToArray();
+                            this.ValidatePropertyNames(type, properties);
+                            foreach (PropertyInfo property in properties)
                             {
                                 IEdmProperty edmProperty = this.CreateEdmProperty(complexType, property);
                                 loadedProperties.Add(edmProperty);
@@ -609,7 +673,7 @@ namespace Microsoft.OData.Client
                     // The partner representing the other side exists only inside this property and is not added to the target entity type,
                     // so it should not cause any name collisions.
                     edmProperty = EdmNavigationProperty.CreateNavigationPropertyWithPartner(
-                        ClientTypeUtil.GetServerDefinedName(propertyInfo),
+                        this.GetServerDefinedName(propertyInfo),
                         propertyEdmType.ToEdmTypeReference(isPropertyNullable),
                         /*dependentProperties*/ null,
                         /*principalProperties*/ null,
@@ -625,11 +689,34 @@ namespace Microsoft.OData.Client
             }
             else
             {
-                edmProperty = new EdmStructuralProperty(declaringType, ClientTypeUtil.GetServerDefinedName(propertyInfo), propertyEdmType.ToEdmTypeReference(isPropertyNullable));
+                edmProperty = new EdmStructuralProperty(declaringType, this.GetServerDefinedName(propertyInfo), propertyEdmType.ToEdmTypeReference(isPropertyNullable));
             }
 
             edmProperty.SetClientPropertyAnnotation(new ClientPropertyAnnotation(edmProperty, propertyInfo, this));
             return edmProperty;
+        }
+
+        /// <summary>Validates that each CLR property maps to a unique server-defined name.</summary>
+        /// <param name="type">CLR declaring type.</param>
+        /// <param name="properties">Properties to validate.</param>
+        private void ValidatePropertyNames(Type type, IEnumerable<PropertyInfo> properties)
+        {
+            Dictionary<string, PropertyInfo> propertiesByServerName = new Dictionary<string, PropertyInfo>(StringComparer.Ordinal);
+            foreach (PropertyInfo property in properties)
+            {
+                string serverDefinedName = this.GetServerDefinedName(property);
+                if (propertiesByServerName.TryGetValue(serverDefinedName, out PropertyInfo conflictingProperty))
+                {
+                    throw Client.Error.InvalidOperation(Error.Format(
+                        SRResources.ClientType_PropertyNameResolverCollision,
+                        conflictingProperty.Name,
+                        property.Name,
+                        type,
+                        serverDefinedName));
+                }
+
+                propertiesByServerName.Add(serverDefinedName, property);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -231,6 +231,20 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary>
+        /// Initializes a new context with a resolver that maps CLR property names to server-defined property names.
+        /// </summary>
+        /// <param name="serviceRoot">An absolute URI that identifies the root of a data service.</param>
+        /// <param name="maxProtocolVersion">The maximum protocol version that the client understands.</param>
+        /// <param name="resolvePropertyName">
+        /// Resolver that maps a CLR property to its server-defined name.
+        /// <see cref="OriginalNameAttribute"/> takes precedence when present.
+        /// </param>
+        public DataServiceContext(Uri serviceRoot, ODataProtocolVersion maxProtocolVersion, Func<PropertyInfo, string> resolvePropertyName)
+            : this(serviceRoot, maxProtocolVersion, CreateClientEdmModel(maxProtocolVersion, resolvePropertyName))
+        {
+        }
+
+        /// <summary>
         /// Instantiates a new context with the specified <paramref name="serviceRoot"/> Uri.
         /// The library expects the Uri to point to the root of a data service,
         /// but does not issue a request to validate it does indeed identify the root of a service.
@@ -758,6 +772,14 @@ namespace Microsoft.OData.Client
         internal ClientEdmModel Model
         {
             get { return this.model; }
+        }
+
+        /// <summary>Gets the server-defined name for a CLR member.</summary>
+        /// <param name="memberInfo">Member to resolve.</param>
+        /// <returns>Server-defined name.</returns>
+        internal string GetServerDefinedName(MemberInfo memberInfo)
+        {
+            return this.model.GetServerDefinedName(memberInfo);
         }
 
         /// <summary>
@@ -4590,6 +4612,19 @@ namespace Microsoft.OData.Client
 
             descriptor.State = EntityStates.Unchanged;
             descriptor.DependsOnIds = null;
+        }
+
+        /// <summary>Creates an isolated client model for a context-specific property-name resolver.</summary>
+        private static ClientEdmModel CreateClientEdmModel(
+            ODataProtocolVersion maxProtocolVersion,
+            Func<PropertyInfo, string> resolvePropertyName)
+        {
+            Util.CheckArgumentNull(resolvePropertyName, "resolvePropertyName");
+            Util.CheckEnumerationValue(maxProtocolVersion, "maxProtocolVersion");
+
+            ClientEdmModel clientModel = new ClientEdmModel(maxProtocolVersion, resolvePropertyName);
+            clientModel.SetEdmVersion(maxProtocolVersion.ToVersion());
+            return clientModel;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/GroupByProjectionPlanCompiler.cs
+++ b/src/Microsoft.OData.Client/GroupByProjectionPlanCompiler.cs
@@ -54,6 +54,9 @@ namespace Microsoft.OData.Client
         /// <summary>Mapping of member names in the GroupBy key selector to their respective expressions.</summary>
         private readonly Dictionary<string, Expression> keySelectorMap;
 
+        /// <summary>The client model used to resolve server-defined property names.</summary>
+        private readonly ClientEdmModel model;
+
         #endregion Private fields
 
         #region Constructors
@@ -65,7 +68,8 @@ namespace Microsoft.OData.Client
         /// <param name="keySelectorMap">Mapping of member names in the GroupBy key selector to their respective expressions.</param>
         private GroupByProjectionPlanCompiler(
             Dictionary<Expression, Expression> normalizerRewrites,
-            Dictionary<string, Expression> keySelectorMap)
+            Dictionary<string, Expression> keySelectorMap,
+            ClientEdmModel model)
         {
             this.annotations = new Dictionary<Expression, ExpressionAnnotation>(ReferenceEqualityComparer<Expression>.Instance);
             this.materializerExpression = Expression.Parameter(typeof(object), "mat");
@@ -73,6 +77,7 @@ namespace Microsoft.OData.Client
             this.pathBuilder = new GroupByProjectionPathBuilder();
             this.resultSelectorMap = new Dictionary<Expression, MappingInfo>(ReferenceEqualityComparer<Expression>.Instance);
             this.keySelectorMap = keySelectorMap;
+            this.model = model;
         }
 
         #endregion Constructors
@@ -87,7 +92,8 @@ namespace Microsoft.OData.Client
         internal static ProjectionPlan CompilePlan(
             LambdaExpression projection,
             Dictionary<Expression, Expression> normalizerRewrites,
-            Dictionary<string, Expression> keySelectorMap)
+            Dictionary<string, Expression> keySelectorMap,
+            ClientEdmModel model)
         {
             Debug.Assert(projection != null, "projection != null");
             Debug.Assert(projection.Parameters.Count >= 1, "projection.Parameters.Count >= 1");
@@ -100,7 +106,7 @@ namespace Microsoft.OData.Client
                 projection.Body.NodeType == ExpressionType.New,
                 "projection.Body.NodeType == Constant, MemberInit, MemberAccess, Convert(Checked) New");
 
-            GroupByProjectionPlanCompiler rewriter = new GroupByProjectionPlanCompiler(normalizerRewrites, keySelectorMap);
+            GroupByProjectionPlanCompiler rewriter = new GroupByProjectionPlanCompiler(normalizerRewrites, keySelectorMap, model);
             GroupByProjectionAnalyzer.Analyze(rewriter, projection);
 
             Expression plan = rewriter.Visit(projection);
@@ -454,7 +460,7 @@ namespace Microsoft.OData.Client
             // annotations always come from target expression
             // that are generated anew (except parameters,
             // but those)
-            ProjectionPathSegment memberSegment = new ProjectionPathSegment(baseAnnotation.Segment.StartPath, m);
+            ProjectionPathSegment memberSegment = ProjectionPathSegment.CreateWithModel(baseAnnotation.Segment.StartPath, m, this.model);
             baseAnnotation.Segment.StartPath.Add(memberSegment);
             return this.CallValueForPathWithType(
                 baseAnnotation.Segment.StartPath.RootEntry,

--- a/src/Microsoft.OData.Client/Materialization/ODataEntityMaterializer.cs
+++ b/src/Microsoft.OData.Client/Materialization/ODataEntityMaterializer.cs
@@ -991,7 +991,11 @@ namespace Microsoft.OData.Client.Materialization
                 // The KeySelectorMap property is initialized and populated with a least one item if we're dealing with a GroupBy expression.
                 if (queryComponents.GroupByKeySelectorMap?.Count > 0)
                 {
-                    result = GroupByProjectionPlanCompiler.CompilePlan(projection, queryComponents.NormalizerRewrites, queryComponents.GroupByKeySelectorMap);
+                    result = GroupByProjectionPlanCompiler.CompilePlan(
+                        projection,
+                        queryComponents.NormalizerRewrites,
+                        queryComponents.GroupByKeySelectorMap,
+                        materializerContext.Model);
                 }
                 else
                 {

--- a/src/Microsoft.OData.Client/Metadata/ClientPropertyAnnotation.cs
+++ b/src/Microsoft.OData.Client/Metadata/ClientPropertyAnnotation.cs
@@ -106,7 +106,7 @@ namespace Microsoft.OData.Client.Metadata
             Debug.Assert(propertyInfo.DeclaringType != null, "Property without a declaring type");
 
             this.EdmProperty = edmProperty;
-            this.PropertyName = ClientTypeUtil.GetServerDefinedName(propertyInfo);
+            this.PropertyName = model.GetServerDefinedName(propertyInfo);
             this.PropertyInfo = propertyInfo;
             this.NullablePropertyType = propertyInfo.PropertyType;
             this.PropertyType = Nullable.GetUnderlyingType(this.NullablePropertyType) ?? this.NullablePropertyType;

--- a/src/Microsoft.OData.Client/Metadata/ClientTypeAnnotation.cs
+++ b/src/Microsoft.OData.Client/Metadata/ClientTypeAnnotation.cs
@@ -173,7 +173,8 @@ namespace Microsoft.OData.Client.Metadata
 
             if (!this.clientPropertyCache.TryGetValue(propertyName, out property))
             {
-                string propertyClientName = ClientTypeUtil.GetClientPropertyName(this.ElementType, propertyName, undeclaredPropertyBehavior);
+                PropertyInfo propertyInfo = this.model.GetClientPropertyInfo(this.ElementType, propertyName, undeclaredPropertyBehavior);
+                string propertyClientName = propertyInfo == null ? propertyName : propertyInfo.Name;
                 if ((string.IsNullOrEmpty(propertyClientName) || !this.clientPropertyCache.TryGetValue(propertyClientName, out property)) && (undeclaredPropertyBehavior == UndeclaredPropertyBehavior.ThrowException))
                 {
                     throw Error.InvalidOperation(Error.Format(SRResources.ClientType_MissingProperty, this.ElementTypeName, propertyName));

--- a/src/Microsoft.OData.Client/Metadata/ClientTypeUtil.cs
+++ b/src/Microsoft.OData.Client/Metadata/ClientTypeUtil.cs
@@ -427,13 +427,36 @@ namespace Microsoft.OData.Client.Metadata
         /// <returns>Server defined name.</returns>
         internal static string GetServerDefinedName(PropertyInfo propertyInfo)
         {
+            return GetServerDefinedName(propertyInfo, null);
+        }
+
+        /// <summary>Gets the server-defined name for a property using an optional naming resolver.</summary>
+        /// <param name="propertyInfo">Property to resolve.</param>
+        /// <param name="resolvePropertyName">Optional property-name resolver.</param>
+        /// <returns>Server-defined name.</returns>
+        internal static string GetServerDefinedName(PropertyInfo propertyInfo, Func<PropertyInfo, string> resolvePropertyName)
+        {
             OriginalNameAttribute originalNameAttribute = (OriginalNameAttribute)propertyInfo.GetCustomAttributes(typeof(OriginalNameAttribute), false).SingleOrDefault();
             if (originalNameAttribute != null)
             {
                 return originalNameAttribute.OriginalName;
             }
 
-            return propertyInfo.Name;
+            if (resolvePropertyName == null)
+            {
+                return propertyInfo.Name;
+            }
+
+            string resolvedName = resolvePropertyName(propertyInfo);
+            if (string.IsNullOrWhiteSpace(resolvedName))
+            {
+                throw Error.InvalidOperation(Error.Format(
+                    SRResources.ClientType_PropertyNameResolverReturnedInvalidName,
+                    propertyInfo.Name,
+                    propertyInfo.DeclaringType));
+            }
+
+            return resolvedName;
         }
 
         /// <summary>Gets the server defined name in <see cref="OriginalNameAttribute"/> of the specified <paramref name="memberInfo"/>.</summary>

--- a/src/Microsoft.OData.Client/ProjectionPathSegment.cs
+++ b/src/Microsoft.OData.Client/ProjectionPathSegment.cs
@@ -43,6 +43,29 @@ namespace Microsoft.OData.Client
         /// <param name="startPath">Path on which this segment is located.</param>
         /// <param name="memberExpression">Member expression for the projection path; possibly null.</param>
         internal ProjectionPathSegment(ProjectionPath startPath, MemberExpression memberExpression)
+            : this(startPath, memberExpression, null)
+        {
+        }
+
+        /// <summary>Creates a projection path segment using a client model's property naming policy.</summary>
+        /// <param name="startPath">Path on which this segment is located.</param>
+        /// <param name="memberExpression">Member expression for the projection path.</param>
+        /// <param name="model">Client model used to resolve the server-defined member name.</param>
+        /// <returns>The projection path segment.</returns>
+        internal static ProjectionPathSegment CreateWithModel(
+            ProjectionPath startPath,
+            MemberExpression memberExpression,
+            ClientEdmModel model)
+        {
+            Debug.Assert(model != null, "model != null");
+            return new ProjectionPathSegment(startPath, memberExpression, model);
+        }
+
+        /// <summary>Initializes a projection path segment using an optional client model.</summary>
+        private ProjectionPathSegment(
+            ProjectionPath startPath,
+            MemberExpression memberExpression,
+            ClientEdmModel model)
         {
             Debug.Assert(startPath != null, "startPath != null");
             Debug.Assert(memberExpression != null, "memberExpression != null");
@@ -50,7 +73,9 @@ namespace Microsoft.OData.Client
             this.StartPath = startPath;
 
             Expression source = ResourceBinder.StripTo<Expression>(memberExpression.Expression);
-            this.Member = ClientTypeUtil.GetServerDefinedName(memberExpression.Member);
+            this.Member = model == null
+                ? ClientTypeUtil.GetServerDefinedName(memberExpression.Member)
+                : model.GetServerDefinedName(memberExpression.Member);
             this.ProjectionType = memberExpression.Type;
             this.SourceTypeAs = source.NodeType == ExpressionType.TypeAs ? source.Type : null;
         }

--- a/src/Microsoft.OData.Client/ProjectionPlanCompiler.cs
+++ b/src/Microsoft.OData.Client/ProjectionPlanCompiler.cs
@@ -668,7 +668,7 @@ namespace Microsoft.OData.Client
             for (int i = 0; i < init.Bindings.Count; i++)
             {
                 MemberAssignment assignment = (MemberAssignment)init.Bindings[i];
-                string memberName = ClientTypeUtil.GetServerDefinedName(assignment.Member);
+                string memberName = this.materializerContext.Model.GetServerDefinedName(assignment.Member);
                 propertyNames.Add(memberName);
 
                 LambdaExpression propertyLambda;
@@ -887,7 +887,7 @@ namespace Microsoft.OData.Client
             {
                 Expression baseTypeExpression = Expression.Constant(baseSourceExpression.Type, typeof(Type));
                 ProjectionPath nestedPath = new ProjectionPath(result as ParameterExpression, baseTypeExpression, result);
-                ProjectionPathSegment nestedSegment = new ProjectionPathSegment(nestedPath, m);
+                ProjectionPathSegment nestedSegment = ProjectionPathSegment.CreateWithModel(nestedPath, m, this.materializerContext.Model);
                 nestedPath.Add(nestedSegment);
                 result = this.CallValueForPathWithType(result, baseTypeExpression, nestedPath, m.Type);
             }
@@ -900,7 +900,7 @@ namespace Microsoft.OData.Client
                 // annotations always come from target expression
                 // that are generated anew (except parameters,
                 // but those)
-                memberSegment = new ProjectionPathSegment(baseAnnotation.Segment.StartPath, m);
+                memberSegment = ProjectionPathSegment.CreateWithModel(baseAnnotation.Segment.StartPath, m, this.materializerContext.Model);
                 baseAnnotation.Segment.StartPath.Add(memberSegment);
                 result = this.CallValueForPathWithType(
                     baseAnnotation.Segment.StartPath.RootEntry,

--- a/src/Microsoft.OData.Client/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.OData.Client.DataServiceContext.DataServiceContext(System.Uri serviceRoot, Microsoft.OData.Client.ODataProtocolVersion maxProtocolVersion, System.Func<System.Reflection.PropertyInfo, string> resolvePropertyName) -> void

--- a/src/Microsoft.OData.Client/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.OData.Client.DataServiceContext.DataServiceContext(System.Uri serviceRoot, Microsoft.OData.Client.ODataProtocolVersion maxProtocolVersion, System.Func<System.Reflection.PropertyInfo, string> resolvePropertyName) -> void

--- a/src/Microsoft.OData.Client/SRResources.Designer.cs
+++ b/src/Microsoft.OData.Client/SRResources.Designer.cs
@@ -751,6 +751,24 @@ namespace Microsoft.OData.Client {
                 return ResourceManager.GetString("ClientType_MissingProperty", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The property name resolver maps properties '{0}' and '{1}' on type '{2}' to the same server-defined name '{3}'.
+        /// </summary>
+        internal static string ClientType_PropertyNameResolverCollision {
+            get {
+                return ResourceManager.GetString("ClientType_PropertyNameResolverCollision", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The property name resolver returned a null, empty, or whitespace name for property '{0}' on type '{1}'.
+        /// </summary>
+        internal static string ClientType_PropertyNameResolverReturnedInvalidName {
+            get {
+                return ResourceManager.GetString("ClientType_PropertyNameResolverReturnedInvalidName", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Multiple implementations of ICollection&lt;T&gt; is not supported..

--- a/src/Microsoft.OData.Client/SRResources.resx
+++ b/src/Microsoft.OData.Client/SRResources.resx
@@ -338,6 +338,12 @@
   <data name="ClientType_MissingProperty" xml:space="preserve">
     <value>The closed type {0} does not have a corresponding {1} settable property.</value>
   </data>
+  <data name="ClientType_PropertyNameResolverCollision" xml:space="preserve">
+    <value>The property name resolver maps properties '{0}' and '{1}' on type '{2}' to the same server-defined name '{3}'.</value>
+  </data>
+  <data name="ClientType_PropertyNameResolverReturnedInvalidName" xml:space="preserve">
+    <value>The property name resolver returned a null, empty, or whitespace name for property '{0}' on type '{1}'.</value>
+  </data>
   <data name="ClientType_KeysMustBeSimpleTypes" xml:space="preserve">
     <value>The key property '{0}' on for type '{1}' is of type '{2}', which is not a simple type. Only properties of simple type can be key properties.</value>
   </data>
@@ -885,4 +891,3 @@
     <value>The header '{0}' has a different value. Old Value: '{1}', Current Value: '{2}' Please make sure to set the header before SendingRequest event is fired</value>
   </data>
 </root>
-

--- a/test/UnitTests/Microsoft.OData.Client.Tests/PropertyNameResolverTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/PropertyNameResolverTests.cs
@@ -1,0 +1,220 @@
+//---------------------------------------------------------------------
+// <copyright file="PropertyNameResolverTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.OData.Client.Metadata;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.OData.Client.Tests
+{
+    public class PropertyNameResolverTests
+    {
+        private static readonly Uri ServiceRoot = new Uri("https://service.test/");
+
+        [Fact]
+        public void ResolverAppliesToFilterAndSelectQueryNames()
+        {
+            DataServiceContext context = CreateContext();
+
+            IQueryable<Customer> query = context.CreateQuery<Customer>("customers")
+                .Where(customer => customer.CompanyName == "Contoso");
+
+            string requestUri = query.ToString();
+            Assert.Contains("$filter=company_name eq 'Contoso'", requestUri);
+
+            string selectUri = context.CreateQuery<Customer>("customers")
+                .Select(customer => new { customer.CompanyName })
+                .ToString();
+            Assert.Contains("$select=company_name", selectUri);
+        }
+
+        [Fact]
+        public void ResolverAppliesToClientModelAndReversePropertyLookup()
+        {
+            DataServiceContext context = CreateContext();
+            IEdmStructuredType edmType = (IEdmStructuredType)context.Model.GetOrCreateEdmType(typeof(Customer));
+
+            Assert.NotNull(edmType.FindProperty("company_name"));
+            Assert.Null(edmType.FindProperty(nameof(Customer.CompanyName)));
+
+            ClientTypeAnnotation typeAnnotation = context.Model.GetClientTypeAnnotation(edmType);
+            ClientPropertyAnnotation property = typeAnnotation.GetProperty(
+                "company_name",
+                UndeclaredPropertyBehavior.ThrowException);
+
+            Assert.Equal(nameof(Customer.CompanyName), property.PropertyInfo.Name);
+            Assert.Equal("company_name", property.PropertyName);
+        }
+
+        [Fact]
+        public void OriginalNameAttributeTakesPrecedenceOverResolver()
+        {
+            DataServiceContext context = CreateContext();
+            IEdmStructuredType edmType = (IEdmStructuredType)context.Model.GetOrCreateEdmType(typeof(Customer));
+
+            Assert.NotNull(edmType.FindProperty("display"));
+            Assert.Null(edmType.FindProperty("display_name"));
+        }
+
+        [Fact]
+        public void ResolverIsIsolatedFromContextsUsingDefaultNames()
+        {
+            DataServiceContext customContext = CreateContext();
+            DataServiceContext defaultContext = new DataServiceContext(ServiceRoot);
+
+            IEdmStructuredType customType = (IEdmStructuredType)customContext.Model.GetOrCreateEdmType(typeof(Customer));
+            IEdmStructuredType defaultType = (IEdmStructuredType)defaultContext.Model.GetOrCreateEdmType(typeof(Customer));
+
+            Assert.NotNull(customType.FindProperty("company_name"));
+            Assert.Null(customType.FindProperty(nameof(Customer.CompanyName)));
+            Assert.NotNull(defaultType.FindProperty(nameof(Customer.CompanyName)));
+            Assert.Null(defaultType.FindProperty("company_name"));
+        }
+
+        [Fact]
+        public void ResolverRejectsPropertyNameCollisions()
+        {
+            DataServiceContext context = new DataServiceContext(
+                ServiceRoot,
+                ODataProtocolVersion.V4,
+                property => "duplicate");
+            IEdmStructuredType edmType = (IEdmStructuredType)context.Model.GetOrCreateEdmType(typeof(Customer));
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+                () => edmType.DeclaredProperties.ToArray());
+
+            Assert.Contains("same server-defined name 'duplicate'", exception.Message);
+        }
+
+        [Fact]
+        public void ResolverRejectsInvalidPropertyNames()
+        {
+            DataServiceContext context = new DataServiceContext(
+                ServiceRoot,
+                ODataProtocolVersion.V4,
+                property => null);
+            IEdmStructuredType edmType = (IEdmStructuredType)context.Model.GetOrCreateEdmType(typeof(Customer));
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+                () => edmType.DeclaredProperties.ToArray());
+
+            Assert.Contains("returned a null, empty, or whitespace name", exception.Message);
+        }
+
+        [Fact]
+        public void ResolverAppliesWhenMaterializingResponseProperties()
+        {
+            DataServiceContext context = CreateContext();
+            context.Format.UseJson(CreateServiceModel());
+            context.MergeOption = MergeOption.NoTracking;
+            context.ResolveName = type => $"NS.{type.Name}";
+            string response = """
+                {
+                  "@odata.context":"https://service.test/$metadata#customers",
+                  "value":[
+                    {
+                      "id":1,
+                      "company_name":"Contoso",
+                      "display":"Contoso Ltd."
+                    }
+                  ]
+                }
+                """;
+            context.Configurations.RequestPipeline.OnMessageCreating = args =>
+                new TestHttpWebRequestMessage(
+                    args,
+                    new Dictionary<string, string>
+                    {
+                        { "Content-Type", "application/json;odata.metadata=minimal" },
+                        { "OData-Version", "4.0" }
+                    },
+                    () => new MemoryStream(Encoding.UTF8.GetBytes(response)));
+
+            Customer customer = context.CreateQuery<Customer>("customers").Execute().Single();
+
+            Assert.Equal(1, customer.Id);
+            Assert.Equal("Contoso", customer.CompanyName);
+            Assert.Equal("Contoso Ltd.", customer.DisplayName);
+        }
+
+        [Fact]
+        public void ResolverAppliesWhenSerializingRequestProperties()
+        {
+            DataServiceContext context = CreateContext();
+            context.Format.UseJson(CreateServiceModel());
+            context.ResolveName = type => $"NS.{type.Name}";
+            context.AddAndUpdateResponsePreference = DataServiceResponsePreference.NoContent;
+            string[] serializedPropertyNames = null;
+            context.Configurations.RequestPipeline.OnEntryStarting(args =>
+                serializedPropertyNames = args.Entry.Properties.Select(property => property.Name).ToArray());
+            context.Configurations.RequestPipeline.OnMessageCreating = args =>
+                new TestHttpWebRequestMessage(
+                    args,
+                    new Dictionary<string, string>
+                    {
+                        { "OData-Version", "4.0" }
+                    },
+                    statusCode: 204,
+                    () => Stream.Null);
+
+            context.AddObject(
+                "customers",
+                new Customer
+                {
+                    Id = 1,
+                    CompanyName = "Contoso",
+                    DisplayName = "Contoso Ltd."
+                });
+            context.SaveChanges();
+
+            Assert.Equal(new[] { "company_name", "display", "id" }, serializedPropertyNames);
+        }
+
+        private static DataServiceContext CreateContext()
+        {
+            return new DataServiceContext(
+                ServiceRoot,
+                ODataProtocolVersion.V4,
+                property => property.Name switch
+                {
+                    nameof(Customer.CompanyName) => "company_name",
+                    nameof(Customer.DisplayName) => "display_name",
+                    _ => property.Name.ToLowerInvariant()
+                });
+        }
+
+        private static IEdmModel CreateServiceModel()
+        {
+            EdmModel model = new EdmModel();
+            EdmEntityType customerType = new EdmEntityType("NS", nameof(Customer));
+            IEdmStructuralProperty id = customerType.AddStructuralProperty("id", EdmPrimitiveTypeKind.Int32, false);
+            customerType.AddKeys(id);
+            customerType.AddStructuralProperty("company_name", EdmPrimitiveTypeKind.String);
+            customerType.AddStructuralProperty("display", EdmPrimitiveTypeKind.String);
+            model.AddElement(customerType);
+
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Container");
+            container.AddEntitySet("customers", customerType);
+            model.AddElement(container);
+            return model;
+        }
+
+        private sealed class Customer
+        {
+            public int Id { get; set; }
+
+            public string CompanyName { get; set; }
+
+            [OriginalName("display")]
+            public string DisplayName { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Add a DataServiceContext constructor that accepts a CLR property-to-wire-name resolver and creates an isolated client EDM model for resolver-enabled contexts.

Apply resolved names consistently across LINQ query generation, request serialization, response materialization, annotations, and projection plans. Preserve OriginalNameAttribute precedence and reject invalid or colliding resolved names with actionable errors.

Add public API baselines and coverage for filters, selects, serialization, materialization, model lookup, precedence, context isolation, and resolver validation.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3590.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
