### PR TITLE
Fix #3606: Avoid allocations in ODataPath equality

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPath.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPath.cs
@@ -216,7 +216,16 @@ namespace Microsoft.OData.UriParser
                 return false;
             }
 
-            return !this.segments.Where((t, i) => !t.Equals(other.segments[i])).Any();
+            int segmentsCount = this.segments.Count;
+            for (int index = 0; index < segmentsCount; index++)
+            {
+                if (!this.segments[index].Equals(other.segments[index]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/ODataPathTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/ODataPathTests.cs
@@ -68,6 +68,58 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         }
 
         [Fact]
+        public void EmptyPathsAreEqual()
+        {
+            Assert.True(new ODataPath().Equals(new ODataPath()));
+        }
+
+        [Fact]
+        public void EqualsThrowsForNullPath()
+        {
+            ODataPath path = new ODataPath(MetadataSegment.Instance);
+
+            Assert.Throws<ArgumentNullException>("other", () => path.Equals((ODataPath)null));
+        }
+
+        [Fact]
+        public void PathsWithMultipleEquivalentSegmentsAreEqual()
+        {
+            ODataPath first = new ODataPath(
+                new DynamicPathSegment("first"),
+                new DynamicPathSegment("middle"),
+                new DynamicPathSegment("last"));
+            ODataPath second = new ODataPath(
+                new DynamicPathSegment("first"),
+                new DynamicPathSegment("middle"),
+                new DynamicPathSegment("last"));
+
+            Assert.True(first.Equals(second));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void PathsWithMismatchAtAnyPositionAreNotEqual(int mismatchIndex)
+        {
+            ODataPathSegment[] firstSegments =
+            {
+                new DynamicPathSegment("first"),
+                new DynamicPathSegment("middle"),
+                new DynamicPathSegment("last")
+            };
+            ODataPathSegment[] secondSegments =
+            {
+                new DynamicPathSegment("first"),
+                new DynamicPathSegment("middle"),
+                new DynamicPathSegment("last")
+            };
+            secondSegments[mismatchIndex] = new DynamicPathSegment("different");
+
+            Assert.False(new ODataPath(firstSegments).Equals(new ODataPath(secondSegments)));
+        }
+
+        [Fact]
         public void PathsShouldNotAllowSegmentsToBeNull()
         {
             Action createWithNull = () => new ODataPath((IEnumerable<ODataPathSegment>)null);


### PR DESCRIPTION
Replace the indexed LINQ query with a direct segment loop while preserving null validation, length checks, ordered comparison, and first-mismatch short-circuiting.

Add coverage for empty paths, null input, multiple equivalent segments, and mismatches at the first, middle, and last positions.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
