### PR TITLE
Fix #729: Correct referential constraint examples

### DIFF
--- a/v6/_posts/core libraries/2016-01-13-17-36-define-referential-constraints.md
+++ b/v6/_posts/core libraries/2016-01-13-17-36-define-referential-constraints.md
@@ -29,31 +29,29 @@ order.AddKeys(orderCustomerId, orderOrderId);
 model.AddElement(order);
 {% endhighlight %}
 
-`Customer.id` is the principal property while `Order.customerId` is the dependent property. Create a navigation property `orders` on the principal entity type `customer`.
+`Customer.id` is the principal property while `Order.customerId` is the dependent property. Create a bidirectional navigation relationship between the principal entity type `customer` and the dependent entity type `order`. Define the referential constraint on the partner navigation property declared on `order`.
 
 {% highlight csharp %}
-var customerOrders = customer.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
-{
-    ContainsTarget = true,
-    Name = "orders",
-    Target = order,
-    TargetMultiplicity = EdmMultiplicity.Many
-});
+var customerOrders = customer.AddBidirectionalNavigation(
+    new EdmNavigationPropertyInfo
+    {
+        ContainsTarget = true,
+        Name = "orders",
+        Target = order,
+        TargetMultiplicity = EdmMultiplicity.Many
+    },
+    new EdmNavigationPropertyInfo
+    {
+        ContainsTarget = false,
+        Name = "customer",
+        Target = customer,
+        TargetMultiplicity = EdmMultiplicity.One,
+        DependentProperties = new[] { orderCustomerId },
+        PrincipalProperties = new[] { customerId }
+    });
 {% endhighlight %}
 
-Then, create its corresponding partner navigation property on the dependent entity type `order` with referential constraint.
-
-{% highlight csharp %}
-var orderCustomer = order.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
-{
-    ContainsTarget = false,
-    Name = "customer",
-    Target = customer,
-    TargetMultiplicity = EdmMultiplicity.One,
-    DependentProperties = new[] { orderCustomerId },
-    PrincipalProperties = new[] { customerId }
-});
-{% endhighlight %}
+`AddBidirectionalNavigation` creates both navigation properties and links them as partners. Calling `AddUnidirectionalNavigation` separately for each direction does not establish a partner relationship, so shortened key predicates cannot use the referential constraint from the reverse navigation.
 
 Create an entity type `Test.Detail` with a composite key consisting of three key properties `customerId` of `Edm.String`, `orderId` of `Edm.String` and `id` of `Edm.Int32`.
 
@@ -76,33 +74,27 @@ Come back to the type `Test.Detail`. There are two referential constraints here:
  - `DetailedOrder.orderId` is the principal property while `Detail.orderId` is the dependent property.
  - `DetailedOrder.customerId` is the principal property while `Detail.customerId` is the dependent property.
 
-Create a navigation property `details`.
+Create a bidirectional navigation relationship between `DetailedOrder` and `Detail`, with the referential constraints defined on the partner navigation property declared on `Detail`.
 
 {% highlight csharp %}
-var detailedOrderDetails = detailedOrder.AddUnidirectionalNavigation(
+var detailedOrderDetails = detailedOrder.AddBidirectionalNavigation(
     new EdmNavigationPropertyInfo
     {
         ContainsTarget = true,
-        Name = "details"
+        Name = "details",
         Target = detail,
         TargetMultiplicity = EdmMultiplicity.Many
-    });
-model.AddElement(detailedOrder);
-{% endhighlight %}
-
-Then, create its corresponding partner navigation property on the dependent entity type `detail` with referential constraint.
-
-{% highlight csharp %}
-var detailDetailedOrder = detail.AddUnidirectionalNavigation(
+    },
     new EdmNavigationPropertyInfo
     {
         ContainsTarget = false,
-        Name = "detailedOrder"
+        Name = "detailedOrder",
         Target = detailedOrder,
         TargetMultiplicity = EdmMultiplicity.One,
         DependentProperties = new[] { detailOrderId, detailCustomerId },
         PrincipalProperties = new[] { orderOrderId, orderCustomerId }
     });
+model.AddElement(detailedOrder);
 {% endhighlight %}
 
 Please note that you should **NOT** specify `Customer.id` as the principal property because the association (represented by the navigation property `details`) is from `DetailedOrder` to `Detail` rather than from `Customer` to `Detail`. And those properties must be specified **in the same order**.

--- a/v7/_posts/core libraries/2016-01-13-02-10-define-referential-constraints.md
+++ b/v7/_posts/core libraries/2016-01-13-02-10-define-referential-constraints.md
@@ -28,31 +28,29 @@ order.AddKeys(orderCustomerId, orderOrderId);
 model.AddElement(order);
 {% endhighlight %}
 
-`Customer.id` is the principal property while `Order.customerId` is the dependent property. Create a navigation property `orders` on the principal entity type `Customer`.
+`Customer.id` is the principal property while `Order.customerId` is the dependent property. Create a bidirectional navigation relationship between the principal entity type `Customer` and the dependent entity type `Order`. Define the referential constraint on the partner navigation property declared on `Order`.
 
 {% highlight csharp %}
-var customerOrders = customer.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
-{
-    ContainsTarget = true,
-    Name = "orders",
-    Target = order,
-    TargetMultiplicity = EdmMultiplicity.Many
-});
+var customerOrders = customer.AddBidirectionalNavigation(
+    new EdmNavigationPropertyInfo
+    {
+        ContainsTarget = true,
+        Name = "orders",
+        Target = order,
+        TargetMultiplicity = EdmMultiplicity.Many
+    },
+    new EdmNavigationPropertyInfo
+    {
+        ContainsTarget = false,
+        Name = "customer",
+        Target = customer,
+        TargetMultiplicity = EdmMultiplicity.One,
+        DependentProperties = new[] { orderCustomerId },
+        PrincipalProperties = new[] { customerId }
+    });
 {% endhighlight %}
 
-Then, create its corresponding partner navigation property on the dependent entity type `Order` with referential constraint.
-
-{% highlight csharp %}
-var orderCustomer = order.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
-{
-    ContainsTarget = false,
-    Name = "customer",
-    Target = customer,
-    TargetMultiplicity = EdmMultiplicity.One,
-    DependentProperties = new[] { orderCustomerId },
-    PrincipalProperties = new[] { customerId }
-});
-{% endhighlight %}
+`AddBidirectionalNavigation` creates both navigation properties and links them as partners. Calling `AddUnidirectionalNavigation` separately for each direction does not establish a partner relationship, so shortened key predicates cannot use the referential constraint from the reverse navigation.
 
 Create an entity type `Test.Detail` with a composite key consisting of three key properties `customerId` of type `Edm.String`, `orderId` of type `Edm.String`, and `id` of type `Edm.Int32`.
 
@@ -75,24 +73,17 @@ Come back to the type `Test.Detail`. There are two referential constraints here:
 - `DetailedOrder.orderId` is the principal property while `Detail.orderId` is the dependent property.
 - `DetailedOrder.customerId` is the principal property while `Detail.customerId` is the dependent property.
 
-Create a navigation property `details`.
+Create a bidirectional navigation relationship between `DetailedOrder` and `Detail`, with the referential constraints defined on the partner navigation property declared on `Detail`.
 
 {% highlight csharp %}
-var detailedOrderDetails = detailedOrder.AddUnidirectionalNavigation(
+var detailedOrderDetails = detailedOrder.AddBidirectionalNavigation(
     new EdmNavigationPropertyInfo
     {
         ContainsTarget = true,
         Name = "details",
         Target = detail,
         TargetMultiplicity = EdmMultiplicity.Many
-    });
-model.AddElement(detailedOrder);
-{% endhighlight %}
-
-Then, create its corresponding partner navigation property on the dependent entity type `Detail` with referential constraint.
-
-{% highlight csharp %}
-var detailDetailedOrder = detail.AddUnidirectionalNavigation(
+    },
     new EdmNavigationPropertyInfo
     {
         ContainsTarget = false,
@@ -102,6 +93,7 @@ var detailDetailedOrder = detail.AddUnidirectionalNavigation(
         DependentProperties = new[] { detailOrderId, detailCustomerId },
         PrincipalProperties = new[] { orderOrderId, orderCustomerId }
     });
+model.AddElement(detailedOrder);
 {% endhighlight %}
 
 Please note that you should **NOT** specify `Customer.id` as the principal property because the association (represented by the navigation property `details`) is from `DetailedOrder` to `Detail` rather than from `Customer` to `Detail`. And those properties must be specified **in the order shown**.


### PR DESCRIPTION
The V6 and V7 referential-constraint examples created two independent
navigation properties with `AddUnidirectionalNavigation` and described them as
partners. Because these properties are not linked, `KeyFinder` cannot discover
the reverse navigation's referential constraint when parsing shortened
composite-key URLs.

This change:

- Uses `AddBidirectionalNavigation` to create actual navigation partners.
- Keeps referential constraints on the dependent-to-principal navigation.
- Explains why separate unidirectional navigations do not support shortened key
  predicates.
- Fixes missing commas in the V6 code sample.

No product behavior changes are required; existing parser tests cover
partner-based key propagation.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #729.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
