### PR TITLE
Fix #3574: Client Sum/aggregate fails on empty result set

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/DataServiceQueryProvider.cs
+++ b/src/Microsoft.OData.Client/ALinq/DataServiceQueryProvider.cs
@@ -159,7 +159,9 @@ namespace Microsoft.OData.Client
                     case SequenceMethod.MinSelector: // Mapped to a generic expression - Min(IQueryable`1<T0>, Expression`1<Func`2<T0, T1>>)->T1
                     case SequenceMethod.MaxSelector: // Mapped to a generic expression - Max(IQueryable`1<T0>, Expression`1<Func`2<T0, T1>>)->T1
                     case SequenceMethod.CountDistinctSelector: // Mapped to a generic expression - CountDistinct(IQueryable`1<T0>, Expression`1<Func`2<T0, T1>>)->Int32
-                        return ((DataServiceQuery<TElement>)query).GetValue(this.Context, this.ParseAggregateSingletonResult<TElement>);
+                        return ((DataServiceQuery<TElement>)query).GetValue(
+                            this.Context,
+                            queryResult => this.ParseAggregateSingletonResult<TElement>(queryResult, sequenceMethod));
                     default:
                         throw Error.MethodNotSupported(mce);
                 }
@@ -292,8 +294,9 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <typeparam name="TElement">The return type.</typeparam>
         /// <param name="queryResult">The query result.</param>
-        /// <returns></returns>
-        private TElement ParseAggregateSingletonResult<TElement>(QueryResult queryResult)
+        /// <param name="aggregationMethod">The aggregation sequence method that produced the request.</param>
+        /// <returns>The materialized scalar aggregate value.</returns>
+        private TElement ParseAggregateSingletonResult<TElement>(QueryResult queryResult, SequenceMethod aggregationMethod)
         {
             IDictionary<string, string> responseHeaders = new Dictionary<string, string>
             {
@@ -308,6 +311,7 @@ namespace Microsoft.OData.Client
             };
 
             ODataResource entry = default(ODataResource);
+            bool sawResourceEntry = false;
             using (ODataMessageReader messageReader = new ODataMessageReader(
                 httpWebResponseMessage, messageReaderSettings, this.Context.Format.ServiceModel))
             {
@@ -318,8 +322,14 @@ namespace Microsoft.OData.Client
                     {
                         case ODataReaderState.ResourceEnd:
                             entry = reader.Item as ODataResource;
+                            if (entry == null)
+                            {
+                                break;
+                            }
+
+                            sawResourceEntry = true;
                             IEnumerable<ODataProperty> properties = entry.Properties?.OfType<ODataProperty>();
-                            if (entry != null && properties?.Any() == true)
+                            if (properties?.Any() == true)
                             {
                                 ODataProperty aggregationProperty = properties.First();
                                 ODataUntypedValue untypedValue = aggregationProperty.Value as ODataUntypedValue;
@@ -342,8 +352,73 @@ namespace Microsoft.OData.Client
                 }
             }
 
-            // Failed to retrieve the aggregate result for whatever reason
+            if (!sawResourceEntry)
+            {
+                // The server returned an empty aggregate result set (no aggregation entry, i.e. "value": []),
+                // which happens when the input set to aggregate over is empty. Materialize the value that
+                // LINQ-to-Objects would produce for an empty sequence instead of failing.
+                return GetEmptyAggregateResult<TElement>(aggregationMethod);
+            }
+
+            // A resource entry was present but no aggregate value could be materialized from it.
+            // Preserve the original failure rather than masking a malformed/unexpected response.
             throw new DataServiceQueryException(SRResources.DataServiceRequest_FailGetValue);
+        }
+
+        /// <summary>
+        /// Gets the scalar value to return when an aggregate request yields an empty result set
+        /// (i.e. there were no rows to aggregate over), matching <see cref="System.Linq.Enumerable"/> semantics.
+        /// </summary>
+        /// <typeparam name="TElement">The return type.</typeparam>
+        /// <param name="aggregationMethod">The aggregation sequence method that produced the request.</param>
+        /// <returns>Zero for Sum/CountDistinct, null for nullable (or reference-type) Average/Min/Max; otherwise throws.</returns>
+        private static TElement GetEmptyAggregateResult<TElement>(SequenceMethod aggregationMethod)
+        {
+            switch (aggregationMethod)
+            {
+                // Sum over an empty sequence is 0, including for the nullable overloads (LINQ returns 0, not null).
+                // CountDistinct over an empty sequence is 0.
+                case SequenceMethod.SumIntSelector:
+                case SequenceMethod.SumDoubleSelector:
+                case SequenceMethod.SumDecimalSelector:
+                case SequenceMethod.SumLongSelector:
+                case SequenceMethod.SumSingleSelector:
+                case SequenceMethod.SumNullableIntSelector:
+                case SequenceMethod.SumNullableDoubleSelector:
+                case SequenceMethod.SumNullableDecimalSelector:
+                case SequenceMethod.SumNullableLongSelector:
+                case SequenceMethod.SumNullableSingleSelector:
+                case SequenceMethod.CountDistinctSelector:
+                    Type zeroType = Nullable.GetUnderlyingType(typeof(TElement)) ?? typeof(TElement);
+                    return (TElement)Convert.ChangeType(0, zeroType, System.Globalization.CultureInfo.InvariantCulture.NumberFormat);
+
+                // Average/Min/Max over an empty sequence returns null for the nullable overloads (and for
+                // reference-type Min/Max), and throws InvalidOperationException for the non-nullable value-type
+                // overloads, matching Enumerable semantics.
+                case SequenceMethod.AverageIntSelector:
+                case SequenceMethod.AverageDoubleSelector:
+                case SequenceMethod.AverageDecimalSelector:
+                case SequenceMethod.AverageLongSelector:
+                case SequenceMethod.AverageSingleSelector:
+                case SequenceMethod.AverageNullableIntSelector:
+                case SequenceMethod.AverageNullableDoubleSelector:
+                case SequenceMethod.AverageNullableDecimalSelector:
+                case SequenceMethod.AverageNullableLongSelector:
+                case SequenceMethod.AverageNullableSingleSelector:
+                case SequenceMethod.MinSelector:
+                case SequenceMethod.MaxSelector:
+                    if (Nullable.GetUnderlyingType(typeof(TElement)) != null || !typeof(TElement).IsValueType)
+                    {
+                        return default(TElement);
+                    }
+
+                    throw new InvalidOperationException(SRResources.ALinq_AggregationOnEmptyCollectionNotSupported);
+
+                default:
+                    // Any other method reaching here is unexpected; preserve the original failure semantics
+                    // rather than silently returning an empty-aggregate value.
+                    throw new DataServiceQueryException(SRResources.DataServiceRequest_FailGetValue);
+            }
         }
     }
 }

--- a/src/Microsoft.OData.Client/SRResources.Designer.cs
+++ b/src/Microsoft.OData.Client/SRResources.Designer.cs
@@ -70,6 +70,14 @@ namespace Microsoft.OData.Client {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The aggregation cannot be performed on an empty collection..
+        /// </summary>
+        internal static string ALinq_AggregationOnEmptyCollectionNotSupported {
+            get {
+                return ResourceManager.GetString("ALinq_AggregationOnEmptyCollectionNotSupported", resourceCulture);
+            }
+        }
+        /// <summary>
         ///   Looks up a localized string similar to The method &apos;{0}&apos; is not supported by the &apos;orderby&apos; query option..
         /// </summary>
         internal static string ALinq_AnyAllNotSupportedInOrderBy {

--- a/src/Microsoft.OData.Client/SRResources.resx
+++ b/src/Microsoft.OData.Client/SRResources.resx
@@ -668,6 +668,9 @@
   <data name="ALinq_AggregationMethodNotSupported" xml:space="preserve">
     <value>The aggregation method '{0}' is not supported.</value>
   </data>
+  <data name="ALinq_AggregationOnEmptyCollectionNotSupported" xml:space="preserve">
+    <value>The aggregation cannot be performed on an empty collection.</value>
+  </data>
   <data name="ALinq_InvalidAggregateExpression" xml:space="preserve">
     <value>The expression '{0}' is not a valid aggregate expression. The aggregate expression must evaluate to a single-valued property path to an aggregatable property.</value>
   </data>

--- a/test/UnitTests/Microsoft.OData.Client.Tests/ALinq/DollarApplyAggregateTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/ALinq/DollarApplyAggregateTests.cs
@@ -432,6 +432,148 @@ namespace Microsoft.OData.Client.Tests.ALinq
             Assert.Throws<NotSupportedException>(() => queryable.Take(1).Min(d => d.Amount));
         }
 
+        #region Empty Aggregate Result (Issue #3574)
+
+        [Fact]
+        public void Sum_ReturnsZero_WhenAggregateResultSetIsEmpty()
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Number>(numbersEntitySetName);
+            MockEmptyAggregateResult("SumIntProp");
+
+            // Act
+            int result = queryable.Sum(d => d.IntProp);
+
+            // Assert
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void Sum_NullableReturnsZero_WhenAggregateResultSetIsEmpty()
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Number>(numbersEntitySetName);
+            MockEmptyAggregateResult("SumNullableDecimalProp");
+
+            // Act
+            decimal? result = queryable.Sum(d => d.NullableDecimalProp);
+
+            // Assert
+            // LINQ-to-Objects returns 0 (not null) for Sum over an empty nullable sequence.
+            Assert.Equal(0m, result);
+        }
+
+        [Fact]
+        public void CountDistinct_ReturnsZero_WhenAggregateResultSetIsEmpty()
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Number>(numbersEntitySetName);
+            MockEmptyAggregateResult("CountDistinctRowParity");
+
+            // Act
+            int result = queryable.CountDistinct(d => d.RowParity);
+
+            // Assert
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void Average_NullableReturnsNull_WhenAggregateResultSetIsEmpty()
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Number>(numbersEntitySetName);
+            MockEmptyAggregateResult("AverageNullableDoubleProp");
+
+            // Act
+            double? result = queryable.Average(d => d.NullableDoubleProp);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Max_NullableReturnsNull_WhenAggregateResultSetIsEmpty()
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Number>(numbersEntitySetName);
+            MockEmptyAggregateResult("MaxNullableLongProp");
+
+            // Act
+            long? result = queryable.Max(d => d.NullableLongProp);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Average_NonNullableThrows_WhenAggregateResultSetIsEmpty()
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Number>(numbersEntitySetName);
+            MockEmptyAggregateResult("AverageDoubleProp");
+
+            // Act & Assert
+            // LINQ-to-Objects throws InvalidOperationException for a non-nullable Average over an empty sequence.
+            // The client surfaces it wrapped in a DataServiceQueryException.
+            var exception = Assert.Throws<DataServiceQueryException>(() => queryable.Average(d => d.DoubleProp));
+            Assert.IsType<InvalidOperationException>(exception.InnerException);
+        }
+
+        [Fact]
+        public void Min_NonNullableThrows_WhenAggregateResultSetIsEmpty()
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Number>(numbersEntitySetName);
+            MockEmptyAggregateResult("MinDecimalProp");
+
+            // Act & Assert
+            var exception = Assert.Throws<DataServiceQueryException>(() => queryable.Min(d => d.DecimalProp));
+            Assert.IsType<InvalidOperationException>(exception.InnerException);
+        }
+
+        [Fact]
+        public void Max_NonNullableThrows_WhenAggregateResultSetIsEmpty()
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Number>(numbersEntitySetName);
+            MockEmptyAggregateResult("MaxDoubleProp");
+
+            // Act & Assert
+            var exception = Assert.Throws<DataServiceQueryException>(() => queryable.Max(d => d.DoubleProp));
+            Assert.IsType<InvalidOperationException>(exception.InnerException);
+        }
+
+        [Fact]
+        public void Sum_ThrowsFailGetValue_WhenResultSetHasEntryWithoutAggregateValue()
+        {
+            // Arrange
+            // A non-empty result set whose entry carries no usable aggregate property is a malformed/unexpected
+            // response. It must NOT be treated as an empty aggregate result (which would silently return 0);
+            // the original FailGetValue error must be preserved.
+            var queryable = this.dsContext.CreateQuery<Number>(numbersEntitySetName);
+            string mockResponse = string.Format(
+                "{{\"@odata.context\":\"{0}/$metadata#{1}(SumIntProp)\",\"value\":[{{}}]}}",
+                serviceUri,
+                numbersEntitySetName);
+            InterceptRequestAndMockResponse(mockResponse);
+
+            // Act & Assert
+            Assert.Throws<DataServiceQueryException>(() => queryable.Sum(d => d.IntProp));
+        }
+
+        private void MockEmptyAggregateResult(string aggregateAlias)
+        {
+            string mockResponse = string.Format(
+                "{{\"@odata.context\":\"{0}/$metadata#{1}({2})\",\"value\":[]}}",
+                serviceUri,
+                numbersEntitySetName,
+                aggregateAlias);
+
+            InterceptRequestAndMockResponse(mockResponse);
+        }
+
+        #endregion Empty Aggregate Result (Issue #3574)
+
         #region Mock Aggregation Responses
 
         private void MockCountDistinct()

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Resources/SRResourcesTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Resources/SRResourcesTests.cs
@@ -15,6 +15,7 @@ public class SRResourcesTests
 {
     [Theory]
     [InlineData("ALinq_AggregationMethodNotSupported", new object[] { "Value" })]
+    [InlineData("ALinq_AggregationOnEmptyCollectionNotSupported", new object[] { })]
     [InlineData("ALinq_AnyAllNotSupportedInOrderBy", new object[] { "Value" })]
     [InlineData("ALinq_BinaryNotSupported", new object[] { "Value" })]
     [InlineData("ALinq_CannotAddCountOption", new object[] { })]


### PR DESCRIPTION
Handle genuinely empty aggregate result sets using LINQ-to-Objects semantics: Sum and CountDistinct return zero, nullable Average/Min/Max return null, and non-nullable Average/Min/Max surface an InvalidOperationException through DataServiceQueryException.

Preserve main's existing ODataUntypedValue conversion for non-empty results, and continue failing malformed entries that contain no aggregate value. Add focused coverage for empty and malformed aggregate responses.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3574.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
