### PR TITLE
Fix product and xUnit analyzer warnings

### DIFF
--- a/src/Microsoft.OData.Client/BaseEntityType.cs
+++ b/src/Microsoft.OData.Client/BaseEntityType.cs
@@ -9,6 +9,7 @@ namespace Microsoft.OData.Client
     /// <summary>
     /// Base type of entity type to include <see cref="Microsoft.OData.Client.DataServiceContext" /> for function and action invocation
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1033:Interface methods should be callable by child types", Justification = "The protected Context property exposes this functionality to derived types.")]
     public class BaseEntityType : IBaseEntityType
     {
         /// <summary>

--- a/src/Microsoft.OData.Client/DataServiceClientException.cs
+++ b/src/Microsoft.OData.Client/DataServiceClientException.cs
@@ -61,6 +61,8 @@ namespace Microsoft.OData.Client
             this.statusCode = statusCode;
         }
 
+        // Legacy formatter-based serialization is retained for compatibility.
+#pragma warning disable SYSLIB0003, SYSLIB0051, CS0672
         private DataServiceClientException(SerializationInfo info, StreamingContext context)
 : base(info, context)
         {
@@ -94,6 +96,7 @@ namespace Microsoft.OData.Client
             // MUST call through to the base class to let it save its own state
             base.GetObjectData(info, context);
         }
+#pragma warning restore SYSLIB0003, SYSLIB0051, CS0672
 
     }
 }

--- a/src/Microsoft.OData.Client/DataServiceQueryException.cs
+++ b/src/Microsoft.OData.Client/DataServiceQueryException.cs
@@ -54,7 +54,7 @@ namespace Microsoft.OData.Client
             this.response = response;
         }
 
-#pragma warning disable 0628
+#pragma warning disable 0628, SYSLIB0051
         /// <summary>
         /// Initializes a new instance of the DataServiceQueryException class from the
         /// specified SerializationInfo and StreamingContext instances.
@@ -71,7 +71,7 @@ namespace Microsoft.OData.Client
             : base(info, context)
         {
         }
-#pragma warning restore 0628
+#pragma warning restore 0628, SYSLIB0051
 
         #endregion Constructors
 

--- a/src/Microsoft.OData.Client/DataServiceRequestException.cs
+++ b/src/Microsoft.OData.Client/DataServiceRequestException.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OData.Client
             this.response = response;
         }
 
-#pragma warning disable 0628
+#pragma warning disable 0628, SYSLIB0051
         /// <summary>
         /// Initializes a new instance of the DataServiceQueryException class from the
         /// specified SerializationInfo and StreamingContext instances.
@@ -67,7 +67,7 @@ namespace Microsoft.OData.Client
             : base(info, context)
         {
         }
-#pragma warning restore 0628
+#pragma warning restore 0628, SYSLIB0051
 
         #endregion Constructors
 

--- a/src/Microsoft.OData.Client/DataServiceWebException.cs
+++ b/src/Microsoft.OData.Client/DataServiceWebException.cs
@@ -34,6 +34,8 @@ namespace Microsoft.OData.Client
 
         }
 
+        // Legacy formatter-based serialization is retained for compatibility.
+#pragma warning disable SYSLIB0003, SYSLIB0051, CS0672
         [SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
         protected DataServiceTransportException(SerializationInfo info, StreamingContext context)
    : base(info, context)
@@ -60,6 +62,7 @@ namespace Microsoft.OData.Client
             // MUST call through to the base class to let it save its own state
             base.GetObjectData(info, context);
         }
+#pragma warning restore SYSLIB0003, SYSLIB0051, CS0672
 
 
     }

--- a/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
@@ -925,7 +925,7 @@ namespace Microsoft.OData.Json
             static async Task AwaitReadInternalAsync(BufferingJsonReader thisParam, Task<bool> readInternalTask)
             {
                 await readInternalTask.ConfigureAwait(false);
-                await thisParam.DetectAndTryReadInStreamErrorAsync();
+                await thisParam.DetectAndTryReadInStreamErrorAsync().ConfigureAwait(false);
             }
         }
 
@@ -2372,6 +2372,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         [DebuggerStepThrough]
         [Conditional("DEBUG")]
+        [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "This method accesses instance state in DEBUG builds.")]
         private void AssertAsynchronous()
         {
 #if DEBUG

--- a/src/Microsoft.OData.Core/Json/JsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/JsonReader.cs
@@ -2195,7 +2195,7 @@ namespace Microsoft.OData.Json
             {
                 await GetOrAwait(pendingPostColonWhitespaceTask).ConfigureAwait(false);
 
-                return await ContinueAfterColonWhitespaceAsync(thisParam);
+                return await ContinueAfterColonWhitespaceAsync(thisParam).ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.OData.Core/Json/ODataJsonValueSerializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonValueSerializer.cs
@@ -725,12 +725,12 @@ namespace Microsoft.OData.Json
             Stream stream = await this.JsonWriter.StartStreamValueScopeAsync().ConfigureAwait(false);
             await streamValue.Stream.CopyToAsync(stream).ConfigureAwait(false);
             await stream.FlushAsync().ConfigureAwait(false);
-            await stream.DisposeAsync();
+            await stream.DisposeAsync().ConfigureAwait(false);
             await this.JsonWriter.EndStreamValueScopeAsync().ConfigureAwait(false);
 
             if (!streamValue.LeaveOpen)
             {
-                await streamValue.Stream.DisposeAsync();
+                await streamValue.Stream.DisposeAsync().ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
@@ -115,7 +115,7 @@ namespace Microsoft.OData.Json
 
             if (this.textWriter != null)
             {
-                await this.textWriter.DisposeAsync();
+                await this.textWriter.DisposeAsync().ConfigureAwait(false);
             }
 
             await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
@@ -173,7 +173,7 @@ namespace Microsoft.OData.Json
             /// <returns>A task representing the asynchronous flush operation.</returns>
             public override async Task FlushAsync()
             {
-                await this.jsonWriter.FlushAsync();
+                await this.jsonWriter.FlushAsync().ConfigureAwait(false);
             }
 
             /// <summary>

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -1137,7 +1137,7 @@ namespace Microsoft.OData.Json
             }
             else if (value.Length > bufferWriter.FreeCapacity || value.Length > chunkSize)
             {
-                await WriteStringValueInChunksAsync(value.AsMemory());
+                await WriteStringValueInChunksAsync(value.AsMemory()).ConfigureAwait(false);
             }
             else
             {
@@ -1189,7 +1189,7 @@ namespace Microsoft.OData.Json
                 }
 
                 // Flush the buffer if needed
-                await this.DrainBufferIfThresholdReachedAsync();
+                await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
             }
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
@@ -1210,7 +1210,7 @@ namespace Microsoft.OData.Json
             }
             else if (value.Length > bufferWriter.FreeCapacity || value.Length > chunkSize)
             {
-                await WriteByteValueInChunksAsync(value);
+                await WriteByteValueInChunksAsync(value).ConfigureAwait(false);
             }
             else
             {

--- a/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
+++ b/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.OData.Metadata
 
 #if !NETSTANDARD1_1
         /// <summary>
-        /// Packs the <see cref="TypeCode"/> of supported primitive types. This is used to speed up the <see cref="IsPrimitiveType(Type)"/> method.
+        /// Packs the <see cref="TypeCode"/> of supported primitive types. This is used to speed up the <c>IsPrimitiveType</c> method.
         /// If the bit at a given type code position is set, it means that's a support primitive type.
         /// </summary>
         private static int PrimitiveTypeCodeBitMap = 0;

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -96,7 +96,7 @@ namespace Microsoft.OData
         /// <summary>
         /// Returns <paramref name="source"/> as an <see cref="IReadOnlyList{T}"/>, materializing the
         /// sequence to an array when it isn't already a known collection. Used to avoid re-enumerating
-        /// the LINQ iterator returned by <see cref="ExtensionMethods.GetDerivedTypeConstraints"/>.
+        /// the LINQ iterator returned by <see cref="ExtensionMethods.GetDerivedTypeConstraints(IEdmModel, IEdmNavigationSource)"/>.
         /// </summary>
         private static IReadOnlyList<string> MaterializeOrNull(IEnumerable<string> source)
         {

--- a/src/Microsoft.OData.Edm/Schema/EdmPathExpression.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmPathExpression.cs
@@ -55,7 +55,7 @@ namespace Microsoft.OData.Edm
                     throw new ArgumentException(SRResources.PathSegmentMustNotBeNull, nameof(pathSegments));
                 }
 
-                if (segment.IndexOf('/') >= 0)
+                if (segment.IndexOf("/", StringComparison.Ordinal) >= 0)
                 {
                     throw new ArgumentException(SRResources.PathSegmentMustNotContainSlash);
                 }

--- a/test/UnitTests/Microsoft.OData.Client.Tests/ScenarioTests/Deadlocks/SynchronizationContextDeadlockTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/ScenarioTests/Deadlocks/SynchronizationContextDeadlockTests.cs
@@ -416,6 +416,8 @@ namespace Microsoft.OData.Client.Tests.ScenarioTests.Deadlocks
     {
         public int Id { get; set; }
         public string Name { get; set; }
+#pragma warning disable CS0067 // Required by INotifyPropertyChanged.
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+#pragma warning restore CS0067
     }
 }

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.OData.Client.Tests.Serialization
 
                     // Assert
                     Assert.Equal(expectedResponse, contents);
-                    Assert.Equal(1, handler.Requests.Count);
+                    Assert.Single(handler.Requests);
                     Assert.Equal("GET http://localhost/", handler.Requests[0]);
                     Assert.Equal(1, httpClientFactory.NumCalls);
                 }

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/MockUnresponsiveHttpClientHandler.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/MockUnresponsiveHttpClientHandler.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OData.Client.Tests.Serialization
         /// </summary>
         public Action OnRequestStarted { get; set; }
 
-        public HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             NotifyRequestStart();
             Stopwatch stopwatch = new Stopwatch();

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextNoTrackingStreamsTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextNoTrackingStreamsTests.cs
@@ -160,12 +160,12 @@ namespace Microsoft.OData.Client.Tests.Tracking
         }
 
         [Fact]
-        public void TestBehaviourShouldRemainTheSameForTheDataContext()
+        public async Task TestBehaviourShouldRemainTheSameForTheDataContext()
         {
             SetupContextWithRequestPipeline(new DataServiceContext[] { DefaultTrackingContext, NonTrackingContext }, false);
 
-            var users = DefaultTrackingContext.Users.ExecuteAsync().GetAwaiter().GetResult();
-            var users2 = NonTrackingContext.Users.ExecuteAsync().GetAwaiter().GetResult();
+            var users = await DefaultTrackingContext.Users.ExecuteAsync();
+            var users2 = await NonTrackingContext.Users.ExecuteAsync();
             // data should be fetched and the count should be the same
             Assert.Equal(users.ToList().Count, users2.ToList().Count);
 
@@ -177,11 +177,11 @@ namespace Microsoft.OData.Client.Tests.Tracking
         }
 
         [Fact]
-        public void TrackMediaEntitiesShouldBePopulatedWithMediaEntities()
+        public async Task TrackMediaEntitiesShouldBePopulatedWithMediaEntities()
         {
             SetupContextWithRequestPipeline(new DataServiceContext[] { NonTrackingContext }, true);
 
-            var documents = NonTrackingContext.Documents.ExecuteAsync().GetAwaiter().GetResult().ToList();
+            var documents = (await NonTrackingContext.Documents.ExecuteAsync()).ToList();
 
             Assert.Empty(NonTrackingContext.EntityTracker.Entities.ToList());
 
@@ -193,7 +193,7 @@ namespace Microsoft.OData.Client.Tests.Tracking
             Assert.Equal("https://localhost:8000/Documents/1/content", NonTrackingContext.GetReadStreamUri(document).ToString());
 
             // try and get the content and verify that the content matches the values
-            Stream result = GetTestReadStreamResult(NonTrackingContext, document).GetAwaiter().GetResult();
+            Stream result = await GetTestReadStreamResult(NonTrackingContext, document);
 
             Assert.Equal("Hello World!", new StreamReader(result).ReadToEnd());
 

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextQueryTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextQueryTests.cs
@@ -255,7 +255,7 @@ namespace Microsoft.OData.Client.Tests.Tracking
             EmployeeSingle query = _defaultContext.Employees.ByKey(
                 new Dictionary<string, object>() { { "EmpNumber", 8 }, { "EmpType", EmployeeType.PartTime }, { "OrgId", 1 } });
 
-            Employee employee = await query.GetValueAsync().ConfigureAwait(false);
+            Employee employee = await query.GetValueAsync();
 
             // Assert
             Assert.Equal(expectedUri, query.Query.ToString());
@@ -341,7 +341,9 @@ namespace Microsoft.OData.Client.Tests.Tracking
         [ForeignKey("OrgId")]
         public virtual Organization Organization { get; set; }
 
+#pragma warning disable CS0067 // Required by INotifyPropertyChanged.
         public event PropertyChangedEventHandler PropertyChanged;
+#pragma warning restore CS0067
     }
 
     public class Organization

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Evaluation/NoOpResourceMetadataBuilderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Evaluation/NoOpResourceMetadataBuilderTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.OData.Tests.Evaluation
 
             ODataResource entry = new ODataResource();
             entry.AddAction(action);
-            Assert.Single(new NoOpResourceMetadataBuilder(entry).GetActions().Where(a => a == action));
+            Assert.Single(new NoOpResourceMetadataBuilder(entry).GetActions(), a => a == action);
 
             // Verify that the action information wasn't removed or changed.
             Assert.Equal(new Uri("http://example.com/$metadata#Action"), action.Metadata);
@@ -115,7 +115,7 @@ namespace Microsoft.OData.Tests.Evaluation
             ODataResource entry = new ODataResource();
             entry.AddFunction(function);
 
-            Assert.Single(new NoOpResourceMetadataBuilder(entry).GetFunctions().Where(f => f == function));
+            Assert.Single(new NoOpResourceMetadataBuilder(entry).GetFunctions(), f => f == function);
 
             // Verify that the Function information wasn't removed or changed.
             Assert.Equal(new Uri("http://example.com/$metadata#Function"), function.Metadata);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Evaluation/NullEntityMetadataBuilderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Evaluation/NullEntityMetadataBuilderTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.OData.Tests.Evaluation
                     new ODataProperty() {Name = "StreamProperty", Value = new ODataStreamReferenceValue()}
                 };
 
-            Assert.Single(this.testSubject.GetProperties(properties).Where(p => p.Name == "IntegerProperty"));
+            Assert.Single(this.testSubject.GetProperties(properties), p => p.Name == "IntegerProperty");
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
@@ -1243,7 +1243,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
             resourceWriter.WriteEnd();
 
             var str = Encoding.UTF8.GetString(stream.ToArray());
-            Assert.Equal(str, "{\"@odata.context\":\"http://svc/$metadata#Customers/$entity\"," +
+            Assert.Equal(actual: str, expected: "{\"@odata.context\":\"http://svc/$metadata#Customers/$entity\"," +
                 "\"Id\":9," +
                 "\"ComplexProperty\":{" +
                     "\"@odata.type\":\"#NS.Address\"," +
@@ -3250,7 +3250,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
                 }
                 else
                 {
-                    Assert.True(false, "Top level item to write must be entry or feed.");
+                    Assert.Fail("Top level item to write must be entry or feed.");
                 }
 
                 Assert.Equal(itemsToWrite.Length, currentIdx);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/UriParameterWriterIntegrationTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/UriParameterWriterIntegrationTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
         public void WriteComplexColParameter_WithoutModel()
         {
             WriteResourceSetParameter(false, false,
-                (actual) => Assert.Equal(actual,
+                (actual) => Assert.Equal(actual: actual, expected:
                     "[" +
                         "{" +
                             "\"@odata.type\":\"#NS.Address\"," +

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/BufferingJsonReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/BufferingJsonReaderTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.OData.Tests.Json
             // Assert
             Assert.True(result);
             Assert.Equal("any target", error.Target);
-            Assert.Equal(1, error.Details.Count);
+            Assert.Single(error.Details);
             var detail = error.Details.Single();
             Assert.Equal("500", detail.Code);
             Assert.Equal("another target", detail.Target);
@@ -381,10 +381,10 @@ namespace Microsoft.OData.Tests.Json
                 var innerError = error.InnerError;
                 Assert.NotNull(innerError);
                 Assert.Equal(3, innerError.Properties.Count);
-                Assert.Single(innerError.Properties.Where(d => d.Key.Equals("message")));
-                Assert.Single(innerError.Properties.Where(d => d.Key.Equals("type")));
-                Assert.Single(innerError.Properties.Where(d => d.Key.Equals("stacktrace")));
-                Assert.Empty(innerError.Properties.Where(d => d.Key.Equals("foo")));
+                Assert.Single(innerError.Properties, d => d.Key.Equals("message"));
+                Assert.Single(innerError.Properties, d => d.Key.Equals("type"));
+                Assert.Single(innerError.Properties, d => d.Key.Equals("stacktrace"));
+                Assert.DoesNotContain(innerError.Properties, d => d.Key.Equals("foo"));
             }
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonBatchReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonBatchReaderTests.cs
@@ -392,7 +392,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     }
                     catch (NullReferenceException ex)
                     {
-                        Assert.False(true, ex.Message);
+                        Assert.Fail(ex.Message);
                     }
                 },
                 isResponse: false);
@@ -428,7 +428,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     }
                     catch (NullReferenceException ex)
                     {
-                        Assert.False(true, ex.Message);
+                        Assert.Fail(ex.Message);
                     }
                 },
                 isResponse: false);
@@ -459,7 +459,7 @@ namespace Microsoft.OData.Core.Tests.Json
                             jsonBatchReader.CreateOperationRequestMessage();
                         }
                     }
-                    Assert.False(true, "The test failed, because the duplicate header has not thrown an ODataException");
+                    Assert.Fail("The test failed, because the duplicate header has not thrown an ODataException");
                 },
                 isResponse: false));
 
@@ -492,7 +492,7 @@ namespace Microsoft.OData.Core.Tests.Json
                             await jsonBatchReader.CreateOperationRequestMessageAsync();
                         }
                     }
-                    Assert.False(true, "The test failed, because the duplicate header has not thrown an ODataException");
+                    Assert.Fail("The test failed, because the duplicate header has not thrown an ODataException");
                 },
                 isResponse: false));
 
@@ -523,7 +523,7 @@ namespace Microsoft.OData.Core.Tests.Json
                             jsonBatchReader.CreateOperationRequestMessage();
                         }
                     }
-                    Assert.False(true, "The test failed, because the duplicate header has thrown no ODataException");
+                    Assert.Fail("The test failed, because the duplicate header has thrown no ODataException");
                 },
                 isResponse: false));
 
@@ -554,7 +554,7 @@ namespace Microsoft.OData.Core.Tests.Json
                                 await jsonBatchReader.CreateOperationRequestMessageAsync();
                             }
                         }
-                        Assert.False(true, "The test failed, because the duplicate header has thrown no ODataException");
+                        Assert.Fail("The test failed, because the duplicate header has thrown no ODataException");
                 },
                 isResponse: false));
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionDeserializerTests.cs
@@ -149,7 +149,6 @@ namespace Microsoft.OData.Tests.Json
                     await jsonCollectionDeserializer.ReadCollectionEndAsync(
                         isReadingNestedPayload: false);
 
-                    Assert.NotNull(readCollectionStartResult);
                     var collectionStart = Assert.IsType<ODataCollectionStart>(readCollectionStartResult.Item1);
                     var actualItemTypeReference = Assert.IsAssignableFrom<IEdmTypeReference>(readCollectionStartResult.Item2);
                     Assert.NotNull(collectionStart);
@@ -196,7 +195,6 @@ namespace Microsoft.OData.Tests.Json
                     await jsonCollectionDeserializer.ReadCollectionEndAsync(
                         isReadingNestedPayload: false);
 
-                    Assert.NotNull(readCollectionStartResult);
                     Assert.Equal("Tea", collectionItem1);
                     Assert.Equal("Coffee", collectionItem2);
                 });

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionWriterTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.OData.Tests.Json
                             }
                         }))));
             var str = Encoding.UTF8.GetString(stream.ToArray());
-            Assert.Equal(str,
+            Assert.Equal(actual: str, expected:
                 "{" +
                     "\"@odata.context\":\"http://svc/$metadata#EntitySet/$entity\"," +
                     "\"ID\":1," +

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeltaReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeltaReaderTests.cs
@@ -558,7 +558,7 @@ namespace Microsoft.OData.Tests.Json
                         break;
                     case ODataReaderState.Stream:
                     case ODataReaderState.NestedResourceInfoStart:
-                        Assert.True(false, "Should not add stream or navigation properties to delta payload");
+                        Assert.Fail("Should not add stream or navigation properties to delta payload");
                         break;
                 }
             }
@@ -4254,12 +4254,12 @@ namespace Microsoft.OData.Tests.Json
                                 Assert.True(nestedResourceInfo.Name.Equals("Details") || nestedResourceInfo.Name.Equals("Address") || nestedResourceInfo.Name.Equals("City"));
                                 break;
                             default:
-                                Assert.True(false, "Wrong reader sub state.");
+                                Assert.Fail("Wrong reader sub state.");
                                 break;
                         }
                         break;
                     default:
-                        Assert.True(false, "Wrong reader state.");
+                        Assert.Fail("Wrong reader state.");
                         break;
                 }
             }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeltaWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeltaWriterTests.cs
@@ -856,7 +856,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.WriteExpandedFeedWithModelImplementation();
 
-            Assert.Equal(this.TestPayload(),
+            Assert.Equal(actual: this.TestPayload(), expected:
                 "{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
@@ -890,7 +890,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.WriteExpandedFeedWithModelImplementation();
 
-            Assert.Equal(this.TestPayload(),
+            Assert.Equal(actual: this.TestPayload(), expected:
                 "{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
@@ -951,7 +951,7 @@ namespace Microsoft.OData.Tests.Json
             writer.WriteEnd(); // deltaFeedWithInfo
             writer.Flush();
 
-            Assert.Equal(this.TestPayload(),
+            Assert.Equal(actual: this.TestPayload(), expected:
                 "{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
@@ -1008,7 +1008,7 @@ namespace Microsoft.OData.Tests.Json
             writer.WriteEnd(); // deltaFeed
             writer.Flush();
 
-            Assert.Equal(this.TestPayload(),
+            Assert.Equal(actual: this.TestPayload(), expected:
                 "{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
@@ -1069,7 +1069,7 @@ namespace Microsoft.OData.Tests.Json
             writer.WriteEnd(); // deltaFeed
             writer.Flush();
 
-            Assert.Equal(this.TestPayload(),
+            Assert.Equal(actual: this.TestPayload(), expected:
                 "{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
@@ -1106,7 +1106,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.WriteNestedDeltaFeedImplementation(isResponse);
 
-            Assert.Equal(this.TestPayload(),
+            Assert.Equal(actual: this.TestPayload(), expected:
                 "{" +
                     "\"@context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +
@@ -1367,7 +1367,7 @@ namespace Microsoft.OData.Tests.Json
             writer.WriteEnd(); // deltaFeed
             writer.Flush();
 
-            Assert.Equal(this.TestPayload(),
+            Assert.Equal(actual: this.TestPayload(), expected:
                 "{" +
                     "\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\"," +
                     "\"value\":" +

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeserializerTests.cs
@@ -633,7 +633,7 @@ namespace Microsoft.OData.Tests.Json
                     jsonReader.ShouldBeOn(JsonNodeType.Property, "@odata.unknown");
                     var propertyAnnotation = duplicateChecker.GetODataPropertyAnnotations("NavProp").Keys;
                     Assert.Contains("odata.navigationLink", propertyAnnotation);
-                    Assert.Equal(1, propertyAnnotation.Count);
+                    Assert.Single(propertyAnnotation);
                 },
                 (jsonReader, name) =>
                 {
@@ -965,7 +965,7 @@ namespace Microsoft.OData.Tests.Json
                     if (odataReader.State == ODataReaderState.ResourceEnd)
                     {
                         var resource = odataReader.Item as ODataResource;
-                        Assert.Equal(0, resource.Properties.First().InstanceAnnotations.Count);
+                        Assert.Empty(resource.Properties.First().InstanceAnnotations);
                     }
                 }
             };
@@ -2063,8 +2063,8 @@ namespace Microsoft.OData.Tests.Json
 
                     var resource = Assert.IsType<ODataResourceValue>(property.ODataValue);
                     Assert.Equal(2, resource.Properties.Count());
-                    var streetProperty = Assert.Single(resource.Properties.Where(d => d.Name.Equals("Street")));
-                    var cityProperty = Assert.Single(resource.Properties.Where(d => d.Name.Equals("City")));
+                    var streetProperty = Assert.Single(resource.Properties, d => d.Name.Equals("Street"));
+                    var cityProperty = Assert.Single(resource.Properties, d => d.Name.Equals("City"));
                     Assert.Equal("S1", streetProperty.Value);
                     Assert.Equal("C1", cityProperty.Value);
                 });

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedDeserializerTests.cs
@@ -327,7 +327,7 @@ namespace Microsoft.OData.Tests.Json
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             ODataResourceSet feed = new ODataResourceSet();
             deserializer.ReadAndApplyResourceSetInstanceAnnotationValue("custom.Int32Annotation", feed, propertyAndAnnotationCollector);
-            Assert.Equal(1, feed.InstanceAnnotations.Count);
+            Assert.Single(feed.InstanceAnnotations);
             TestUtils.AssertODataValueAreEqual(new ODataPrimitiveValue(123), feed.InstanceAnnotations.Single(ia => ia.Name == "custom.Int32Annotation").Value);
         }
 
@@ -374,7 +374,7 @@ namespace Microsoft.OData.Tests.Json
             AdvanceReaderToFirstPropertyValue(deserializer.JsonReader);
             var entryState = new TestJsonReaderEntryState();
             deserializer.ApplyEntryInstanceAnnotation(entryState, "custom.Int32Annotation", 123);
-            Assert.Equal(1, entryState.Resource.InstanceAnnotations.Count);
+            Assert.Single(entryState.Resource.InstanceAnnotations);
             TestUtils.AssertODataValueAreEqual(new ODataPrimitiveValue(123), entryState.Resource.InstanceAnnotations.Single(ia => ia.Name == "custom.Int32Annotation").Value);
         }
 
@@ -403,7 +403,7 @@ namespace Microsoft.OData.Tests.Json
             var feed = new ODataResourceSet();
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             deserializer.ReadTopLevelResourceSetAnnotations(feed, propertyAndAnnotationCollector, true /*forResourceSetStart*/, true /*readAllFeedProperties*/);
-            Assert.Equal(0, feed.InstanceAnnotations.Count);
+            Assert.Empty(feed.InstanceAnnotations);
         }
 
         [Fact]
@@ -414,7 +414,7 @@ namespace Microsoft.OData.Tests.Json
             var feed = new ODataResourceSet();
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             deserializer.ReadTopLevelResourceSetAnnotations(feed, propertyAndAnnotationCollector, true /*forResourceSetStart*/, false /*readAllFeedProperties*/);
-            Assert.Equal(1, feed.InstanceAnnotations.Count);
+            Assert.Single(feed.InstanceAnnotations);
             TestUtils.AssertODataValueAreEqual(new ODataPrimitiveValue(123), feed.InstanceAnnotations.Single(ia => ia.Name == "custom.before").Value);
         }
 
@@ -426,7 +426,7 @@ namespace Microsoft.OData.Tests.Json
             var feed = new ODataResourceSet();
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             deserializer.ReadTopLevelResourceSetAnnotations(feed, propertyAndAnnotationCollector, true /*forResourceSetStart*/, false /*readAllFeedProperties*/);
-            Assert.Equal(0, feed.InstanceAnnotations.Count);
+            Assert.Empty(feed.InstanceAnnotations);
         }
 
         [Fact]
@@ -448,7 +448,7 @@ namespace Microsoft.OData.Tests.Json
             var feed = new ODataResourceSet();
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             deserializer.ReadTopLevelResourceSetAnnotations(feed, propertyAndAnnotationCollector, false /*forResourceSetStart*/, false /*readAllFeedProperties*/);
-            Assert.Equal(1, feed.InstanceAnnotations.Count);
+            Assert.Single(feed.InstanceAnnotations);
             TestUtils.AssertODataValueAreEqual(new ODataPrimitiveValue(456), feed.InstanceAnnotations.Single(ia => ia.Name == "custom.after").Value);
         }
 
@@ -460,7 +460,7 @@ namespace Microsoft.OData.Tests.Json
             var feed = new ODataResourceSet();
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
             deserializer.ReadTopLevelResourceSetAnnotations(feed, propertyAndAnnotationCollector, false /*forResourceSetStart*/, false /*readAllFeedProperties*/);
-            Assert.Equal(0, feed.InstanceAnnotations.Count);
+            Assert.Empty(feed.InstanceAnnotations);
         }
 
         #endregion Test ReadTopLevelResourceSetAnnotations
@@ -486,7 +486,7 @@ namespace Microsoft.OData.Tests.Json
             AdvanceReaderToFirstProperty(deserializer.JsonReader);
             var entryState = new TestJsonReaderEntryState();
             deserializer.ReadResourceContent(entryState);
-            Assert.Equal(0, entryState.Resource.InstanceAnnotations.Count);
+            Assert.Empty(entryState.Resource.InstanceAnnotations);
         }
 
         #endregion Test ReadResourceContent

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonErrorDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonErrorDeserializerTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OData.Tests.Json
 
             // Assert
             Assert.Equal("any target", error.Target);
-            Assert.Equal(1, error.Details.Count);
+            Assert.Single(error.Details);
             var detail = error.Details.Single();
             Assert.Equal("500", detail.Code);
             Assert.Equal("another target", detail.Target);
@@ -132,7 +132,7 @@ namespace Microsoft.OData.Tests.Json
 
             // Assert Top Level properties
             Assert.Equal("any target", error.Target);
-            Assert.Equal(1, error.Details.Count);
+            Assert.Single(error.Details);
             var detail = error.Details.Single();
             Assert.Equal("500", detail.Code);
             Assert.Equal("any target", detail.Target);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonPayloadKindDetectionDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonPayloadKindDetectionDeserializerTests.cs
@@ -41,8 +41,8 @@ namespace Microsoft.OData.Tests.Json
                     var payloadKinds = jsonPayloadKindDetectionDeserializer.DetectPayloadKind(this.payloadKindDetectionInfo);
 
                     Assert.Equal(2, payloadKinds.Count());
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Resource)));
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Delta)));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Resource));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Delta));
                 });
         }
 
@@ -59,7 +59,7 @@ namespace Microsoft.OData.Tests.Json
                     var payloadKinds = jsonPayloadKindDetectionDeserializer.DetectPayloadKind(this.payloadKindDetectionInfo);
 
                     Assert.Single(payloadKinds);
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Error)));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Error));
                 });
         }
 
@@ -97,8 +97,8 @@ namespace Microsoft.OData.Tests.Json
                     var payloadKinds = await jsonPayloadKindDetectionDeserializer.DetectPayloadKindAsync(this.payloadKindDetectionInfo);
 
                     Assert.Equal(2, payloadKinds.Count());
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Resource)));
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Delta)));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Resource));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Delta));
                 });
         }
 
@@ -115,7 +115,7 @@ namespace Microsoft.OData.Tests.Json
                     var payloadKinds = await jsonPayloadKindDetectionDeserializer.DetectPayloadKindAsync(this.payloadKindDetectionInfo);
 
                     Assert.Single(payloadKinds);
-                    Assert.Single(payloadKinds.Where(d => d.Equals(ODataPayloadKind.Error)));
+                    Assert.Single(payloadKinds, d => d.Equals(ODataPayloadKind.Error));
                 });
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonResourceDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonResourceDeserializerTests.cs
@@ -682,7 +682,7 @@ namespace Microsoft.OData.Tests.Json
                 this.categoryEntityType,
                 (resourceState) =>
                 {
-                    var mediaProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Media"))));
+                    var mediaProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("Media")));
                     var streamReferenceValue = Assert.IsType<ODataStreamReferenceValue>(mediaProperty.Value);
 
                     Assert.Equal("http://tempuri.org/Categories(1)/Media", streamReferenceValue.EditLink.AbsoluteUri);
@@ -741,7 +741,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var warehousePinProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("WarehousePin"))));
+                    var warehousePinProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("WarehousePin")));
                     var geographyPoint = Assert.IsAssignableFrom<GeographyPoint>(warehousePinProperty.Value);
                     Assert.Equal(22.2, geographyPoint.Latitude);
                     Assert.Equal(22.2, geographyPoint.Longitude);
@@ -765,7 +765,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var piProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Pi"))));
+                    var piProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("Pi")));
                     var untypedValue = Assert.IsType<ODataUntypedValue>(piProperty.Value);
                     Assert.Equal("3.1428571429", untypedValue.RawValue);
                 });
@@ -789,7 +789,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var creditLimitProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("CreditLimit"))));
+                    var creditLimitProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("CreditLimit")));
                     var untypedValue = Assert.IsType<ODataUntypedValue>(creditLimitProperty.Value);
                     Assert.Equal("1730", untypedValue.RawValue);
                 });
@@ -814,7 +814,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var creditLimitProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("CreditLimit"))));
+                    var creditLimitProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("CreditLimit")));
                     Assert.Equal(1730M, creditLimitProperty.Value);
                 });
         }
@@ -1056,7 +1056,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var photoProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Photo"))));
+                    var photoProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("Photo")));
                     var streamReferenceValue = Assert.IsType<ODataStreamReferenceValue>(photoProperty.Value);
 
                     Assert.Equal("http://tempuri.org/Products(1)/Photo", streamReferenceValue.EditLink.AbsoluteUri);
@@ -1082,7 +1082,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Assert.Equal(3, resourceState.Resource.Properties.Count());
 
-                    var photoProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Photo"))));
+                    var photoProperty = Assert.IsType<ODataProperty>(Assert.Single(resourceState.Resource.Properties, d => d.Name.Equals("Photo")));
                     var streamReferenceValue = Assert.IsType<ODataStreamReferenceValue>(photoProperty.Value);
 
                     Assert.Equal("http://tempuri.org/Products(1)/Photo", streamReferenceValue.EditLink.AbsoluteUri);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterTests.cs
@@ -814,7 +814,7 @@ namespace Microsoft.OData.Core.Tests.Json
                 {
                     if (!CsdlReader.TryParse(xmlReader, out model, out var errors))
                     {
-                        Assert.True(false, string.Join(Environment.NewLine, errors));
+                        Assert.Fail(string.Join(Environment.NewLine, errors));
                     }
                 }
             }
@@ -875,7 +875,7 @@ namespace Microsoft.OData.Core.Tests.Json
                 {
                     if (!CsdlReader.TryParse(xmlReader, out model, out var errors))
                     {
-                        Assert.True(false, string.Join(Environment.NewLine, errors));
+                        Assert.Fail(string.Join(Environment.NewLine, errors));
                     }
                 }
             }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataBinaryStreamReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataBinaryStreamReaderTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.OData.Tests
 
                 var bytesRead = reader.Read(buffer, 0, maxLength);
 
-                Assert.Equal(bytesRead, maxLength);
+                Assert.Equal(maxLength, bytesRead);
                 Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 }, buffer);
             }
         }
@@ -67,7 +67,7 @@ namespace Microsoft.OData.Tests
 
                 var bytesRead = await reader.ReadAsync(buffer, 0, maxLength);
 
-                Assert.Equal(bytesRead, maxLength);
+                Assert.Equal(maxLength, bytesRead);
                 Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 }, buffer);
             }
         }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "aggregate(Id with sum as TotalId)";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(TotalId)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(TotalId)", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -136,7 +136,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "aggregate(DynamicProperty with " + method + " as DynamicPropertyTotal)";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(DynamicPropertyTotal)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(DynamicPropertyTotal)", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -154,7 +154,7 @@ namespace Microsoft.OData.Tests
 
                 foreach (ODataVersion version in Versions)
                 {
-                    Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(DisctRestaurants)");
+                    Assert.Equal(MetadataDocumentUriString + "#Cities(DisctRestaurants)", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
                 }
             }
             finally
@@ -170,7 +170,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "groupby((Name, Address/Street))";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(Name,Address(Street))");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Name,Address(Street))", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -180,7 +180,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "groupby((Name, DynamicProperty, Address/Street))";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(Name,DynamicProperty,Address(Street))");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Name,DynamicProperty,Address(Street))", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -190,7 +190,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "filter(Id eq 1)";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities");
+                Assert.Equal(MetadataDocumentUriString + "#Cities", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
         [Fact]
@@ -199,7 +199,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "groupby((Name), aggregate(Id with sum as TotalId))";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(Name,TotalId)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Name,TotalId)", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -209,7 +209,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "groupby((Name), aggregate(Id with sum as TotalId))";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri("Name", null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(Name)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Name)", this.CreateFeedContextUri("Name", null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -219,7 +219,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "expand(Districts, filter(true))";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities");
+                Assert.Equal(MetadataDocumentUriString + "#Cities", this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString);
             }
         }
 
@@ -230,7 +230,7 @@ namespace Microsoft.OData.Tests
             string computeClause = "compute('Test' as NewColumn)";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, computeClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities");
+                Assert.Equal(MetadataDocumentUriString + "#Cities", this.CreateFeedContextUri(null, null, computeClause, null, version).OriginalString);
             }
         }
 
@@ -240,7 +240,7 @@ namespace Microsoft.OData.Tests
             string computeClause = "compute('Test' as NewColumn)";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri("Id,Name,NewColumn", null, computeClause, null, version).OriginalString, MetadataDocumentUriString + "#Cities(Id,Name,NewColumn)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Id,Name,NewColumn)", this.CreateFeedContextUri("Id,Name,NewColumn", null, computeClause, null, version).OriginalString);
             }
         }
 
@@ -250,7 +250,7 @@ namespace Microsoft.OData.Tests
             string computeClause = "'Test' as NewColumn";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri(null, null, null, computeClause, version).OriginalString, MetadataDocumentUriString + "#Cities");
+                Assert.Equal(MetadataDocumentUriString + "#Cities", this.CreateFeedContextUri(null, null, null, computeClause, version).OriginalString);
             }
         }
 
@@ -260,7 +260,7 @@ namespace Microsoft.OData.Tests
             string computeClause = "'Test' as NewColumn";
             foreach (ODataVersion version in Versions)
             {
-                Assert.Equal(this.CreateFeedContextUri("Id,Name,NewColumn", null, null, computeClause, version).OriginalString, MetadataDocumentUriString + "#Cities(Id,Name,NewColumn)");
+                Assert.Equal(MetadataDocumentUriString + "#Cities(Id,Name,NewColumn)", this.CreateFeedContextUri("Id,Name,NewColumn", null, null, computeClause, version).OriginalString);
             }
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataEntityReferenceLinkTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataEntityReferenceLinkTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.OData.Tests
             ODataEntityReferenceLink referencelink = new ODataEntityReferenceLink();
             Assert.NotNull(referencelink.InstanceAnnotations);
             referencelink.InstanceAnnotations.Add(new ODataInstanceAnnotation("TestNamespace.name", new ODataPrimitiveValue("value")));
-            Assert.Equal(1, referencelink.InstanceAnnotations.Count);
+            Assert.Single(referencelink.InstanceAnnotations);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
@@ -136,7 +136,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void MaxReceivedMessageSizeShouldBeSetByDefault()
         {
-            Assert.Equal(this.settings.MessageQuotas.MaxReceivedMessageSize, 1024 * 1024);
+            Assert.Equal(1024 * 1024, this.settings.MessageQuotas.MaxReceivedMessageSize);
         }
 
         [Fact]
@@ -459,11 +459,11 @@ namespace Microsoft.OData.Tests
             Assert.Same(this.settings.BaseUri, baseUri);
             Assert.True(this.settings.EnableCharactersCheck);
             Assert.False(this.settings.EnableMessageStreamDisposal);
-            Assert.Equal(this.settings.MessageQuotas.MaxPartsPerBatch, maxPartsPerBatch);
-            Assert.Equal(this.settings.MessageQuotas.MaxOperationsPerChangeset, maxOperationsPerChangeset);
-            Assert.Equal(this.settings.MessageQuotas.MaxNestingDepth, maxNestingDepth);
+            Assert.Equal(maxPartsPerBatch, this.settings.MessageQuotas.MaxPartsPerBatch);
+            Assert.Equal(maxOperationsPerChangeset, this.settings.MessageQuotas.MaxOperationsPerChangeset);
+            Assert.Equal(maxNestingDepth, this.settings.MessageQuotas.MaxNestingDepth);
             Assert.Equal(this.settings.Version, version);
-            Assert.Equal(this.settings.LibraryCompatibility, library);
+            Assert.Equal(library, this.settings.LibraryCompatibility);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataTextStreamReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataTextStreamReaderTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.OData.Tests
 
                 var charsRead = reader.Read(charBuffer, 0, maxLength);
 
-                Assert.Equal(charsRead, maxLength);
+                Assert.Equal(maxLength, charsRead);
                 Assert.Equal("fox jumps over", new string(charBuffer));
             }
         }
@@ -67,7 +67,7 @@ namespace Microsoft.OData.Tests
 
                 var charsRead = await reader.ReadAsync(charBuffer, 0, maxLength);
 
-                Assert.Equal(charsRead, maxLength);
+                Assert.Equal(maxLength, charsRead);
                 Assert.Equal("fox jumps over", new string(charBuffer));
             }
         }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.Async.cs
@@ -244,10 +244,10 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.Roundtrip
 
             using (var writer = XmlWriter.Create(stringWriter, new XmlWriterSettings() { Async = true }))
             {
-                var (success, errors) = await CsdlWriter.TryWriteCsdlAsync(this.model, writer, CsdlTarget.OData).ConfigureAwait(false);
+                var (success, errors) = await CsdlWriter.TryWriteCsdlAsync(this.model, writer, CsdlTarget.OData);
                 if (!success)
                 {
-                    Assert.True(false, "Serialization was unsuccessful");
+                    Assert.Fail("Serialization was unsuccessful");
                 }
             }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/JsonBatchRoundTripTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/JsonBatchRoundTripTests.cs
@@ -295,7 +295,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.Json
                             }
                             else
                             {
-                                Assert.True(false, "Unexpected response id received: " + responseId);
+                                Assert.Fail("Unexpected response id received: " + responseId);
                             }
                             break;
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/SingletonBatchRoundtripJsonTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/SingletonBatchRoundtripJsonTests.cs
@@ -1285,7 +1285,7 @@ Content-Type: application/json;odata.metadata=none
 
                     default:
                         {
-                            Assert.True(false, "Unknown BatchFormat value");
+                            Assert.Fail("Unknown BatchFormat value");
                         }
                         break;
                 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -3051,7 +3051,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var inNode = Assert.IsType<InNode>(inFilter.Expression);
             Assert.Equal("SSN", Assert.IsType<SingleValuePropertyAccessNode>(inNode.Left).Property.Name);
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
-            Assert.Equal(1, collectionNode.Collection.Count);
+            Assert.Single(collectionNode.Collection);
 
             var eqNode = Assert.IsType<BinaryOperatorNode>(eqFilter.Expression);
             Assert.Equal("SSN", Assert.IsType<SingleValuePropertyAccessNode>(eqNode.Left).Property.Name);
@@ -3074,7 +3074,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var inNode = Assert.IsType<InNode>(inFilter.Expression);
             Assert.Equal("SSN", Assert.IsType<SingleValuePropertyAccessNode>(inNode.Left).Property.Name);
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
-            Assert.Equal(1, collectionNode.Collection.Count);
+            Assert.Single(collectionNode.Collection);
 
             Assert.Equal(constantString, collectionNode.Collection.ElementAt(0).Value);
 
@@ -3194,7 +3194,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var inNode = Assert.IsType<InNode>(filter.Expression);
 
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
-            Assert.Equal(0, collectionNode.Collection.Count);
+            Assert.Empty(collectionNode.Collection);
         }
 
         [Theory]
@@ -3209,7 +3209,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var inNode = Assert.IsType<InNode>(filter.Expression);
 
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
-            Assert.Equal(1, collectionNode.Collection.Count);
+            Assert.Single(collectionNode.Collection);
 
             ConstantNode constantNode = collectionNode.Collection.First();
             Assert.Equal(string.Empty, constantNode.Value);
@@ -3231,7 +3231,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var inNode = Assert.IsType<InNode>(filter.Expression);
 
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
-            Assert.Equal(1, collectionNode.Collection.Count);
+            Assert.Single(collectionNode.Collection);
 
             ConstantNode constantNode = collectionNode.Collection.First();
             Assert.Equal(string.Empty, constantNode.Value);
@@ -3763,7 +3763,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             var inNode = Assert.IsType<InNode>(filter.Expression);
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
-            Assert.Equal(1, collectionNode.Collection.Count);
+            Assert.Single(collectionNode.Collection);
 
             ConstantNode constantNode = collectionNode.Collection.First();
             Assert.Equal(expectedLiteral, constantNode.LiteralText);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -560,7 +560,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             var result = RunParseSelectExpand("", "MyDog", HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
             Assert.True(result.AllSelected);
-            Assert.Empty(result.SelectedItems.Where(x => x is PathSelectItem));
+            Assert.DoesNotContain(result.SelectedItems, x => x is PathSelectItem);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/FullPayloadValidateTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/FullPayloadValidateTests.cs
@@ -1150,7 +1150,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.Json
                 }
                 else
                 {
-                    Assert.True(false, "Top level item to write must be entry or feed.");
+                    Assert.Fail("Top level item to write must be entry or feed.");
                 }
 
                 Assert.Equal(itemsToWrite.Length, currentIdx);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/ODataJsonInheritComplexCollectionWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/ODataJsonInheritComplexCollectionWriterTests.cs
@@ -77,41 +77,41 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.Json
         #region Writing odata.context
 
         [Fact]
-        public void ShouldWriteContextUriForComplexCollectionRequestWithoutUserModelAndWithSerializationInfo()
+        public async Task ShouldWriteContextUriForComplexCollectionRequestWithoutUserModelAndWithSerializationInfo()
         {
-            WriteAndValidate(this.collectionStartWithSerializationInfo, items, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.Address)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State@odata.type\":\"#ns.StateEnum\",\"State\":\"WA\"}]}", writingResponse: false);
+            await WriteAndValidateAsync(this.collectionStartWithSerializationInfo, items, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.Address)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State@odata.type\":\"#ns.StateEnum\",\"State\":\"WA\"}]}", writingResponse: false);
         }
 
         [Fact]
-        public void ShouldWriteContextUriForComplexCollectionRequestWithoutUserModelAndWithItemType()
+        public async Task ShouldWriteContextUriForComplexCollectionRequestWithoutUserModelAndWithItemType()
         {
-            WriteAndValidate(this.collectionStartWithoutSerializationInfo, this.items, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.Address)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\"}]}", writingResponse: false, itemTypeReference: this.addressTypeReference);
+            await WriteAndValidateAsync(this.collectionStartWithoutSerializationInfo, this.items, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.Address)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\"}]}", writingResponse: false, itemTypeReference: this.addressTypeReference);
         }
 
         [Fact]
-        public void ShouldNotWriteContextUriForComplexCollectionRequestWithoutUserModelAndWithoutItemTypeAndWithoutSerializationInfo()
+        public async Task ShouldNotWriteContextUriForComplexCollectionRequestWithoutUserModelAndWithoutItemTypeAndWithoutSerializationInfo()
         {
-            WriteAndValidate(this.collectionStartWithoutSerializationInfo, this.items, "{\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State@odata.type\":\"#ns.StateEnum\",\"State\":\"WA\"}]}", writingResponse: false);
+            await WriteAndValidateAsync(this.collectionStartWithoutSerializationInfo, this.items, "{\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State@odata.type\":\"#ns.StateEnum\",\"State\":\"WA\"}]}", writingResponse: false);
         }
 
         [Fact]
-        public void ShouldWriteContextUriBasedOnSerializationInfoForComplexCollectionRequestWithoutUserModelWhenBothItemTypeAndSerializationInfoAreGiven()
+        public async Task ShouldWriteContextUriBasedOnSerializationInfoForComplexCollectionRequestWithoutUserModelWhenBothItemTypeAndSerializationInfoAreGiven()
         {
             ODataResourceSet collectionStart = new ODataResourceSet();
             collectionStart.SetSerializationInfo(new ODataResourceSerializationInfo { ExpectedTypeName = "foo.bar" });
-            WriteAndValidate(collectionStart, this.items, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(foo.bar)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\"}]}", writingResponse: false, itemTypeReference: this.addressTypeReference);
+            await WriteAndValidateAsync(collectionStart, this.items, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(foo.bar)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\"}]}", writingResponse: false, itemTypeReference: this.addressTypeReference);
         }
 
         [Fact]
-        public void ShouldWriteContextUriForComplexCollectionResponseWithoutUserModelAndWithSerializationInfo()
+        public async Task ShouldWriteContextUriForComplexCollectionResponseWithoutUserModelAndWithSerializationInfo()
         {
-            WriteAndValidate(this.collectionStartWithSerializationInfo, items, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.Address)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\"}]}", writingResponse: true);
+            await WriteAndValidateAsync(this.collectionStartWithSerializationInfo, items, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.Address)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\"}]}", writingResponse: true);
         }
 
         [Fact]
-        public void ShouldWriteContextUriForComplexCollectionResponseWithoutUserModelAndWithItemType()
+        public async Task ShouldWriteContextUriForComplexCollectionResponseWithoutUserModelAndWithItemType()
         {
-            WriteAndValidate(this.collectionStartWithoutSerializationInfo, items, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.Address)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\"}]}", writingResponse: true, itemTypeReference: this.addressTypeReference);
+            await WriteAndValidateAsync(this.collectionStartWithoutSerializationInfo, items, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.Address)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\"}]}", writingResponse: true, itemTypeReference: this.addressTypeReference);
         }
 
         [Fact]
@@ -124,15 +124,15 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.Json
         }
 
         [Fact]
-        public void ShouldWriteContextUriBasedOnSerializationInfoForComplexCollectionResponseWithoutUserModelWhenBothItemTypeAndSerializationInfoAreGiven()
+        public async Task ShouldWriteContextUriBasedOnSerializationInfoForComplexCollectionResponseWithoutUserModelWhenBothItemTypeAndSerializationInfoAreGiven()
         {
             ODataResourceSet collectionStart = new ODataResourceSet();
             collectionStart.SetSerializationInfo(new ODataResourceSerializationInfo { ExpectedTypeName = "foo.bar" });
-            WriteAndValidate(collectionStart, this.items, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(foo.bar)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\"}]}", writingResponse: true, itemTypeReference: this.addressTypeReference);
+            await WriteAndValidateAsync(collectionStart, this.items, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(foo.bar)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\"}]}", writingResponse: true, itemTypeReference: this.addressTypeReference);
         }
 
         [Fact]
-        public void ShouldWriteCountAndNextLinkAnnotationOfComplexCollectionPropertyIfSpecified()
+        public async Task ShouldWriteCountAndNextLinkAnnotationOfComplexCollectionPropertyIfSpecified()
         {
             ODataResourceSet collectionStart = new ODataResourceSet()
             {
@@ -140,47 +140,47 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.Json
                 NextPageLink = new Uri("http://next-link")
             };
             collectionStart.SetSerializationInfo(new ODataResourceSerializationInfo { ExpectedTypeName = "foo.bar" });
-            WriteAndValidate(collectionStart, this.items, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(foo.bar)\",\"@odata.count\":3,\"@odata.nextLink\":\"http://next-link/\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\"}]}", writingResponse: true, itemTypeReference: this.addressTypeReference);
+            await WriteAndValidateAsync(collectionStart, this.items, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(foo.bar)\",\"@odata.count\":3,\"@odata.nextLink\":\"http://next-link/\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\"}]}", writingResponse: true, itemTypeReference: this.addressTypeReference);
         }
         #endregion
 
         #region Inheritance
         [Fact]
-        public void ShouldWriteContextUriForComplexCollectionRequestWithoutUserModelAndWithSerializationInfo_Inherit()
+        public async Task ShouldWriteContextUriForComplexCollectionRequestWithoutUserModelAndWithSerializationInfo_Inherit()
         {
-            WriteAndValidate(this.collectionStartWithSerializationInfo, derivedItems, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.Address)\",\"value\":[{\"@odata.type\":\"#ns.DerivedAddress\",\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State@odata.type\":\"#ns.StateEnum\",\"State\":\"WA\",\"City\":\"Shanghai\"}]}", writingResponse: false);
+            await WriteAndValidateAsync(this.collectionStartWithSerializationInfo, derivedItems, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.Address)\",\"value\":[{\"@odata.type\":\"#ns.DerivedAddress\",\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State@odata.type\":\"#ns.StateEnum\",\"State\":\"WA\",\"City\":\"Shanghai\"}]}", writingResponse: false);
         }
 
         [Fact]
-        public void ShouldWriteContextUriForComplexCollectionRequestWithoutUserModelAndWithItemType_Inherit()
+        public async Task ShouldWriteContextUriForComplexCollectionRequestWithoutUserModelAndWithItemType_Inherit()
         {
-            WriteAndValidate(this.collectionStartWithoutSerializationInfo, this.derivedItems, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.DerivedAddress)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\",\"City\":\"Shanghai\"}]}", writingResponse: false, itemTypeReference: this.derivedAddressTypeReference);
+            await WriteAndValidateAsync(this.collectionStartWithoutSerializationInfo, this.derivedItems, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.DerivedAddress)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\",\"City\":\"Shanghai\"}]}", writingResponse: false, itemTypeReference: this.derivedAddressTypeReference);
         }
 
         [Fact]
-        public void ShouldNotWriteContextUriForComplexCollectionRequestWithoutUserModelAndWithoutItemTypeAndWithoutSerializationInfo_Inherit()
+        public async Task ShouldNotWriteContextUriForComplexCollectionRequestWithoutUserModelAndWithoutItemTypeAndWithoutSerializationInfo_Inherit()
         {
-            WriteAndValidate(this.collectionStartWithoutSerializationInfo, this.derivedItems, "{\"value\":[{\"@odata.type\":\"#ns.DerivedAddress\",\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State@odata.type\":\"#ns.StateEnum\",\"State\":\"WA\",\"City\":\"Shanghai\"}]}", writingResponse: false);
+            await WriteAndValidateAsync(this.collectionStartWithoutSerializationInfo, this.derivedItems, "{\"value\":[{\"@odata.type\":\"#ns.DerivedAddress\",\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State@odata.type\":\"#ns.StateEnum\",\"State\":\"WA\",\"City\":\"Shanghai\"}]}", writingResponse: false);
         }
 
         [Fact]
-        public void ShouldWriteContextUriBasedOnSerializationInfoForComplexCollectionRequestWithoutUserModelWhenBothItemTypeAndSerializationInfoAreGiven_Inherit()
+        public async Task ShouldWriteContextUriBasedOnSerializationInfoForComplexCollectionRequestWithoutUserModelWhenBothItemTypeAndSerializationInfoAreGiven_Inherit()
         {
             ODataResourceSet collectionStart = new ODataResourceSet();
             collectionStart.SetSerializationInfo(new ODataResourceSerializationInfo { ExpectedTypeName = "foo.bar" });
-            WriteAndValidate(collectionStart, this.derivedItems, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(foo.bar)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\",\"City\":\"Shanghai\"}]}", writingResponse: false, itemTypeReference: this.derivedAddressTypeReference);
+            await WriteAndValidateAsync(collectionStart, this.derivedItems, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(foo.bar)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\",\"City\":\"Shanghai\"}]}", writingResponse: false, itemTypeReference: this.derivedAddressTypeReference);
         }
 
         [Fact]
-        public void ShouldWriteContextUriForComplexCollectionResponseWithoutUserModelAndWithSerializationInfo_Inherit()
+        public async Task ShouldWriteContextUriForComplexCollectionResponseWithoutUserModelAndWithSerializationInfo_Inherit()
         {
-            WriteAndValidate(this.collectionStartWithSerializationInfo, derivedItems, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.Address)\",\"value\":[{\"@odata.type\":\"#ns.DerivedAddress\",\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\",\"City\":\"Shanghai\"}]}", writingResponse: true);
+            await WriteAndValidateAsync(this.collectionStartWithSerializationInfo, derivedItems, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.Address)\",\"value\":[{\"@odata.type\":\"#ns.DerivedAddress\",\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\",\"City\":\"Shanghai\"}]}", writingResponse: true);
         }
 
         [Fact]
-        public void ShouldWriteContextUriForComplexCollectionResponseWithoutUserModelAndWithItemType_Inherit()
+        public async Task ShouldWriteContextUriForComplexCollectionResponseWithoutUserModelAndWithItemType_Inherit()
         {
-            WriteAndValidate(this.collectionStartWithoutSerializationInfo, derivedItems, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.DerivedAddress)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\",\"City\":\"Shanghai\"}]}", writingResponse: true, itemTypeReference: this.derivedAddressTypeReference);
+            await WriteAndValidateAsync(this.collectionStartWithoutSerializationInfo, derivedItems, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(ns.DerivedAddress)\",\"value\":[{\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\",\"City\":\"Shanghai\"}]}", writingResponse: true, itemTypeReference: this.derivedAddressTypeReference);
         }
 
         [Fact]
@@ -193,20 +193,20 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.Json
         }
 
         [Fact]
-        public void ShouldWriteContextUriBasedOnSerializationInfoForComplexCollectionResponseWithoutUserModelWhenBothItemTypeAndSerializationInfoAreGiven_Inherit()
+        public async Task ShouldWriteContextUriBasedOnSerializationInfoForComplexCollectionResponseWithoutUserModelWhenBothItemTypeAndSerializationInfoAreGiven_Inherit()
         {
             ODataResourceSet collectionStart = new ODataResourceSet();
             collectionStart.SetSerializationInfo(new ODataResourceSerializationInfo { ExpectedTypeName = "foo.bar" });
-            WriteAndValidate(collectionStart, this.derivedItems, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(foo.bar)\",\"value\":[{\"@odata.type\":\"#ns.DerivedAddress\",\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\",\"City\":\"Shanghai\"}]}", writingResponse: true, itemTypeReference: this.derivedAddressTypeReference);
+            await WriteAndValidateAsync(collectionStart, this.derivedItems, "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(foo.bar)\",\"value\":[{\"@odata.type\":\"#ns.DerivedAddress\",\"Street\":\"1 Microsoft Way\",\"Zipcode\":98052,\"State\":\"WA\",\"City\":\"Shanghai\"}]}", writingResponse: true, itemTypeReference: this.derivedAddressTypeReference);
         }
         #endregion Without model
 
-        private static void WriteAndValidate(ODataResourceSet collectionStart, IEnumerable<ODataResource> items, string expectedPayload, bool writingResponse = true, IEdmTypeReference itemTypeReference = null)
+        private static async Task WriteAndValidateAsync(ODataResourceSet collectionStart, IEnumerable<ODataResource> items, string expectedPayload, bool writingResponse = true, IEdmTypeReference itemTypeReference = null)
         {
             WriteAndValidateSync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
-            WriteAndValidateAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
+            await WriteAndValidateResourcesAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
             WriteAndValidatePrimitivesSync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
-            WriteAndValidatePrimitivesAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse).GetAwaiter().GetResult();
+            await WriteAndValidatePrimitivesAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
         }
 
         private static void WriteAndValidateSync(IEdmTypeReference itemTypeReference, ODataResourceSet collectionStart, IEnumerable<ODataResource> items, string expectedPayload, bool writingResponse)
@@ -225,21 +225,19 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.Json
             ValidateWrittenPayload(stream, expectedPayload);
         }
 
-        private static void WriteAndValidateAsync(IEdmTypeReference itemTypeReference, ODataResourceSet collectionStart, IEnumerable<ODataResource> items, string expectedPayload, bool writingResponse)
+        private static async Task WriteAndValidateResourcesAsync(IEdmTypeReference itemTypeReference, ODataResourceSet collectionStart, IEnumerable<ODataResource> items, string expectedPayload, bool writingResponse)
         {
             MemoryStream stream = new MemoryStream();
             var outputContext = CreateJsonOutputContext(stream, writingResponse, synchronous: false);
-            var createODataWriterTask = outputContext.CreateODataResourceSetWriterAsync(null, itemTypeReference == null ? null : itemTypeReference.ToStructuredType());
-            createODataWriterTask.Wait();
-            var odataWriter = createODataWriterTask.Result;
-            odataWriter.WriteStartAsync(collectionStart).Wait();
+            var odataWriter = await outputContext.CreateODataResourceSetWriterAsync(null, itemTypeReference == null ? null : itemTypeReference.ToStructuredType());
+            await odataWriter.WriteStartAsync(collectionStart);
             foreach (ODataResource item in items)
             {
-                odataWriter.WriteStartAsync(item).Wait();
-                odataWriter.WriteEndAsync().Wait();
+                await odataWriter.WriteStartAsync(item);
+                await odataWriter.WriteEndAsync();
             }
 
-            odataWriter.WriteEndAsync().Wait();
+            await odataWriter.WriteEndAsync();
             ValidateWrittenPayload(stream, expectedPayload);
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/ODataJsonInheritComplexCollectionWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/ODataJsonInheritComplexCollectionWriterTests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.Json
             WriteAndValidateSync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
             WriteAndValidateAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
             WriteAndValidatePrimitivesSync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
-            WriteAndValidatePrimitivesAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
+            WriteAndValidatePrimitivesAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse).GetAwaiter().GetResult();
         }
 
         private static void WriteAndValidateSync(IEdmTypeReference itemTypeReference, ODataResourceSet collectionStart, IEnumerable<ODataResource> items, string expectedPayload, bool writingResponse)

--- a/test/UnitTests/Microsoft.OData.Core.Tests/TestUtils.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/TestUtils.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OData.Tests
                 }
                 else
                 {
-                    Assert.True(false, "Test only currently supports creating ODataResource from IEdmPrimitiveValue instances.");
+                    Assert.Fail("Test only currently supports creating ODataResource from IEdmPrimitiveValue instances.");
                     return null;
                 }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
@@ -985,7 +985,7 @@ namespace Microsoft.OData.Tests.UriParser
                     return ch;
                 }
             }
-            Assert.True(false, "Should never get here");
+            Assert.Fail("Should never get here");
             return (char)0;
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -1178,7 +1178,7 @@ namespace Microsoft.OData.Tests.UriParser
                     parser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Slash;
                     break;
                 default:
-                    Assert.True(false, "Unreachable code path");
+                    Assert.Fail("Unreachable code path");
                     break;
             }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/ODataPathTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/ODataPathTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
             ODataPath clone = new ODataPath(existing);
 
             clone.FirstSegment.ShouldBeMetadataSegment();
-            Assert.Equal(1, clone.Segments.Count);
+            Assert.Single(clone.Segments);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/OperationImportSegmentTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/OperationImportSegmentTests.cs
@@ -166,7 +166,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
             {
                 // Dummy code, just need to access property to get the exception
                 var type = segment.EdmType;
-                Assert.True(false, "The EdmType getter returned '" + type + "', but should have thrown.");
+                Assert.Fail("The EdmType getter returned '" + type + "', but should have thrown.");
             }
             catch (ODataException e)
             {

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.Async.cs
@@ -87,7 +87,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
 
             // Verify writing model
             model.SetEdmVersion(Version.Parse(odataVersion));
-            await VerifyXmlModelAsync(model, odataVersion == "4.0" ? entitySetWithoutNavProperties : entitySetWithNavProperties).ConfigureAwait(false);
+            await VerifyXmlModelAsync(model, odataVersion == "4.0" ? entitySetWithoutNavProperties : entitySetWithNavProperties);
         }
 
         [Fact]
@@ -146,7 +146,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                    "<Term Name=\"MyDefaultTerm\" Type=\"Edm.String\" DefaultValue=\"This is a test\" AppliesTo=\"Property Term\" Nullable=\"false\" />" +
                  "</Schema>" +
                "</edmx:DataServices>" +
-             "</edmx:Edmx>").ConfigureAwait(false);
+             "</edmx:Edmx>");
         }
 
         [Fact]
@@ -210,7 +210,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                        "<Term Name=\"MyDefaultBoolTerm3\" Type=\"Edm.Boolean\" DefaultValue=\"true\" AppliesTo=\"Property Term\" Nullable=\"false\" />" +
                      "</Schema>" +
                    "</edmx:DataServices>" +
-                 "</edmx:Edmx>").ConfigureAwait(false);
+                 "</edmx:Edmx>");
         }
 
         [Fact]
@@ -310,7 +310,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                  "<Term Name=\"DefaultDateTerm\" Type=\"Edm.Date\" DefaultValue=\"2000-12-10\" AppliesTo=\"Property Term\" Nullable=\"false\" />" +
                  "</Schema>" +
                "</edmx:DataServices>" +
-             "</edmx:Edmx>", writerSettings).ConfigureAwait(false);
+             "</edmx:Edmx>", writerSettings);
         }
 
         static async Task VerifyXmlModelAsync(IEdmModel model, string csdl)

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.Async.cs
@@ -70,7 +70,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                 "<Annotation Term=\"Core.LongDescription\" String=\"EdmReference Description.\" />" +
               "</edmx:Reference>" +
               "<edmx:DataServices />" +
-            "</edmx:Edmx>").ConfigureAwait(false);
+            "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -115,7 +115,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       ""@Core.LongDescription"": ""EdmReference Description.""
     }
   }
-}").ConfigureAwait(false);
+}");
         }
         #endregion
 
@@ -171,7 +171,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                       "</EntityContainer>" +
                     "</Schema>" +
                   "</edmx:DataServices>" +
-                "</edmx:Edmx>").ConfigureAwait(false);
+                "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -205,7 +205,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -307,7 +307,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                 "<EntitySet Name=\"CountryOrRegion\" EntityType=\"DefaultNs.CountryOrRegion\" />" +
                 "</EntityContainer></Schema>" +
                 "</edmx:DataServices>" +
-                "</edmx:Edmx>").ConfigureAwait(false);
+                "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -384,7 +384,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -452,7 +452,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                       "</EntityContainer>" +
                     "</Schema>" +
                   "</edmx:DataServices>" +
-                "</edmx:Edmx>").ConfigureAwait(false);
+                "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -502,7 +502,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -588,7 +588,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</EntityContainer>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -644,7 +644,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -745,7 +745,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                             "</ComplexType>" +
                         "</Schema>" +
                     "</edmx:DataServices>" +
-                "</edmx:Edmx>").ConfigureAwait(false);
+                "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -824,7 +824,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -888,7 +888,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                             "</EntityType>" +
                         "</Schema>" +
                     "</edmx:DataServices>" +
-                "</edmx:Edmx>").ConfigureAwait(false);
+                "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -943,7 +943,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
         #endregion
 
@@ -989,7 +989,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                   "</EntityContainer>" +
                 "</Schema>" +
               "</edmx:DataServices>" +
-            "</edmx:Edmx>").ConfigureAwait(false);
+            "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1025,7 +1025,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1083,7 +1083,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                  "</Annotations>" +
                 "</Schema>" +
               "</edmx:DataServices>" +
-            "</edmx:Edmx>").ConfigureAwait(false);
+            "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1118,7 +1118,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1161,7 +1161,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                  "</Annotations>" +
                 "</Schema>" +
               "</edmx:DataServices>" +
-            "</edmx:Edmx>").ConfigureAwait(false);
+            "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1187,7 +1187,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         #endregion
@@ -1215,7 +1215,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</Function>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1234,7 +1234,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     ]
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1261,7 +1261,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</Annotations>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1284,7 +1284,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1311,7 +1311,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</EntityType>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1331,7 +1331,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1364,7 +1364,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</EntityType>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1384,7 +1384,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1411,7 +1411,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "<Term Name=\"MyTerm\" Type=\"NS.SelectType\" />" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1435,7 +1435,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       ""$Nullable"": true
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1461,7 +1461,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</EntityContainer>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1475,7 +1475,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1500,7 +1500,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</EntityContainer>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1515,7 +1515,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1543,7 +1543,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</EntityType>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1559,7 +1559,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1593,7 +1593,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</EntityType>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1619,7 +1619,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1644,7 +1644,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "<ComplexType Name=\"Address\" BaseType=\"Edm.ComplexType\" />" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1659,7 +1659,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       ""$BaseType"": ""Edm.ComplexType""
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1681,7 +1681,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "<TypeDefinition Name=\"MyType\" UnderlyingType=\"Edm.PrimitiveType\" />" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1692,7 +1692,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       ""$UnderlyingType"": ""Edm.PrimitiveType""
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1721,7 +1721,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</Function>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1747,7 +1747,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     ]
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1803,7 +1803,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</Annotations>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1831,7 +1831,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1862,7 +1862,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</ComplexType>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -1880,7 +1880,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -1975,7 +1975,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</EntityContainer>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -2043,7 +2043,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -2082,7 +2082,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</Function>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -2120,7 +2120,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     ]
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -2159,7 +2159,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                    "<Term Name=\"MyNavigationPathTerm\" Type=\"Edm.NavigationPropertyPath\" Nullable=\"false\" />" +
                  "</Schema>" +
                "</edmx:DataServices>" +
-             "</edmx:Edmx>").ConfigureAwait(false);
+             "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -2179,7 +2179,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       ""$Type"": ""Edm.NavigationPropertyPath""
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -2226,7 +2226,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                    "<Term Name=\"MyDefaultBoolTerm\" Type=\"Edm.Boolean\" DefaultValue=\"true\" AppliesTo=\"Property Term\" Nullable=\"false\" />" +
                  "</Schema>" +
                "</edmx:DataServices>" +
-             "</edmx:Edmx>").ConfigureAwait(false);
+             "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -2258,7 +2258,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       ""$DefaultValue"": ""true""
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -2334,7 +2334,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                  "<Term Name=\"DefaultDateTerm\" Type=\"Edm.Date\" DefaultValue=\"2000-12-10\" Nullable=\"false\" />" +
                  "</Schema>" +
                "</edmx:DataServices>" +
-             "</edmx:Edmx>").ConfigureAwait(false);
+             "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -2423,7 +2423,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       ""$DefaultValue"": ""2000-12-10""
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -2460,7 +2460,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             Assert.True(validated);
 
             // Act & Assert for Reserialized XML
-            await WriteAndVerifyXmlAsync(model, csdlTemplate, writerSettings).ConfigureAwait(false);
+            await WriteAndVerifyXmlAsync(model, csdlTemplate, writerSettings);
         }
 
         [Fact]
@@ -2492,7 +2492,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             Assert.True(validated);
 
             // Act & Assert for Reserialized XML
-            await WriteAndVerifyXmlAsync(model, csdlTemplate).ConfigureAwait(false);
+            await WriteAndVerifyXmlAsync(model, csdlTemplate);
         }
 
         [Fact]
@@ -2583,7 +2583,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</EntityContainer>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -2648,7 +2648,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -2783,18 +2783,18 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                             "</EntitySet>";
 
             // Act & Assert for XML 4.0
-            await WriteAndVerifyXmlAsync(model, String.Format(xmlResult, "4.0", v40EntitySet)).ConfigureAwait(false);
+            await WriteAndVerifyXmlAsync(model, String.Format(xmlResult, "4.0", v40EntitySet));
 
             // Act & Assert for JSON 4.0
-            await WriteAndVerifyJsonAsync(model, v40Json).ConfigureAwait(false);
+            await WriteAndVerifyJsonAsync(model, v40Json);
 
             model.SetEdmVersion(Version.Parse("4.01"));
 
             // Act & Assert for XML 4.1
-            await WriteAndVerifyXmlAsync(model, String.Format(xmlResult, "4.01", v401EntitySet)).ConfigureAwait(false);
+            await WriteAndVerifyXmlAsync(model, String.Format(xmlResult, "4.01", v401EntitySet));
 
             // Act & Assert for JSON 4.1
-            await WriteAndVerifyJsonAsync(model, v40Json.Replace("4.0", "4.01")).ConfigureAwait(false);
+            await WriteAndVerifyJsonAsync(model, v40Json.Replace("4.0", "4.01"));
         }
 
         [Fact]
@@ -2824,7 +2824,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                       "</EntityType>" +
                     "</Schema>" +
                   "</edmx:DataServices>" +
-                "</edmx:Edmx>").ConfigureAwait(false);
+                "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -2849,7 +2849,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Theory]
@@ -2862,10 +2862,10 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             edmModel.SetEdmVersion(odataVersion == "4.0" ? EdmConstants.EdmVersion4 : EdmConstants.EdmVersion401);
 
             // XML
-            await WriteAndVerifyXmlAsync(edmModel, "<?xml version=\"1.0\" encoding=\"utf-16\"?><edmx:Edmx Version=\"" + odataVersion + "\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\"><edmx:DataServices /></edmx:Edmx>").ConfigureAwait(false);
+            await WriteAndVerifyXmlAsync(edmModel, "<?xml version=\"1.0\" encoding=\"utf-16\"?><edmx:Edmx Version=\"" + odataVersion + "\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\"><edmx:DataServices /></edmx:Edmx>");
 
             // JSON
-            await WriteAndVerifyJsonAsync(edmModel, "{\"$Version\":\"" + odataVersion + "\"}", false).ConfigureAwait(false);
+            await WriteAndVerifyJsonAsync(edmModel, "{\"$Version\":\"" + odataVersion + "\"}", false);
         }
 
         [Fact]
@@ -2909,7 +2909,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                   "</EntityContainer>" +
                 "</Schema>" +
               "</edmx:DataServices>" +
-            "</edmx:Edmx>").ConfigureAwait(false);
+            "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -2945,7 +2945,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Theory]
@@ -2964,10 +2964,10 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             var builder = new StringBuilder();
             using (var writer = XmlWriter.Create(builder, new XmlWriterSettings { Encoding = Encoding.UTF8, Async = true }))
             {
-                var (result, errors) = await CsdlWriter.TryWriteCsdlAsync(model, writer, csdlTarget).ConfigureAwait(false);
+                var (result, errors) = await CsdlWriter.TryWriteCsdlAsync(model, writer, csdlTarget);
                 if (!result)
                 {
-                    Assert.True(false, "Serialization was unsuccessful");
+                    Assert.Fail("Serialization was unsuccessful");
                 }
 
                 // Xml writer should have flushed whatever is in the buffer before TryWriteCsdl is exited

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.TargetPath.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.TargetPath.Async.cs
@@ -61,7 +61,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</Annotations>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -95,7 +95,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -158,7 +158,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</Annotations>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -203,7 +203,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -268,7 +268,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</Annotations>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -316,7 +316,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -372,7 +372,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     "</Annotations>" +
                   "</Schema>" +
                 "</edmx:DataServices>" +
-              "</edmx:Edmx>").ConfigureAwait(false);
+              "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -411,7 +411,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.VocabularyAnnotation.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.VocabularyAnnotation.Async.cs
@@ -59,7 +59,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                    "<Term Name=\"MyDefaultBoolTerm\" Type=\"Edm.Boolean\" DefaultValue=\"true\" AppliesTo=\"Property Term\" Nullable=\"false\" />" +
                  "</Schema>" +
                "</edmx:DataServices>" +
-             "</edmx:Edmx>").ConfigureAwait(false);
+             "</edmx:Edmx>");
 
             // Act & Assert for JSON
             await WriteAndVerifyJsonAsync(model, @"{
@@ -91,7 +91,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       ""$DefaultValue"": ""true""
     }
   }
-}").ConfigureAwait(false);
+}");
         }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
@@ -3063,7 +3063,7 @@ var v40Json =
             {
                 if (!CsdlWriter.TryWriteCsdl(model, writer, csdlTarget, out var errors))
                 {
-                    Assert.True(false, "Serialization was unsuccessful");
+                    Assert.Fail("Serialization was unsuccessful");
                 }
 
                 // Xml writer should have flushed whatever is in the buffer before TryWriteCsdl is exited

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSchemaWriterTests.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSchemaWriterTests.Async.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
         {
             EdmAction action = new EdmAction("Default.Namespace", "Checkout", null /*returnType*/, true /*isBound*/, null /*entitySetPath*/);
             action.AddParameter("param", EdmCoreModel.Instance.GetString(true));
-            await this.TestWriteActionElementHeaderMethodWithAsync(action, @"<Action Name=""Checkout"" IsBound=""true""").ConfigureAwait(false);
+            await this.TestWriteActionElementHeaderMethodWithAsync(action, @"<Action Name=""Checkout"" IsBound=""true""");
         }
 
         [Fact]
@@ -31,7 +31,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
         {
             EdmFunction function = new EdmFunction("Default.Namespace", "Checkout", EdmCoreModel.Instance.GetString(true) /*returnType*/, false /*isBound*/, null /*entitySetPath*/, false /*isComposable*/);
             function.AddParameter("param", EdmCoreModel.Instance.GetString(true));
-            await this.TestWriteFunctionElementHeaderMethodWithAsync(function, @"<Function Name=""Checkout""").ConfigureAwait(false);
+            await this.TestWriteFunctionElementHeaderMethodWithAsync(function, @"<Function Name=""Checkout""");
         }
 
         [Fact]
@@ -39,14 +39,14 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
         {
             EdmAction action = new EdmAction("Default.Namespace", "Checkout", null /*returnType*/, true /*isBound*/, new EdmPathExpression("Customer", "Orders") /*entitySetPath*/);
             action.AddParameter("param", EdmCoreModel.Instance.GetString(true));
-            await this.TestWriteActionElementHeaderMethodWithAsync(action, @"<Action Name=""Checkout"" IsBound=""true"" EntitySetPath=""Customer/Orders""").ConfigureAwait(false);
+            await this.TestWriteActionElementHeaderMethodWithAsync(action, @"<Action Name=""Checkout"" IsBound=""true"" EntitySetPath=""Customer/Orders""");
         }
 
         [Fact]
         public async Task ComposableFunctionShouldWriteIsComposableEqualTrue_Async()
         {
             EdmFunction function = new EdmFunction("Default.Namespace", "Checkout", EdmCoreModel.Instance.GetString(true) /*returnType*/, false /*isBound*/, null /*entitySetPath*/, true /*isComposable*/);
-            await this.TestWriteFunctionElementHeaderMethodWithAsync(function, @"<Function Name=""Checkout"" IsComposable=""true""").ConfigureAwait(false);
+            await this.TestWriteFunctionElementHeaderMethodWithAsync(function, @"<Function Name=""Checkout"" IsComposable=""true""");
         }
 
         private async Task TestWriteActionElementHeaderMethodWithAsync(EdmAction action, string expected)
@@ -68,7 +68,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             await this.EdmModelCsdlSchemaWriterTestAsync(
                 async (writer) => await writer.WriteActionImportElementHeaderAsync(actionImport).ConfigureAwait(false),
-                @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" EntitySet=""Customers""").ConfigureAwait(false);
+                @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" EntitySet=""Customers""");
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             await this.EdmModelCsdlSchemaWriterTestAsync(
                 async (writer) => await writer.WriteFunctionImportElementHeaderAsync(functionImport).ConfigureAwait(false),
-                @"<FunctionImport Name=""GetStuff"" Function=""Default.NameSpace2.GetStuff"" EntitySet=""Customers/Orders""").ConfigureAwait(false);
+                @"<FunctionImport Name=""GetStuff"" Function=""Default.NameSpace2.GetStuff"" EntitySet=""Customers/Orders""");
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
             var csdlSchemaWriter = CreateEdmModelCsdlSchemaWriterForErrorTestForAsync();
             async Task errorTest() => await csdlSchemaWriter.WriteActionImportElementHeaderAsync(actionImport).ConfigureAwait(false);
 
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(errorTest).ConfigureAwait(false);
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(errorTest);
             Assert.Equal(Error.Format(SRResources.EdmModel_Validator_Semantic_OperationImportEntitySetExpressionIsInvalid, actionImport.Name), exception.Message);
         }
         #endregion
@@ -102,7 +102,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             await this.EdmModelCsdlSchemaWriterTestAsync(
                 async (writer) => await writer.WriteActionImportElementHeaderAsync(actionImport).ConfigureAwait(false),
-                @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut""").ConfigureAwait(false);
+                @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut""");
         }
         #endregion
 
@@ -114,7 +114,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             await this.EdmModelCsdlSchemaWriterTestAsync(
                 async (writer) => await writer.WriteFunctionImportElementHeaderAsync(functionImport).ConfigureAwait(false),
-                @"<FunctionImport Name=""GetStuff"" Function=""Default.NameSpace2.GetStuff"" EntitySet=""Customers/Orders""").ConfigureAwait(false);
+                @"<FunctionImport Name=""GetStuff"" Function=""Default.NameSpace2.GetStuff"" EntitySet=""Customers/Orders""");
         }
 
         [Fact]
@@ -124,7 +124,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             await this.EdmModelCsdlSchemaWriterTestAsync(
                 async (writer) => await writer.WriteFunctionImportElementHeaderAsync(functionImport).ConfigureAwait(false),
-                @"<FunctionImport Name=""GetStuff"" Function=""Default.NameSpace2.GetStuff"" EntitySet=""Customers/Orders"" IncludeInServiceDocument=""true""").ConfigureAwait(false);
+                @"<FunctionImport Name=""GetStuff"" Function=""Default.NameSpace2.GetStuff"" EntitySet=""Customers/Orders"" IncludeInServiceDocument=""true""");
         }
         #endregion
 
@@ -133,7 +133,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
         public async Task ShouldWriteOpenTypeAttributeForOpenComplexType_Async()
         {
             IEdmComplexType complexType = new EdmComplexType("Default.NameSpace2", "OpenComplex", null, false, true);
-            await TestWriteComplexTypeElementHeaderMethodWithAsync(complexType, @"<ComplexType Name=""OpenComplex"" OpenType=""true""").ConfigureAwait(false);
+            await TestWriteComplexTypeElementHeaderMethodWithAsync(complexType, @"<ComplexType Name=""OpenComplex"" OpenType=""true""");
         }
 
         private async Task TestWriteComplexTypeElementHeaderMethodWithAsync(IEdmComplexType complexType, string expected)

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.Async.cs
@@ -39,7 +39,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
   <Property Name=""Weight"" Type=""Edm.Decimal"" Precision=""6"" Scale=""Variable"" />
   <Property Name=""Length"" Type=""Edm.Decimal"" Nullable=""false"" Scale=""Variable"" />
   <Property Name=""Breadth"" Type=""Edm.Decimal"" Precision=""6"" Scale=""0"" />
-</ComplexType>").ConfigureAwait(false);
+</ComplexType>");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync(v => v.VisitSchemaTypeAsync(complexType), @"{
@@ -66,7 +66,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
       ""$Scale"": 0
     }
   }
-}").ConfigureAwait(false);
+}");
         }
         #endregion
 
@@ -95,7 +95,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
     <Parameter Name=""param1"" Type=""Edm.Int32"" />
     <ReturnType Type=""Edm.String"" />
   </Action>
-</Schema>").ConfigureAwait(false);
+</Schema>");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync((v) => v.VisitEdmSchemaAsync(schema, null), @"{
@@ -130,7 +130,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
       }
     ]
   }
-}").ConfigureAwait(false);
+}");
         }
         #endregion
 
@@ -145,7 +145,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             // Act & Assert for XML
             await VisitAndVerifyXmlAsync((v) => v.VisitEntityContainerElementsAsync(new[] { entitySet }),
-                @"<EntitySet Name=""Set"" EntityType=""NS.EntityType"" />").ConfigureAwait(false);
+                @"<EntitySet Name=""Set"" EntityType=""NS.EntityType"" />");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new[] { entitySet }).ConfigureAwait(false),
@@ -154,11 +154,11 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
     ""$Collection"": true,
     ""$Type"": ""NS.EntityType""
   }
-}").ConfigureAwait(false);
+}");
 
             // Act & Assert for non-indent JSON
             await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new[] { entitySet }),
-                @"{""Set"":{""$Collection"":true,""$Type"":""NS.EntityType""}}", false).ConfigureAwait(false);
+                @"{""Set"":{""$Collection"":true,""$Type"":""NS.EntityType""}}", false);
         }
 
         [Fact]
@@ -230,7 +230,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
   <NavigationPropertyBinding Path=""HomeAddress/City"" Target=""City"" />
   <NavigationPropertyBinding Path=""WorkAddress/NS.WorkAddress/CountryOrRegion"" Target=""CountryOrRegion"" />
   <Annotation Term=""UI.ReadOnly"" Bool=""true"" />
-</EntitySet>").ConfigureAwait(false);
+</EntitySet>");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new[] { people }),
@@ -245,7 +245,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
     },
     ""@UI.ReadOnly"": true
   }
-}").ConfigureAwait(false);
+}");
         }
         #endregion
 
@@ -258,16 +258,16 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
             EdmSingleton singleton = new EdmSingleton(container, "Me", entityType);
 
             await VisitAndVerifyXmlAsync((v) => v.VisitEntityContainerElementsAsync(new[] { singleton }),
-                @"<Singleton Name=""Me"" Type=""NS.EntityType"" />").ConfigureAwait(false);
+                @"<Singleton Name=""Me"" Type=""NS.EntityType"" />");
 
             await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new[] { singleton }), @"{
   ""Me"": {
     ""$Type"": ""NS.EntityType""
   }
-}").ConfigureAwait(false);
+}");
 
             await VisitAndVerifyJsonAsync((v) =>  v.VisitEntityContainerElementsAsync(new[] { singleton }),
-                @"{""Me"":{""$Type"":""NS.EntityType""}}", false).ConfigureAwait(false);
+                @"{""Me"":{""$Type"":""NS.EntityType""}}", false);
         }
 
         [Fact]
@@ -296,14 +296,14 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
   <Annotation Term=""NS.MyTerm"">
     <EnumMember>NS.Permission/Read NS.Permission/Write</EnumMember>
   </Annotation>
-</Singleton>").ConfigureAwait(false);
+</Singleton>");
 
             await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new[] { singleton }), @"{
   ""Me"": {
     ""$Type"": ""NS.EntityType"",
     ""@NS.MyTerm"": ""Read,Write""
   }
-}").ConfigureAwait(false);
+}");
         }
 
         #endregion
@@ -317,7 +317,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             // Act & Assert for XML
             await VisitAndVerifyXmlAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport }),
-                @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" />").ConfigureAwait(false);
+                @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" />");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport }),
@@ -326,11 +326,11 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
     ""$Kind"": ""ActionImport"",
     ""$Action"": ""Default.NameSpace2.CheckOut""
   }
-}").ConfigureAwait(false);
+}");
 
             // Act & Assert for non-indent JSON
             await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport }),
-                @"{""Checkout"":{""$Kind"":""ActionImport"",""$Action"":""Default.NameSpace2.CheckOut""}}", false).ConfigureAwait(false);
+                @"{""Checkout"":{""$Kind"":""ActionImport"",""$Action"":""Default.NameSpace2.CheckOut""}}", false);
         }
 
         [Fact]
@@ -342,7 +342,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             // Act & Assert for XML
             await VisitAndVerifyXmlAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }),
-                @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" />").ConfigureAwait(false);
+                @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" />");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }),
@@ -351,7 +351,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
     ""$Kind"": ""ActionImport"",
     ""$Action"": ""Default.NameSpace2.CheckOut""
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -363,7 +363,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             // Act & Assert for XML
             await VisitAndVerifyXmlAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }),
-                @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" EntitySet=""Set"" />").ConfigureAwait(false);
+                @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" EntitySet=""Set"" />");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }),
@@ -373,7 +373,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
     ""$Action"": ""Default.NameSpace2.CheckOut"",
     ""$EntitySet"": ""Set""
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -385,7 +385,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             // Act & Assert for XML
             await VisitAndVerifyXmlAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }),
-                @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" EntitySet=""path1/path2"" />").ConfigureAwait(false);
+                @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" EntitySet=""path1/path2"" />");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }),
@@ -395,7 +395,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
     ""$Action"": ""Default.NameSpace2.CheckOut"",
     ""$EntitySet"": ""path1/path2""
   }
-}").ConfigureAwait(false);
+}");
         }
 
         /// <summary>
@@ -416,7 +416,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
                 @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" EntitySet=""Set"" />
 <ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" EntitySet=""Set2"" />
 <ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" />
-<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" EntitySet=""path1/path2"" />").ConfigureAwait(false);
+<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" EntitySet=""path1/path2"" />");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImportOnSet, actionImportOnSet2, actionImportWithNoEntitySet, actionImportWithUniqueEdmPath }),
@@ -440,7 +440,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
     ""$Action"": ""Default.NameSpace2.CheckOut"",
     ""$EntitySet"": ""path1/path2""
   }
-}").ConfigureAwait(false);
+}");
         }
         #endregion
 
@@ -453,7 +453,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             // Act & Assert for XML
             await VisitAndVerifyXmlAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { functionImport }).ConfigureAwait(false),
-                @"<FunctionImport Name=""GetStuff"" Function=""Default.NameSpace2.GetStuff"" IncludeInServiceDocument=""true"" />").ConfigureAwait(false);
+                @"<FunctionImport Name=""GetStuff"" Function=""Default.NameSpace2.GetStuff"" IncludeInServiceDocument=""true"" />");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { functionImport }).ConfigureAwait(false),
@@ -463,7 +463,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
     ""$Function"": ""Default.NameSpace2.GetStuff"",
     ""$IncludeInServiceDocument"": true
   }
-}").ConfigureAwait(false);
+}");
 
             // Act & Assert for non-indent JSON
             await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { functionImport }).ConfigureAwait(false),
@@ -479,7 +479,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             // Act & Assert for XML
             await VisitAndVerifyXmlAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { functionImport, functionImport2 }).ConfigureAwait(false),
-                @"<FunctionImport Name=""GetStuff"" Function=""Default.NameSpace2.GetStuff"" IncludeInServiceDocument=""true"" />").ConfigureAwait(false);
+                @"<FunctionImport Name=""GetStuff"" Function=""Default.NameSpace2.GetStuff"" IncludeInServiceDocument=""true"" />");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { functionImport, functionImport2 }).ConfigureAwait(false),
@@ -489,7 +489,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
     ""$Function"": ""Default.NameSpace2.GetStuff"",
     ""$IncludeInServiceDocument"": true
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -501,7 +501,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             // Act & Assert for XML
             await VisitAndVerifyXmlAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { functionImport, functionImport2 }).ConfigureAwait(false),
-                @"<FunctionImport Name=""GetStuff"" Function=""Default.NameSpace2.GetStuff"" EntitySet=""Set"" IncludeInServiceDocument=""true"" />").ConfigureAwait(false);
+                @"<FunctionImport Name=""GetStuff"" Function=""Default.NameSpace2.GetStuff"" EntitySet=""Set"" IncludeInServiceDocument=""true"" />");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { functionImport, functionImport2 }).ConfigureAwait(false),
@@ -512,7 +512,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
     ""$EntitySet"": ""Set"",
     ""$IncludeInServiceDocument"": true
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -524,7 +524,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             // Act & Assert for XML
             await VisitAndVerifyXmlAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { functionImport, functionImport2 }).ConfigureAwait(false),
-                @"<FunctionImport Name=""GetStuff"" Function=""Default.NameSpace2.GetStuff"" EntitySet=""path1/path2"" IncludeInServiceDocument=""true"" />").ConfigureAwait(false);
+                @"<FunctionImport Name=""GetStuff"" Function=""Default.NameSpace2.GetStuff"" EntitySet=""path1/path2"" IncludeInServiceDocument=""true"" />");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { functionImport, functionImport2 }).ConfigureAwait(false),
@@ -535,7 +535,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
     ""$EntitySet"": ""path1/path2"",
     ""$IncludeInServiceDocument"": true
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -552,7 +552,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
                 @"<FunctionImport Name=""Checkout"" Function=""Default.NameSpace2.GetStuff"" EntitySet=""Set"" />
 <FunctionImport Name=""Checkout"" Function=""Default.NameSpace2.GetStuff"" EntitySet=""Set2"" />
 <FunctionImport Name=""Checkout"" Function=""Default.NameSpace2.GetStuff"" IncludeInServiceDocument=""true"" />
-<FunctionImport Name=""Checkout"" Function=""Default.NameSpace2.GetStuff"" EntitySet=""path1/path2"" />").ConfigureAwait(false);
+<FunctionImport Name=""Checkout"" Function=""Default.NameSpace2.GetStuff"" EntitySet=""path1/path2"" />");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { functionImportOnSet, functionImportOnSet2, functionmportWithNoEntitySet, functionImportWithUniqueEdmPath }).ConfigureAwait(false),
@@ -577,7 +577,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
     ""$Function"": ""Default.NameSpace2.GetStuff"",
     ""$EntitySet"": ""path1/path2""
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -606,7 +606,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
     <Parameter Name=""param2"" Type=""Edm.Int32"" Nullable=""false"" />
     <ReturnType Type=""Edm.Guid"" Nullable=""false"" />
   </Function>
-</Schema>").ConfigureAwait(false);
+</Schema>");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync(async (v) => await v.VisitEdmSchemaAsync(schema, null).ConfigureAwait(false), @"{
@@ -644,7 +644,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
       }
     ]
   }
-}").ConfigureAwait(false);
+}");
         }
         #endregion
 
@@ -683,7 +683,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
   <Annotations Target=""NS.ComplexType/Name"">
     <Annotation Term=""UI.DisplayName"" Qualifier=""Tablet"" Int=""42"" />
   </Annotations>
-</Schema>").ConfigureAwait(false);
+</Schema>");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync(async (v) => await v.VisitEdmSchemaAsync(schema, null).ConfigureAwait(false), @"{
@@ -699,7 +699,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
 
         [Fact]
@@ -732,7 +732,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
     <Annotation Term=""UI.DisplayName"" Int=""42"" />
     <Annotation Term=""UI.DisplayName"" Qualifier=""Tablet"" Int=""88"" />
   </Annotations>
-</Schema>").ConfigureAwait(false);
+</Schema>");
 
             // Act & Assert for JSON
             await VisitAndVerifyJsonAsync(async (v) => await v.VisitEdmSchemaAsync(schema, null).ConfigureAwait(false), @"{
@@ -747,7 +747,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
       }
     }
   }
-}").ConfigureAwait(false);
+}");
         }
         #endregion
 

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/ScenarioTests/OasisActionsFunctionsRelationshipChangesAcceptanceTests.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/ScenarioTests/OasisActionsFunctionsRelationshipChangesAcceptanceTests.Async.cs
@@ -22,10 +22,10 @@ namespace Microsoft.OData.Edm.Tests.ScenarioTests
             var builder = new StringBuilder();
             using (var writer = XmlWriter.Create(builder, new XmlWriterSettings() { Async = true }))
             {
-                var (result, errors) = await CsdlWriter.TryWriteCsdlAsync(this.TestModel.RepresentativeModel, writer, CsdlTarget.OData).ConfigureAwait(false);
+                var (result, errors) = await CsdlWriter.TryWriteCsdlAsync(this.TestModel.RepresentativeModel, writer, CsdlTarget.OData);
                 Assert.True(result);
                 Assert.Empty(errors);
-                await writer.FlushAsync().ConfigureAwait(false);
+                await writer.FlushAsync();
             }
 
             string actual = builder.ToString();

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/ScenarioTests/OasisRelationshipChangesAcceptanceTests.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/ScenarioTests/OasisRelationshipChangesAcceptanceTests.Async.cs
@@ -21,10 +21,10 @@ namespace Microsoft.OData.Edm.Tests.ScenarioTests
             var builder = new StringBuilder();
             using (var writer = XmlWriter.Create(builder, new XmlWriterSettings() { Async = true }))
             {
-                var (result, errors) = await CsdlWriter.TryWriteCsdlAsync(this.representativeModel, writer, CsdlTarget.OData).ConfigureAwait(false);
+                var (result, errors) = await CsdlWriter.TryWriteCsdlAsync(this.representativeModel, writer, CsdlTarget.OData);
                 Assert.True(result);
                 Assert.Empty(errors);
-                await writer.FlushAsync().ConfigureAwait(false);
+                await writer.FlushAsync();
             }
 
             string actual = builder.ToString();

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/Vocabularies/AlternateKeysVocabularyTests.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/Vocabularies/AlternateKeysVocabularyTests.Async.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             IEnumerable<EdmError> errors;
             using (var xw = XmlWriter.Create(sw, new XmlWriterSettings { Indent = true, Encoding = Encoding.UTF8, Async = true }))
             {
-                var (result, errorsAsync) = await model.TryWriteSchemaAsync(xw).ConfigureAwait(false);
+                var (result, errorsAsync) = await model.TryWriteSchemaAsync(xw);
                 Assert.True(result);
 
                 errors = errorsAsync; // Assign the async errors to the variable

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/Vocabularies/AuthorizationVocabularyTests.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/Vocabularies/AuthorizationVocabularyTests.Async.cs
@@ -135,8 +135,8 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             settings.Encoding = System.Text.Encoding.UTF8;
 
             XmlWriter xw = XmlWriter.Create(sw, settings);
-            var (_, errors) = await this._authorizationModel.TryWriteSchemaAsync(xw).ConfigureAwait(false);
-            await xw.FlushAsync().ConfigureAwait(false);
+            var (_, errors) = await this._authorizationModel.TryWriteSchemaAsync(xw);
+            await xw.FlushAsync();
 
             xw.Close();
             string output = sw.ToString();

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/Vocabularies/CapabilitiesVocabularyTests.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/Vocabularies/CapabilitiesVocabularyTests.Async.cs
@@ -845,8 +845,8 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             settings.Encoding = System.Text.Encoding.UTF8;
 
             XmlWriter xw = XmlWriter.Create(sw, settings);
-            var (_, errors) = await this.capVocModel.TryWriteSchemaAsync(xw).ConfigureAwait(false);
-            await xw.FlushAsync().ConfigureAwait(false);
+            var (_, errors) = await this.capVocModel.TryWriteSchemaAsync(xw);
+            await xw.FlushAsync();
 
             xw.Close();
             string output = sw.ToString();

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/Vocabularies/CommunityVocabularyTests.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/Vocabularies/CommunityVocabularyTests.Async.cs
@@ -33,7 +33,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             IEnumerable<EdmError> errors;
             using (var xw = XmlWriter.Create(sw, new XmlWriterSettings { Indent = true, Encoding = Encoding.UTF8, Async = true }))
             {
-                var (result, errorsAsync) = await model.TryWriteSchemaAsync(xw).ConfigureAwait(false);
+                var (result, errorsAsync) = await model.TryWriteSchemaAsync(xw);
                 Assert.True(result);
 
                 errors = errorsAsync;

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.Async.cs
@@ -71,8 +71,8 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             };
 
             XmlWriter xw = XmlWriter.Create(sw, settings);
-            var (_, errors) = await coreVocModel.TryWriteSchemaAsync(xw).ConfigureAwait(false);
-            await xw.FlushAsync().ConfigureAwait(false);
+            var (_, errors) = await coreVocModel.TryWriteSchemaAsync(xw);
+            await xw.FlushAsync();
             xw.Close();
             string output = sw.ToString();
             Assert.False(errors.Any(), "No Errors");

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/Vocabularies/ValidationVocabularyTests.Async.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/Vocabularies/ValidationVocabularyTests.Async.cs
@@ -121,8 +121,8 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             };
 
             XmlWriter xw = XmlWriter.Create(sw, settings);
-            var (_, errors) = await this._validationModel.TryWriteSchemaAsync(xw).ConfigureAwait(false);
-            await xw.FlushAsync().ConfigureAwait(false);
+            var (_, errors) = await this._validationModel.TryWriteSchemaAsync(xw);
+            await xw.FlushAsync();
             xw.Close();
             string output = sw.ToString();
 

--- a/test/UnitTests/Microsoft.Spatial.Tests/DataServicesSpatialImplementationTests.cs
+++ b/test/UnitTests/Microsoft.Spatial.Tests/DataServicesSpatialImplementationTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Spatial.Tests
             {
                 if (!spatialPipelineReturnTestedMethods.Contains(method.Name))
                 {
-                    Assert.True(false, "Not testing the SpatialPipeline return of method " + method.Name + " to be sure it is wrapped in a forwarding pipeline.");
+                    Assert.Fail("Not testing the SpatialPipeline return of method " + method.Name + " to be sure it is wrapped in a forwarding pipeline.");
                 }
             }
         }

--- a/test/UnitTests/Microsoft.Spatial.Tests/GeoJsonObjectWriterTests.cs
+++ b/test/UnitTests/Microsoft.Spatial.Tests/GeoJsonObjectWriterTests.cs
@@ -679,7 +679,7 @@ namespace Microsoft.Spatial.Tests
                 case SpatialType.Collection:
                     return "GeometryCollection";
                 default:
-                    Assert.True(false, string.Format("Unrecognized GeoJson type '{0}'", type));
+                    Assert.Fail(string.Format("Unrecognized GeoJson type '{0}'", type));
                     return null;
             }
         }

--- a/test/UnitTests/Microsoft.Spatial.Tests/GmlReaderTests.cs
+++ b/test/UnitTests/Microsoft.Spatial.Tests/GmlReaderTests.cs
@@ -915,7 +915,7 @@ namespace Microsoft.Spatial.Tests
                     payloadBuilder.Append(GmlEndElement("MultiGeometry"));
                     break;
                 default:
-                    Assert.True(false, "unknown spatial type");
+                    Assert.Fail("unknown spatial type");
                     break;
             }
 

--- a/test/UnitTests/Microsoft.Spatial.Tests/ScenarioTests/SpatialEqualityTests.cs
+++ b/test/UnitTests/Microsoft.Spatial.Tests/ScenarioTests/SpatialEqualityTests.cs
@@ -377,7 +377,7 @@ namespace Microsoft.Spatial.Tests.ScenarioTests
                 return (T)geographyTypes[(int)GeographyTypeKind.FullGlobe];
             }
 
-            Assert.True(false, String.Format(CultureInfo.InvariantCulture, "Invalid Geography type encountered - {0}", typeof(T).FullName));
+            Assert.Fail(String.Format(CultureInfo.InvariantCulture, "Invalid Geography type encountered - {0}", typeof(T).FullName));
             return null;
         }
 
@@ -412,7 +412,7 @@ namespace Microsoft.Spatial.Tests.ScenarioTests
                 return (T)geometryTypes[(int)GeometryTypeKind.Collection];
             }
 
-            Assert.True(false, String.Format(CultureInfo.InvariantCulture, "Invalid Geometry type encountered - {0}", typeof(T).FullName));
+            Assert.Fail(String.Format(CultureInfo.InvariantCulture, "Invalid Geometry type encountered - {0}", typeof(T).FullName));
             return null;
         }
     }

--- a/test/UnitTests/Microsoft.Spatial.Tests/SpatialOperationsTests.cs
+++ b/test/UnitTests/Microsoft.Spatial.Tests/SpatialOperationsTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Spatial.Tests
         {
             this.implementation.callback = (methodName, arguments) =>
             {
-                Assert.True(false, "shouldn't call the implementation");
+                Assert.Fail("shouldn't call the implementation");
             };
             var result = GeometryOperationsExtensions.Distance(null, geomPoints[0]);
             Assert.Null(result);
@@ -109,7 +109,7 @@ namespace Microsoft.Spatial.Tests
         {
             this.implementation.callback = (methodName, arguments) =>
                                                {
-                                                   Assert.True(false, "shouldn't call the implementation");
+                                                   Assert.Fail("shouldn't call the implementation");
                                                };
             var result = GeographyOperationsExtensions.Distance(null, geogPoints[0]);
             Assert.Null(result);
@@ -224,7 +224,7 @@ namespace Microsoft.Spatial.Tests
                 }
                 else
                 {
-                    Assert.True(false, "Unsupported type: " + type);
+                    Assert.Fail("Unsupported type: " + type);
                 }
             }
 

--- a/test/UnitTests/Microsoft.Spatial.Tests/SpatialReaderTests.cs
+++ b/test/UnitTests/Microsoft.Spatial.Tests/SpatialReaderTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Spatial.Tests
                     return (TException) ex;
                 throw;
             }
-            Assert.True(false, "Expected exception, but no exception was thrown.");
+            Assert.Fail("Expected exception, but no exception was thrown.");
 // ReSharper disable HeuristicUnreachableCode
             return default(TException);
 // ReSharper restore HeuristicUnreachableCode

--- a/test/UnitTests/Microsoft.Spatial.Tests/SpatialTestUtils.cs
+++ b/test/UnitTests/Microsoft.Spatial.Tests/SpatialTestUtils.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Spatial.Tests
             {
                 return ex as T;
             }
-            Assert.True(false, "Exception of the wrong type thrown - expected " + typeof(T).Name + " but got " + ex.GetType().Name);
+            Assert.Fail("Exception of the wrong type thrown - expected " + typeof(T).Name + " but got " + ex.GetType().Name);
             return null;
         }
 
@@ -342,7 +342,7 @@ namespace Microsoft.Spatial.Tests
                 messageBuilder.AppendLine(actualBuilder.ToString());
 
                 var message = messageBuilder.ToString();
-                Assert.True(false, message);
+                Assert.Fail(message);
             }
         }
 


### PR DESCRIPTION
### Summary

Resolve actionable product and xUnit analyzer warnings from the current `main` build while preserving existing runtime and test behavior.

This change addresses all 271 targeted xUnit diagnostics and fixes non-obsolete product warnings. Legacy formatter-based serialization warnings are narrowly suppressed because removing that functionality requires a separately planned breaking change.

### Product warning fixes

#### Configure library awaits explicitly

Add `ConfigureAwait(false)` to asynchronous product-code continuations that do not require a captured synchronization context.

This follows library guidance, avoids unnecessary context capture, and resolves `CA2007` without changing the result of the asynchronous operations.

#### Retain legacy formatter serialization temporarily

The OData Client exception types still contain formatter-based serialization constructors and `GetObjectData` overrides. Modern .NET reports these APIs through `SYSLIB0051`, with related `SYSLIB0003` and `CS0672` diagnostics.

The serialization members are retained for compatibility and the warnings are suppressed only around the affected members. Removing `[Serializable]`, serialization constructors, and `GetObjectData` would change legacy behavior and, for some protected/public members, the shipped API surface. That removal should be handled separately in an appropriate breaking-change release.

Affected exception types include:

- `DataServiceClientException`
- `DataServiceQueryException`
- `DataServiceRequestException`
- `DataServiceTransportException`

#### Resolve remaining product diagnostics

- Use ordinal comparison when checking path segments for `/`.
- Correct XML documentation references.
- Add narrowly scoped analyzer suppressions where the reported design or performance issue does not apply:
  - `BaseEntityType` exposes the interface functionality to derived types through its protected `Context` property.
  - `BufferingJsonReader.AssertAsynchronous` accesses instance state in `DEBUG` builds.

### xUnit analyzer fixes

#### Keep test continuations on the xUnit context

Remove `.ConfigureAwait(false)` from `[Fact]` and `[Theory]` methods to resolve `xUnit1030`.

xUnit uses its synchronization context to control test parallelism. `ConfigureAwait(false)` bypasses that context and resumes on the unrestricted thread pool, potentially allowing more concurrent test execution than xUnit intends.

These tests verify OData behavior rather than synchronization-context behavior, so plain `await` preserves their intent:

```csharp
Employee employee = await query.GetValueAsync();
```

Avoid blocking asynchronous operations

Replace blocking task operations with  await  to resolve  xUnit1031 .

Blocking operations can consume xUnit worker threads and cause deadlocks or reduced test throughput.

Improve assertion intent and diagnostics

Apply the xUnit-specific assertion patterns recommended by the analyzers:

• Put constants and expected values first in equality assertions.
• Replace collection count comparisons with  Assert.Empty ,  Assert.NotEmpty , or  Assert.Single .
• Replace unconditional  Assert.True(false, message)  calls with  Assert.Fail(message) .
• Replace  Assert.Empty(collection.Where(...))  with  Assert.DoesNotContain .
• Use the predicate overload of  Assert.Single  instead of applying  Where  first.
• Remove null assertions on non-nullable value types.

For example,  ReadCollectionStartAsync  returns a value tuple. A value tuple cannot be  null , so this assertion could never fail:

`Assert.NotNull(readCollectionStartResult);`

The tuple contents continue to be validated with type and value assertions.

Diagnostics addressed
| Diagnostic | Count | Resolution |
|---|---:|---|
| `xUnit1030` | 155 | Remove `ConfigureAwait(false)` from test methods |
| `xUnit1031` | 4 | Replace blocking task operations with `await` |
| `xUnit2000` | 32 | Put expected values first |
| `xUnit2002` | 2 | Remove impossible value-type null checks |
| `xUnit2013` | 22 | Use collection-specific assertions |
| `xUnit2020` | 33 | Use `Assert.Fail` |
| `xUnit2029` | 2 | Use `Assert.DoesNotContain` |
| `xUnit2031` | 21 | Use the predicate overload of `Assert.Single` |
| **Total** | **271** | |

## Testing

Executed:

dotnet test .\sln\OData.sln --configuration Release --no-restore

Results:
| Project | Passed | Skipped | Failed |
|---|---:|---:|---:|
| Microsoft.Spatial.Tests | 402 | 0 | 0 |
| Microsoft.OData.Edm.Tests | 1,382 | 0 | 0 |
| Microsoft.OData.Client.Tests | 564 | 0 | 0 |
| Microsoft.OData.Core.Tests | 10,528 | 5 | 0 |
| **Total** | **12,876** | **5** | **0** |

The legacy  build.cmd Nightly  runner could not start because its Visual Studio 2019 MSBuild is incompatible with the installed .NET SDK. The failure occurred during SDK resolution before any tests ran and is unrelated to this change.

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
