### PR TITLE
Prevent duplicate pooled buffer returns

### DIFF
--- a/src/Microsoft.OData.Core/Json/ODataJsonValueSerializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonValueSerializer.cs
@@ -382,15 +382,24 @@ namespace Microsoft.OData.Json
 
         public virtual void WriteStreamValue(ODataBinaryStreamValue streamValue)
         {
-            Stream stream = this.JsonWriter.StartStreamValueScope();
-            streamValue.Stream.CopyTo(stream);
-            stream.Flush();
-            stream.Dispose();
-            this.JsonWriter.EndStreamValueScope();
-
-            if (!streamValue.LeaveOpen)
+            try
             {
-                streamValue.Stream.Dispose();
+                Stream stream = this.JsonWriter.StartStreamValueScope();
+                try
+                {
+                    streamValue.Stream.CopyTo(stream);
+                }
+                finally
+                {
+                    this.JsonWriter.EndStreamValueScope();
+                }
+            }
+            finally
+            {
+                if (!streamValue.LeaveOpen)
+                {
+                    streamValue.Stream.Dispose();
+                }
             }
         }
 
@@ -722,15 +731,24 @@ namespace Microsoft.OData.Json
         /// <returns>A task that represents the asynchronous write operation.</returns>
         public virtual async Task WriteStreamValueAsync(ODataBinaryStreamValue streamValue)
         {
-            Stream stream = await this.JsonWriter.StartStreamValueScopeAsync().ConfigureAwait(false);
-            await streamValue.Stream.CopyToAsync(stream).ConfigureAwait(false);
-            await stream.FlushAsync().ConfigureAwait(false);
-            await stream.DisposeAsync().ConfigureAwait(false);
-            await this.JsonWriter.EndStreamValueScopeAsync().ConfigureAwait(false);
-
-            if (!streamValue.LeaveOpen)
+            try
             {
-                await streamValue.Stream.DisposeAsync().ConfigureAwait(false);
+                Stream stream = await this.JsonWriter.StartStreamValueScopeAsync().ConfigureAwait(false);
+                try
+                {
+                    await streamValue.Stream.CopyToAsync(stream).ConfigureAwait(false);
+                }
+                finally
+                {
+                    await this.JsonWriter.EndStreamValueScopeAsync().ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                if (!streamValue.LeaveOpen)
+                {
+                    await streamValue.Stream.DisposeAsync().ConfigureAwait(false);
+                }
             }
         }
 

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
@@ -43,8 +43,9 @@ namespace Microsoft.OData.Json
         /// </summary>
         public void EndStreamValueScope()
         {
-            this.binaryValueStream?.Dispose();
+            Stream stream = this.binaryValueStream;
             this.binaryValueStream = null;
+            stream?.Dispose();
             this.Flush();
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
@@ -76,10 +77,11 @@ namespace Microsoft.OData.Json
         /// <returns>A task representing the asynchronous operation.</returns>
         public async Task EndStreamValueScopeAsync()
         {
-            if (this.binaryValueStream != null)
+            Stream stream = this.binaryValueStream;
+            this.binaryValueStream = null;
+            if (stream != null)
             {
-                await this.binaryValueStream.DisposeAsync().ConfigureAwait(false);
-                this.binaryValueStream = null;
+                await stream.DisposeAsync().ConfigureAwait(false);
             }
 
             await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
@@ -96,16 +98,24 @@ namespace Microsoft.OData.Json
         internal sealed class ODataUtf8JsonWriteStream : Stream
         {
             private readonly ODataUtf8JsonWriter jsonWriter = null;
+            private readonly ArrayPool<byte> arrayPool;
             private byte[] buffer;
-            int numBytesNotWrittenFromPreviousChunk = 0;
+            private int disposed;
+            private int numBytesNotWrittenFromPreviousChunk = 0;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="ODataUtf8JsonWriter"> class with the specified ODataUtf8JsonWriter.
             /// </summary>
             /// <param name="writer">The OData UTF-8 JSON writer to write to.</param>
             internal ODataUtf8JsonWriteStream(ODataUtf8JsonWriter writer)
+                : this(writer, ArrayPool<byte>.Shared)
+            {
+            }
+
+            internal ODataUtf8JsonWriteStream(ODataUtf8JsonWriter writer, ArrayPool<byte> arrayPool)
             {
                 this.jsonWriter = writer;
+                this.arrayPool = arrayPool;
             }
 
             public override bool CanRead => false;
@@ -147,22 +157,35 @@ namespace Microsoft.OData.Json
             /// <param name="disposing">true if called from Dispose; false if called form the finalizer.</param>
             protected override void Dispose(bool disposing)
             {
-                if (this.numBytesNotWrittenFromPreviousChunk > 0)
+                if (Interlocked.Exchange(ref this.disposed, 1) != 0)
                 {
-                    // If there are unprocessed bytes, encode and write them as the final block.
-                    ReadOnlySpan<byte> bytesNotProcessedFromPreviousChunk = this.buffer.AsSpan().Slice(0, this.numBytesNotWrittenFromPreviousChunk);
-
-                    this.jsonWriter.Base64EncodeAndWriteChunk(bytesNotProcessedFromPreviousChunk, isFinalBlock: true, out this.numBytesNotWrittenFromPreviousChunk);
-                    Debug.Assert(numBytesNotWrittenFromPreviousChunk == 0, "numBytesNotWrittenFromPreviousChunk == 0");
+                    return;
                 }
 
-                if (this.buffer != null)
-                {
-                    ArrayPool<byte>.Shared.Return(this.buffer);
-                }
+                byte[] buffer = Interlocked.Exchange(ref this.buffer, null);
 
-                this.Flush();
-                base.Dispose(disposing);
+                try
+                {
+                    if (buffer != null && this.numBytesNotWrittenFromPreviousChunk > 0)
+                    {
+                        // If there are unprocessed bytes, encode and write them as the final block.
+                        ReadOnlySpan<byte> bytesNotProcessedFromPreviousChunk = buffer.AsSpan().Slice(0, this.numBytesNotWrittenFromPreviousChunk);
+
+                        this.jsonWriter.Base64EncodeAndWriteChunk(bytesNotProcessedFromPreviousChunk, isFinalBlock: true, out this.numBytesNotWrittenFromPreviousChunk);
+                        Debug.Assert(numBytesNotWrittenFromPreviousChunk == 0, "numBytesNotWrittenFromPreviousChunk == 0");
+                    }
+
+                    this.Flush();
+                }
+                finally
+                {
+                    if (buffer != null)
+                    {
+                        this.arrayPool.Return(buffer);
+                    }
+
+                    base.Dispose(disposing);
+                }
             }
 
             /// <summary>
@@ -171,21 +194,36 @@ namespace Microsoft.OData.Json
             /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
             public override async ValueTask DisposeAsync()
             {
-                if (this.numBytesNotWrittenFromPreviousChunk > 0)
+                if (Interlocked.Exchange(ref this.disposed, 1) != 0)
                 {
-                    // If there are unprocessed bytes, encode and write them as the final block.
-                    ReadOnlyMemory<byte> bytesNotProcessedFromPreviousChunk = this.buffer.AsMemory().Slice(0, this.numBytesNotWrittenFromPreviousChunk);
-
-                    this.jsonWriter.Base64EncodeAndWriteChunk(bytesNotProcessedFromPreviousChunk.Span, isFinalBlock: true, out this.numBytesNotWrittenFromPreviousChunk);
-                    Debug.Assert(numBytesNotWrittenFromPreviousChunk == 0, "numBytesNotWrittenFromPreviousChunk == 0");
+                    return;
                 }
 
-                if (this.buffer != null)
-                {
-                    ArrayPool<byte>.Shared.Return(this.buffer);
-                }
+                byte[] buffer = Interlocked.Exchange(ref this.buffer, null);
 
-                await this.jsonWriter.FlushAsync().ConfigureAwait(false);
+                try
+                {
+                    if (buffer != null && this.numBytesNotWrittenFromPreviousChunk > 0)
+                    {
+                        // If there are unprocessed bytes, encode and write them as the final block.
+                        ReadOnlyMemory<byte> bytesNotProcessedFromPreviousChunk = buffer.AsMemory().Slice(0, this.numBytesNotWrittenFromPreviousChunk);
+
+                        this.jsonWriter.Base64EncodeAndWriteChunk(bytesNotProcessedFromPreviousChunk.Span, isFinalBlock: true, out this.numBytesNotWrittenFromPreviousChunk);
+                        Debug.Assert(numBytesNotWrittenFromPreviousChunk == 0, "numBytesNotWrittenFromPreviousChunk == 0");
+                    }
+
+                    await this.jsonWriter.FlushAsync().ConfigureAwait(false);
+                }
+                finally
+                {
+                    if (buffer != null)
+                    {
+                        this.arrayPool.Return(buffer);
+                    }
+
+                    base.Dispose(true);
+                    GC.SuppressFinalize(this);
+                }
             }
 
             /// <summary>
@@ -263,7 +301,7 @@ namespace Microsoft.OData.Json
                         int totalLength = bytesNotProcessedFromPreviousChunk.Length + chunk.Length;
 
                         // Rent an array to hold bytes from both previous and current chunks.
-                        byte[] combinedArray = ArrayPool<byte>.Shared.Rent(totalLength);
+                        byte[] combinedArray = this.arrayPool.Rent(totalLength);
 
                         // Copy bytes from bytesNotProcessedFromPreviousChunk to the combined array
                         bytesNotProcessedFromPreviousChunk.CopyTo(combinedArray);
@@ -273,7 +311,7 @@ namespace Microsoft.OData.Json
 
                         WriteChunk(combinedArray.AsSpan().Slice(0, totalLength), totalLength, isFinalBlock);
 
-                        ArrayPool<byte>.Shared.Return(combinedArray);
+                        this.arrayPool.Return(combinedArray);
                     }
                     else
                     {
@@ -309,7 +347,7 @@ namespace Microsoft.OData.Json
                         int totalLength = bytesNotProcessedFromPreviousChunk.Length + chunk.Length;
 
                         // Rent an array to hold bytes from both previous and current chunks.
-                        byte[] combinedArray = ArrayPool<byte>.Shared.Rent(totalLength);
+                        byte[] combinedArray = this.arrayPool.Rent(totalLength);
 
                         // Copy bytes from bytesNotProcessedFromPreviousChunk to the combined array
                         bytesNotProcessedFromPreviousChunk.Span.CopyTo(combinedArray);
@@ -319,7 +357,7 @@ namespace Microsoft.OData.Json
 
                         WriteChunk(combinedArray.AsSpan().Slice(0, totalLength), totalLength, isFinalBlock);
 
-                        ArrayPool<byte>.Shared.Return(combinedArray);
+                        this.arrayPool.Return(combinedArray);
                     }
                     else
                     {
@@ -345,7 +383,7 @@ namespace Microsoft.OData.Json
                 {
                     if (this.buffer == null)
                     {
-                        this.buffer = ArrayPool<byte>.Shared.Rent(ODataUtf8JsonWriter.chunkSize);
+                        this.buffer = this.arrayPool.Rent(ODataUtf8JsonWriter.chunkSize);
                     }
 
                     // Update the buffer with unprocessed bytes from the current chunk.

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
@@ -11,6 +11,7 @@ namespace Microsoft.OData.Json
     using System.IO;
     using System.Text;
     using System.Text.Unicode;
+    using System.Threading;
     using System.Threading.Tasks;
 
     internal sealed partial class ODataUtf8JsonWriter
@@ -68,7 +69,9 @@ namespace Microsoft.OData.Json
                 this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
             }
 
-            this.textWriter?.Dispose();
+            TextWriter textWriter = this.textWriter;
+            this.textWriter = null;
+            textWriter?.Dispose();
             this.Flush();
 
             CheckIfSeparatorNeeded();
@@ -113,9 +116,11 @@ namespace Microsoft.OData.Json
                 this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
             }
 
-            if (this.textWriter != null)
+            TextWriter textWriter = this.textWriter;
+            this.textWriter = null;
+            if (textWriter != null)
             {
-                await this.textWriter.DisposeAsync().ConfigureAwait(false);
+                await textWriter.DisposeAsync().ConfigureAwait(false);
             }
 
             await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
@@ -139,6 +144,7 @@ namespace Microsoft.OData.Json
         internal sealed class ODataUtf8JsonTextWriter : TextWriter
         {
             private readonly ODataUtf8JsonWriter jsonWriter = null;
+            private readonly ArrayPool<char> arrayPool;
             // Buffer used to store chars that could not be encoded due to
             // insufficient data in the input buffer. The chars will be prepended
             // to the next chunk of input.
@@ -148,10 +154,17 @@ namespace Microsoft.OData.Json
             // This buffer is used by Write(char) to store the char so
             // that we can re-use our Write(char[], ...) method.
             private char[] singleCharBuffer;
+            private int disposed;
 
             public ODataUtf8JsonTextWriter(ODataUtf8JsonWriter jsonWriter)
+                : this(jsonWriter, ArrayPool<char>.Shared)
+            {
+            }
+
+            internal ODataUtf8JsonTextWriter(ODataUtf8JsonWriter jsonWriter, ArrayPool<char> arrayPool)
             {
                 this.jsonWriter = jsonWriter;
+                this.arrayPool = arrayPool;
             }
 
             /// <summary>
@@ -182,18 +195,32 @@ namespace Microsoft.OData.Json
             /// <param name="disposing">true if called from Dispose; false if called form the finalizer.</param>
             protected override void Dispose(bool disposing)
             {
-                if (this.buffer != null)
+                if (Interlocked.Exchange(ref this.disposed, 1) != 0)
                 {
-                    ArrayPool<char>.Shared.Return(this.buffer);
+                    return;
                 }
 
-                if (this.singleCharBuffer != null)
-                {
-                    ArrayPool<char>.Shared.Return(this.singleCharBuffer);
-                }
+                char[] buffer = Interlocked.Exchange(ref this.buffer, null);
+                char[] singleCharBuffer = Interlocked.Exchange(ref this.singleCharBuffer, null);
 
-                this.Flush();
-                base.Dispose(disposing);
+                try
+                {
+                    this.Flush();
+                }
+                finally
+                {
+                    if (buffer != null)
+                    {
+                        this.arrayPool.Return(buffer);
+                    }
+
+                    if (singleCharBuffer != null)
+                    {
+                        this.arrayPool.Return(singleCharBuffer);
+                    }
+
+                    base.Dispose(disposing);
+                }
             }
 
             /// <summary>
@@ -202,17 +229,33 @@ namespace Microsoft.OData.Json
             /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
             public override async ValueTask DisposeAsync()
             {
-                if (this.buffer != null)
+                if (Interlocked.Exchange(ref this.disposed, 1) != 0)
                 {
-                    ArrayPool<char>.Shared.Return(this.buffer);
+                    return;
                 }
 
-                if (this.singleCharBuffer != null)
-                {
-                    ArrayPool<char>.Shared.Return(this.singleCharBuffer);
-                }
+                char[] buffer = Interlocked.Exchange(ref this.buffer, null);
+                char[] singleCharBuffer = Interlocked.Exchange(ref this.singleCharBuffer, null);
 
-                await this.FlushAsync().ConfigureAwait(false);
+                try
+                {
+                    await this.FlushAsync().ConfigureAwait(false);
+                }
+                finally
+                {
+                    if (buffer != null)
+                    {
+                        this.arrayPool.Return(buffer);
+                    }
+
+                    if (singleCharBuffer != null)
+                    {
+                        this.arrayPool.Return(singleCharBuffer);
+                    }
+
+                    base.Dispose(true);
+                    GC.SuppressFinalize(this);
+                }
             }
 
             /// <summary>
@@ -238,7 +281,7 @@ namespace Microsoft.OData.Json
             /// <param name="value">The character to write.</param>
             public override async Task WriteAsync(char value)
             {
-                this.singleCharBuffer ??= ArrayPool<char>.Shared.Rent(1);
+                this.singleCharBuffer ??= this.arrayPool.Rent(1);
                 this.singleCharBuffer[0] = value;
                 ReadOnlyMemory<char> input = this.singleCharBuffer.AsMemory().Slice(0, 1);
 
@@ -314,7 +357,7 @@ namespace Microsoft.OData.Json
                         ReadOnlySpan<char> charsNotProcessedFromPreviousChunk = this.buffer.AsSpan().Slice(0, this.numOfCharsNotWrittenFromPreviousChunk);
                         int totalLength = charsNotProcessedFromPreviousChunk.Length + chunk.Length;
 
-                        char[] combinedArray = ArrayPool<char>.Shared.Rent(totalLength);
+                        char[] combinedArray = this.arrayPool.Rent(totalLength);
 
                         // Copy chars from charsNotProcessedFromPreviousChunk to the combined array
                         charsNotProcessedFromPreviousChunk.CopyTo(combinedArray);
@@ -327,7 +370,7 @@ namespace Microsoft.OData.Json
                         // Write the chunk.
                         this.WriteChunk(combinedArray.AsSpan().Slice(0, totalLength), totalLength, firstIndexToEscape, isFinalBlock);
 
-                        ArrayPool<char>.Shared.Return(combinedArray);
+                        this.arrayPool.Return(combinedArray);
                     }
                     else
                     {
@@ -362,7 +405,7 @@ namespace Microsoft.OData.Json
                         ReadOnlyMemory<char> charsNotProcessedFromPreviousChunk = this.buffer.AsMemory().Slice(0, this.numOfCharsNotWrittenFromPreviousChunk);
                         int totalLength = charsNotProcessedFromPreviousChunk.Length + chunk.Length;
 
-                        char[] combinedArray = ArrayPool<char>.Shared.Rent(totalLength);
+                        char[] combinedArray = this.arrayPool.Rent(totalLength);
 
                         // Copy chars from charsNotProcessedFromPreviousChunk to the combined array
                         charsNotProcessedFromPreviousChunk.CopyTo(combinedArray);
@@ -375,7 +418,7 @@ namespace Microsoft.OData.Json
                         // Write the chunk.
                         this.WriteChunk(combinedArray.AsSpan().Slice(0, totalLength), totalLength, firstIndexToEscape, isFinalBlock);
 
-                        ArrayPool<char>.Shared.Return(combinedArray);
+                        this.arrayPool.Return(combinedArray);
                     }
                     else
                     {
@@ -411,7 +454,7 @@ namespace Microsoft.OData.Json
                         ReadOnlySpan<char> charsNotProcessedFromPreviousChunk = this.buffer.AsSpan().Slice(0, this.numOfCharsNotWrittenFromPreviousChunk);
                         int totalLength = charsNotProcessedFromPreviousChunk.Length + chunk.Length;
 
-                        char[] combinedArray = ArrayPool<char>.Shared.Rent(totalLength);
+                        char[] combinedArray = this.arrayPool.Rent(totalLength);
 
                         // Copy chars from charsNotProcessedFromPreviousChunk to the combined array
                         charsNotProcessedFromPreviousChunk.CopyTo(combinedArray);
@@ -422,7 +465,7 @@ namespace Microsoft.OData.Json
                         // Write the chunk.
                         this.WriteChunkWithoutEscaping(combinedArray.AsSpan().Slice(0, totalLength), totalLength, isFinalBlock);
 
-                        ArrayPool<char>.Shared.Return(combinedArray, true);
+                        this.arrayPool.Return(combinedArray, true);
                     }
                     else
                     {
@@ -455,7 +498,7 @@ namespace Microsoft.OData.Json
                         ReadOnlyMemory<char> charsNotProcessedFromPreviousChunk = this.buffer.AsMemory().Slice(0, this.numOfCharsNotWrittenFromPreviousChunk);
                         int totalLength = charsNotProcessedFromPreviousChunk.Length + chunk.Length;
 
-                        char[] combinedArray = ArrayPool<char>.Shared.Rent(totalLength);
+                        char[] combinedArray = this.arrayPool.Rent(totalLength);
 
                         // Copy chars from charsNotProcessedFromPreviousChunk to the combined array
                         charsNotProcessedFromPreviousChunk.CopyTo(combinedArray);
@@ -466,7 +509,7 @@ namespace Microsoft.OData.Json
                         // Write the chunk.
                         this.WriteChunkWithoutEscaping(combinedArray.AsSpan().Slice(0, totalLength), totalLength, isFinalBlock);
 
-                        ArrayPool<char>.Shared.Return(combinedArray, true);
+                        this.arrayPool.Return(combinedArray, true);
                     }
                     else
                     {
@@ -488,7 +531,7 @@ namespace Microsoft.OData.Json
                     {
                         if (this.buffer == null)
                         {
-                            this.buffer = ArrayPool<char>.Shared.Rent(ODataUtf8JsonWriter.chunkSize);
+                            this.buffer = this.arrayPool.Rent(ODataUtf8JsonWriter.chunkSize);
                         }
 
                         // Update the buffer with unprocessed bytes from the current chunk.
@@ -522,7 +565,7 @@ namespace Microsoft.OData.Json
                 {
                     if (this.buffer == null)
                     {
-                        this.buffer = ArrayPool<char>.Shared.Rent(ODataUtf8JsonWriter.chunkSize);
+                        this.buffer = this.arrayPool.Rent(ODataUtf8JsonWriter.chunkSize);
                     }
 
                     // Update the buffer with unprocessed bytes from the current chunk.

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
@@ -23,6 +23,10 @@ namespace Microsoft.OData.Tests.Json
     {
         public Action<string> WriteNameVerifier;
         public Action<string> WriteValueVerifier;
+        public Func<Stream> StartStreamValueScopeFunc;
+        public Action EndStreamValueScopeAction;
+        public Func<Task<Stream>> StartStreamValueScopeAsyncFunc;
+        public Func<Task> EndStreamValueScopeAsyncFunc;
 
         public void StartPaddingFunctionScope() => throw new NotImplementedException();
 
@@ -168,19 +172,19 @@ namespace Microsoft.OData.Tests.Json
 
         public Task WriteValueAsync(JsonElement value) => throw new NotImplementedException();
 
-        public Stream StartStreamValueScope() => throw new NotImplementedException();
+        public Stream StartStreamValueScope() => this.StartStreamValueScopeFunc?.Invoke() ?? throw new NotImplementedException();
 
         public TextWriter StartTextWriterValueScope(string contentType) => throw new NotImplementedException();
 
-        public void EndStreamValueScope() => throw new NotImplementedException();
+        public void EndStreamValueScope() => (this.EndStreamValueScopeAction ?? throw new NotImplementedException()).Invoke();
 
         public void EndTextWriterValueScope() => throw new NotImplementedException();
 
-        public Task<Stream> StartStreamValueScopeAsync() => throw new NotImplementedException();
+        public Task<Stream> StartStreamValueScopeAsync() => this.StartStreamValueScopeAsyncFunc?.Invoke() ?? throw new NotImplementedException();
 
         public Task<TextWriter> StartTextWriterValueScopeAsync(string contentType) => throw new NotImplementedException();
 
-        public Task EndStreamValueScopeAsync() => throw new NotImplementedException();
+        public Task EndStreamValueScopeAsync() => this.EndStreamValueScopeAsyncFunc?.Invoke() ?? throw new NotImplementedException();
 
         public Task EndTextWriterValueScopeAsync() => throw new NotImplementedException();
     }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonValueSerializerAsyncTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonValueSerializerAsyncTests.cs
@@ -10,6 +10,8 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.OData.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Core.Tests.DependencyInjection;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Json;
 using Xunit;
@@ -505,6 +507,24 @@ namespace Microsoft.OData.Tests.Json
             Assert.Equal("\"CjEyMzQ1Njc4OTA=\"", result);
         }
 
+        [Fact]
+        public async Task WriteStreamValueAsync_DisposesWriterStreamOnce()
+        {
+            var writerStream = new DisposeTrackingMemoryStream();
+            var jsonWriter = new MockJsonWriter
+            {
+                StartStreamValueScopeAsyncFunc = () => Task.FromResult<Stream>(writerStream),
+                EndStreamValueScopeAsyncFunc = async () => await writerStream.DisposeAsync()
+            };
+            var container = ServiceProviderHelper.BuildServiceProvider(
+                services => services.AddSingleton<IJsonWriterFactory>(new MockJsonWriterFactory(jsonWriter)));
+            var serializer = this.CreateODataJsonValueSerializer(true, container, true);
+
+            await serializer.WriteStreamValueAsync(new ODataBinaryStreamValue(new MemoryStream(new byte[] { 1 })));
+
+            Assert.Equal(1, writerStream.DisposeCount);
+        }
+
         private ODataJsonValueSerializer CreateODataJsonValueSerializer(bool writingResponse, IServiceProvider serviceProvider = null, bool isAsync = false)
         {
             var messageInfo = new ODataMessageInfo
@@ -536,6 +556,21 @@ namespace Microsoft.OData.Tests.Json
             this.stream.Position = 0;
             
             return await new StreamReader(this.stream).ReadToEndAsync();
+        }
+
+        private sealed class DisposeTrackingMemoryStream : MemoryStream
+        {
+            public int DisposeCount { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    this.DisposeCount++;
+                }
+
+                base.Dispose(disposing);
+            }
         }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonValueSerializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonValueSerializerTests.cs
@@ -363,6 +363,24 @@ namespace Microsoft.OData.Tests.Json
             Assert.Equal("\"CjEyMzQ1Njc4OTA=\"", result);
         }
 
+        [Fact]
+        public void WriteStreamValue_DisposesWriterStreamOnce()
+        {
+            var writerStream = new DisposeTrackingMemoryStream();
+            var jsonWriter = new MockJsonWriter
+            {
+                StartStreamValueScopeFunc = () => writerStream,
+                EndStreamValueScopeAction = () => writerStream.Dispose()
+            };
+            var container = ServiceProviderHelper.BuildServiceProvider(
+                services => services.AddSingleton<IJsonWriterFactory>(new MockJsonWriterFactory(jsonWriter)));
+            var serializer = this.CreateODataJsonValueSerializer(true, container);
+
+            serializer.WriteStreamValue(new ODataBinaryStreamValue(new MemoryStream(new byte[] { 1 })));
+
+            Assert.Equal(1, writerStream.DisposeCount);
+        }
+
         private ODataJsonValueSerializer CreateODataJsonValueSerializer(bool writingResponse, IServiceProvider serviceProvider = null)
         {
             var messageInfo = new ODataMessageInfo
@@ -398,11 +416,14 @@ namespace Microsoft.OData.Tests.Json
         {
             public bool Disposed { get; private set; } = false;
 
+            public int DisposeCount { get; private set; }
+
             protected override void Dispose(bool disposing)
             {
                 if (disposing)
                 {
                     this.Disposed = true;
+                    this.DisposeCount++;
                 }
 
                 base.Dispose(disposing);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonTextWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonTextWriterTests.cs
@@ -5,6 +5,10 @@
 //---------------------------------------------------------------------
 
 using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.OData.Json;
 using static Microsoft.OData.Json.ODataUtf8JsonWriter;
 using Xunit;
 
@@ -17,6 +21,22 @@ namespace Microsoft.OData.Core.Tests.Json
         {
             var stream = new ODataUtf8JsonTextWriter(null);
             Assert.Throws<NotSupportedException>(() => stream.Encoding);
+        }
+
+        [Fact]
+        public async Task MixedDispose_ReturnsEachRentedBufferOnce()
+        {
+            var output = new MemoryStream();
+            var jsonWriter = new ODataUtf8JsonWriter(output, false, Encoding.UTF8, leaveStreamOpen: true);
+            var arrayPool = new TrackingArrayPool<char>();
+            var textWriter = new ODataUtf8JsonTextWriter(jsonWriter, arrayPool);
+
+            await textWriter.WriteAsync('a');
+            await textWriter.DisposeAsync();
+            textWriter.Dispose();
+
+            Assert.Equal(1, arrayPool.RentCount);
+            Assert.Equal(arrayPool.RentCount, arrayPool.ReturnCount);
         }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterStreamTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterStreamTests.cs
@@ -5,6 +5,12 @@
 //---------------------------------------------------------------------
 
 using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.OData.Json;
 using static Microsoft.OData.Json.ODataUtf8JsonWriter;
 using Xunit;
 using System.IO;
@@ -75,6 +81,71 @@ namespace Microsoft.OData.Core.Tests.Json
         {
             var stream = new ODataUtf8JsonWriteStream(null);
             Assert.Throws<NotSupportedException>(() => stream.SetLength(10));
+        }
+
+        [Theory]
+        [InlineData(1, 1)]
+        [InlineData(2, 1)]
+        [InlineData(3, 0)]
+        [InlineData(2048, 1)]
+        [InlineData(2049, 2)]
+        public void DisposeTwice_ReturnsEachRentedBufferOnce(int payloadLength, int expectedRentCount)
+        {
+            var output = new MemoryStream();
+            var jsonWriter = new ODataUtf8JsonWriter(output, false, Encoding.UTF8, leaveStreamOpen: true);
+            var arrayPool = new TrackingArrayPool<byte>();
+            var stream = new ODataUtf8JsonWriteStream(jsonWriter, arrayPool);
+            byte[] payload = Enumerable.Range(0, payloadLength).Select(i => (byte)i).ToArray();
+
+            stream.Write(payload, 0, payload.Length);
+            stream.Dispose();
+            stream.Dispose();
+            jsonWriter.Flush();
+
+            Assert.Equal(Convert.ToBase64String(payload), Encoding.UTF8.GetString(output.ToArray()));
+            Assert.Equal(expectedRentCount, arrayPool.RentCount);
+            Assert.Equal(arrayPool.RentCount, arrayPool.ReturnCount);
+        }
+
+        [Fact]
+        public async Task MixedDispose_ReturnsEachRentedBufferOnce()
+        {
+            var output = new MemoryStream();
+            var jsonWriter = new ODataUtf8JsonWriter(output, false, Encoding.UTF8, leaveStreamOpen: true);
+            var arrayPool = new TrackingArrayPool<byte>();
+            var stream = new ODataUtf8JsonWriteStream(jsonWriter, arrayPool);
+
+            await stream.WriteAsync(new byte[2049], 0, 2049);
+            stream.Write(new byte[3], 0, 3);
+            await stream.DisposeAsync();
+            stream.Dispose();
+            await jsonWriter.FlushAsync();
+
+            Assert.Equal(2, arrayPool.RentCount);
+            Assert.Equal(arrayPool.RentCount, arrayPool.ReturnCount);
+        }
+    }
+
+    internal sealed class TrackingArrayPool<T> : ArrayPool<T>
+    {
+        private readonly HashSet<T[]> rentedArrays = new HashSet<T[]>();
+        private readonly HashSet<T[]> returnedArrays = new HashSet<T[]>();
+
+        public int RentCount => this.rentedArrays.Count;
+
+        public int ReturnCount => this.returnedArrays.Count;
+
+        public override T[] Rent(int minimumLength)
+        {
+            var array = new T[minimumLength];
+            this.rentedArrays.Add(array);
+            return array;
+        }
+
+        public override void Return(T[] array, bool clearArray = false)
+        {
+            Assert.Contains(array, this.rentedArrays);
+            Assert.True(this.returnedArrays.Add(array), "The same pooled array was returned more than once.");
         }
     }
 }


### PR DESCRIPTION
Make UTF-8 JSON binary and text stream disposal idempotent across synchronous and asynchronous paths. Transfer pooled buffer ownership atomically so each rented array is returned exactly once.

Let stream scope completion own writer-stream disposal and guarantee scope and input-stream cleanup when copying fails. Add regression coverage for repeated and mixed disposal, boundary payload sizes, and serializer ownership.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
