### PR TITLE
Fix async APIs for WebAssembly compatibility

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceActionQuerySingleOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceActionQuerySingleOfT.cs
@@ -78,9 +78,12 @@ namespace Microsoft.OData.Client
         /// <summary>Asynchronously sends the request so that this call does not block processing while waiting for the results from the service.</summary>
         /// <returns>A task represents the result of the operation. </returns>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        public Task<T> GetValueAsync(CancellationToken cancellationToken)
+        public async Task<T> GetValueAsync(CancellationToken cancellationToken)
         {
-            return this.context.FromAsync(this.BeginGetValue, this.EndGetValue, cancellationToken);
+            IEnumerable<T> result = await context.ExecuteAsync<T>(this.RequestUri, XmlConstants.HttpMethodPost, true, cancellationToken, parameters)
+                .ConfigureAwait(false);
+
+            return ClientTypeUtil.CanAssignNull(typeof(T)) ? result.SingleOrDefault() : result.Single();
         }
 
         /// <summary>Called to complete the <see cref="Microsoft.OData.Client.DataServiceActionQuery{T}.BeginExecute(AsyncCallback,Object)" />.</summary>

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -1200,6 +1200,7 @@ namespace Microsoft.OData.Client
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public virtual async Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, DataServiceQueryContinuation continuation, CancellationToken cancellationToken)
         {
+            Util.CheckArgumentNull(continuation, "continuation");
             LoadPropertyResult result = this.CreateLoadPropertyRequest(entity, propertyName, callback: null, state: null, requestUri: null, continuation);
             await result.ExecuteQueryAsync(cancellationToken).ConfigureAwait(false);
 
@@ -1717,12 +1718,14 @@ namespace Microsoft.OData.Client
         /// <param name="queries">The array of query requests to include in the batch request.</param>
         public virtual async Task<DataServiceResponse> ExecuteBatchAsync(SaveChangesOptions options, CancellationToken cancellationToken, params DataServiceRequest[] queries)
         {
+            Util.CheckArgumentNotEmpty(queries, "queries");
+
             if (!Util.IsBatch(options))
             {
                 throw new InvalidOperationException();
             }
 
-            BatchSaveResult result = new BatchSaveResult(this, "ExecuteBatchAsync", queries, options, null, null);
+            BatchSaveResult result = new BatchSaveResult(this, "ExecuteBatch", queries, options, null, null);
             await result.BatchRequestAsync(cancellationToken).ConfigureAwait(false);
 
             return result.EndRequest();
@@ -2157,7 +2160,7 @@ namespace Microsoft.OData.Client
             DataServiceResponse errors = null;
             this.ValidateSaveChangesOptions(options);
 
-            BaseSaveResult result = BaseSaveResult.CreateSaveResult(this, "SaveChangesAsync", null, options, null, null);
+            BaseSaveResult result = BaseSaveResult.CreateSaveResult(this, Util.SaveChangesMethodName, null, options, null, null);
             if (result.IsBatchRequest)
             {
                 await ((BatchSaveResult)result).BatchRequestAsync(cancellationToken).ConfigureAwait(false);
@@ -2277,7 +2280,7 @@ namespace Microsoft.OData.Client
                 throw Error.Argument(SRResources.Util_EmptyArray, nameof(objects));
             }
 
-            BulkUpdateSaveResult result = new BulkUpdateSaveResult(this, "BulkUpdateAsync", SaveChangesOptions.BulkUpdate, null, null);
+            BulkUpdateSaveResult result = new BulkUpdateSaveResult(this, Util.BulkUpdateMethodName, SaveChangesOptions.BulkUpdate, null, null);
             await result.BulkUpdateRequestAsync(cancellationToken, objects).ConfigureAwait(false);
 
             return result.EndRequest();
@@ -2348,14 +2351,14 @@ namespace Microsoft.OData.Client
         /// <typeparam name="T">The type of top-level object to be deep inserted.</typeparam>
         /// <param name="resource">The top-level object of the type to be deep inserted.</param>
         /// <returns>A task representing the <see cref="DataServiceResponse"/> that holds the result of the deep insert operation.</returns>
-        public async virtual Task<DataServiceResponse> DeepInsertAsync<T>(T resource, CancellationToken cancellationToken)
+        public virtual async Task<DataServiceResponse> DeepInsertAsync<T>(T resource, CancellationToken cancellationToken)
         {
             if (resource == null)
             {
                 throw Error.ArgumentNull(nameof(resource));
             }
 
-            DeepInsertSaveResult result = new DeepInsertSaveResult(this, "DeepInsertAsync", SaveChangesOptions.DeepInsert, callback: null, state: null);
+            DeepInsertSaveResult result = new DeepInsertSaveResult(this, Util.DeepInsertMethodName, SaveChangesOptions.DeepInsert, callback: null, state: null);
             await result.DeepInsertRequestAsync(resource, cancellationToken).ConfigureAwait(false);
 
             return result.EndRequest();

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -1121,9 +1121,12 @@ namespace Microsoft.OData.Client
         /// <param name="entity">The entity that contains the property to load.</param>
         /// <param name="propertyName">The name of the property on the specified entity to load.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        public virtual Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, CancellationToken cancellationToken)
+        public virtual async Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, CancellationToken cancellationToken)
         {
-            return this.FromAsync(this.BeginLoadProperty, this.EndLoadProperty, entity, propertyName, cancellationToken);
+            LoadPropertyResult result = this.CreateLoadPropertyRequest(entity, propertyName, callback: null, state: null, requestUri: null, continuation: null);
+            await result.ExecuteQueryAsync(cancellationToken).ConfigureAwait(false);
+
+            return result.LoadProperty();
         }
 
         /// <summary>Asynchronously loads a page of related entities from the data service by using the supplied next link URI.</summary>
@@ -1156,9 +1159,12 @@ namespace Microsoft.OData.Client
         /// <param name="propertyName">The name of the property on the specified entity to load.</param>
         /// <param name="nextLinkUri">The URI used to load the next results page.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        public virtual Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, Uri nextLinkUri, CancellationToken cancellationToken)
+        public virtual async Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, Uri nextLinkUri, CancellationToken cancellationToken)
         {
-            return this.FromAsync(this.BeginLoadProperty, this.EndLoadProperty, entity, propertyName, nextLinkUri, cancellationToken);
+            LoadPropertyResult result = this.CreateLoadPropertyRequest(entity, propertyName, callback: null, state: null, nextLinkUri, continuation: null);
+            await result.ExecuteQueryAsync(cancellationToken).ConfigureAwait(false);
+
+            return result.LoadProperty();
         }
 
         /// <summary>Asynchronously loads the next page of related entities from the data service by using the supplied query continuation object.</summary>
@@ -1192,9 +1198,12 @@ namespace Microsoft.OData.Client
         /// <param name="propertyName">The name of the property on the specified entity to load.</param>
         /// <param name="continuation">A <see cref="Microsoft.OData.Client.DataServiceQueryContinuation{T}" /> object that represents the next page of related entity data to return from the data service.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        public virtual Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, DataServiceQueryContinuation continuation, CancellationToken cancellationToken)
+        public virtual async Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, DataServiceQueryContinuation continuation, CancellationToken cancellationToken)
         {
-            return this.FromAsync(this.BeginLoadProperty, this.EndLoadProperty, entity, propertyName, continuation, cancellationToken);
+            LoadPropertyResult result = this.CreateLoadPropertyRequest(entity, propertyName, callback: null, state: null, requestUri: null, continuation);
+            await result.ExecuteQueryAsync(cancellationToken).ConfigureAwait(false);
+
+            return result.LoadProperty();
         }
 
         /// <summary>Called to complete the <see cref="Microsoft.OData.Client.DataServiceContext.BeginLoadProperty(System.Object,System.String,System.AsyncCallback,System.Object)" /> operation.</summary>
@@ -1403,9 +1412,11 @@ namespace Microsoft.OData.Client
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <exception cref="System.ArgumentNullException">Any of the parameters supplied to the method is null.</exception>
         /// <exception cref="System.ArgumentException">The <paramref name="entity" /> is not tracked by this <see cref="Microsoft.OData.Client.DataServiceContext" />.-or-The <paramref name="entity" /> is in the <see cref="Microsoft.OData.Client.EntityStates.Added" /> state.-or-The <paramref name="entity" /> is not a Media Link Entry and does not have a related binary data stream.</exception>
-        public virtual Task<DataServiceStreamResponse> GetReadStreamAsync(object entity, DataServiceRequestArgs args, CancellationToken cancellationToken)
+        public virtual async Task<DataServiceStreamResponse> GetReadStreamAsync(object entity, DataServiceRequestArgs args, CancellationToken cancellationToken)
         {
-            return this.FromAsync(this.BeginGetReadStream, this.EndGetReadStream, entity, args, cancellationToken);
+            GetReadStreamResult result = this.CreateGetReadStreamResult(entity, args, callback: null, state: null, name: null);
+
+            return await result.ExecuteAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously gets a named binary data stream that belongs to the specified entity, by using the specified message headers.</summary>
@@ -1440,9 +1451,14 @@ namespace Microsoft.OData.Client
         /// <param name="name">The name of the binary stream to request.</param>
         /// <param name="args">Instance of the <see cref="Microsoft.OData.Client.DataServiceRequestArgs" /> class that contains settings for the HTTP request message.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        public virtual Task<DataServiceStreamResponse> GetReadStreamAsync(object entity, string name, DataServiceRequestArgs args, CancellationToken cancellationToken)
+        public virtual async Task<DataServiceStreamResponse> GetReadStreamAsync(object entity, string name, DataServiceRequestArgs args, CancellationToken cancellationToken)
         {
-            return this.FromAsync(this.BeginGetReadStream, this.EndGetReadStream, entity, name, args, cancellationToken);
+            Util.CheckArgumentNullAndEmpty(name, "name");
+
+            this.EnsureMinimumProtocolVersionV3();
+            GetReadStreamResult result = this.CreateGetReadStreamResult(entity, args, callback: null, state: null, name);
+
+            return await result.ExecuteAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Called to complete the asynchronous operation of retrieving a binary data stream.</summary>
@@ -1699,14 +1715,17 @@ namespace Microsoft.OData.Client
         /// <param name="options">A member of the <see cref="Microsoft.OData.Client.SaveChangesOptions" /> enumeration for how the client can save the pending set of changes.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="queries">The array of query requests to include in the batch request.</param>
-        public virtual Task<DataServiceResponse> ExecuteBatchAsync(SaveChangesOptions options, CancellationToken cancellationToken, params DataServiceRequest[] queries)
+        public virtual async Task<DataServiceResponse> ExecuteBatchAsync(SaveChangesOptions options, CancellationToken cancellationToken, params DataServiceRequest[] queries)
         {
             if (!Util.IsBatch(options))
             {
                 throw new InvalidOperationException();
             }
 
-            return this.FromAsync((callback, state) => this.BeginExecuteBatch(callback, state, options, queries), this.EndExecuteBatch, cancellationToken);
+            BatchSaveResult result = new BatchSaveResult(this, "ExecuteBatchAsync", queries, options, null, null);
+            await result.BatchRequestAsync(cancellationToken).ConfigureAwait(false);
+
+            return result.EndRequest();
         }
 
         /// <summary>Called to complete the <see cref="Microsoft.OData.Client.DataServiceContext.BeginExecuteBatch(System.AsyncCallback,System.Object,Microsoft.OData.Client.DataServiceRequest[])" />.</summary>
@@ -2133,9 +2152,31 @@ namespace Microsoft.OData.Client
         /// <returns>A task that represents a <see cref="Microsoft.OData.Client.DataServiceResponse" /> object that indicates the result of the batch operation.</returns>
         /// <param name="options">A member of the <see cref="Microsoft.OData.Client.SaveChangesOptions" /> enumeration for how the client can save the pending set of changes.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        public virtual Task<DataServiceResponse> SaveChangesAsync(SaveChangesOptions options, CancellationToken cancellationToken)
+        public virtual async Task<DataServiceResponse> SaveChangesAsync(SaveChangesOptions options, CancellationToken cancellationToken)
         {
-            return FromAsync(this.BeginSaveChanges, this.EndSaveChanges, options, cancellationToken);
+            DataServiceResponse errors = null;
+            this.ValidateSaveChangesOptions(options);
+
+            BaseSaveResult result = BaseSaveResult.CreateSaveResult(this, "SaveChangesAsync", null, options, null, null);
+            if (result.IsBatchRequest)
+            {
+                await ((BatchSaveResult)result).BatchRequestAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await ((SaveResult)result).CreateNextChangeAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            errors = result.EndRequest();
+
+            Debug.Assert(errors != null, "null errors");
+
+            if (this.ChangesSaved != null)
+            {
+                this.ChangesSaved(this, new SaveChangesEventArgs(errors));
+            }
+
+            return errors;
         }
 
         /// <summary>Called to complete the <see cref="Microsoft.OData.Client.DataServiceContext.BeginSaveChanges(System.AsyncCallback,System.Object)" /> operation.</summary>
@@ -2229,9 +2270,17 @@ namespace Microsoft.OData.Client
         /// <typeparam name="T">The type of top-level objects to be deep updated.</typeparam>
         /// <param name="objects">The top-level objects of the type to be deep updated.</param>
         /// <returns>A task representing the <see cref="DataServiceResponse"/> that holds the result of a bulk operation.</returns>
-        public virtual Task<DataServiceResponse> BulkUpdateAsync<T>(CancellationToken cancellationToken, params T[] objects)
+        public virtual async Task<DataServiceResponse> BulkUpdateAsync<T>(CancellationToken cancellationToken, params T[] objects)
         {
-            return FromAsync((objectsArg, callback, state) => BeginBulkUpdate(callback, state, objectsArg), EndBulkUpdate, objects, cancellationToken);
+            if (objects == null || objects.Length == 0)
+            {
+                throw Error.Argument(SRResources.Util_EmptyArray, nameof(objects));
+            }
+
+            BulkUpdateSaveResult result = new BulkUpdateSaveResult(this, "BulkUpdateAsync", SaveChangesOptions.BulkUpdate, null, null);
+            await result.BulkUpdateRequestAsync(cancellationToken, objects).ConfigureAwait(false);
+
+            return result.EndRequest();
         }
 
         /// <summary>Asynchronously submits top-level objects to be deep-updated to the data service.</summary>
@@ -2299,9 +2348,17 @@ namespace Microsoft.OData.Client
         /// <typeparam name="T">The type of top-level object to be deep inserted.</typeparam>
         /// <param name="resource">The top-level object of the type to be deep inserted.</param>
         /// <returns>A task representing the <see cref="DataServiceResponse"/> that holds the result of the deep insert operation.</returns>
-        public virtual Task<DataServiceResponse> DeepInsertAsync<T>(T resource, CancellationToken cancellationToken)
+        public async virtual Task<DataServiceResponse> DeepInsertAsync<T>(T resource, CancellationToken cancellationToken)
         {
-            return FromAsync((objectsArg, callback, state) => BeginDeepInsert(callback, state, objectsArg), EndDeepInsert, resource, cancellationToken);
+            if (resource == null)
+            {
+                throw Error.ArgumentNull(nameof(resource));
+            }
+
+            DeepInsertSaveResult result = new DeepInsertSaveResult(this, "DeepInsertAsync", SaveChangesOptions.DeepInsert, callback: null, state: null);
+            await result.DeepInsertRequestAsync(resource, cancellationToken).ConfigureAwait(false);
+
+            return result.EndRequest();
         }
 
         /// <summary>Asynchronously submits top-level objects to be deep inserted to the data service.</summary>
@@ -3140,14 +3197,18 @@ namespace Microsoft.OData.Client
         /// <param name="propertyName">The name of the property of the specified entity to load.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>An object representing an asynchronous operation resulting in an instance of <see cref="Microsoft.OData.Client.QueryOperationResponse{T}" /> that contains the results of the last page request.</returns>
-        [SuppressMessage("Reliability", "CA2008:Do not create tasks without passing a TaskScheduler", Justification = "<Pending>")]
-        internal Task<QueryOperationResponse> LoadPropertyAllPagesAsync(object entity, string propertyName, CancellationToken cancellationToken)
+        internal async Task<QueryOperationResponse> LoadPropertyAllPagesAsync(object entity, string propertyName, CancellationToken cancellationToken)
         {
-            var currentTask = this.FromAsync(this.BeginLoadProperty, this.EndLoadProperty, entity, propertyName, cancellationToken);
+            QueryOperationResponse response = await LoadPropertyAsync(entity, propertyName, cancellationToken).ConfigureAwait(false);
 
-            return currentTask.ContinueWith(
-                t => ContinuePageAsync(t.Result, entity, propertyName, cancellationToken),
-                cancellationToken).Unwrap();
+            DataServiceQueryContinuation continuation = response.GetContinuation();
+            while (continuation != null)
+            {
+                response = await LoadPropertyAsync(entity, propertyName, continuation, cancellationToken).ConfigureAwait(false);
+                continuation = response.GetContinuation();
+            }
+
+            return response;
         }
 
         /// <summary>
@@ -3631,40 +3692,6 @@ namespace Microsoft.OData.Client
             }
 
             return response;
-        }
-
-        [SuppressMessage("Reliability", "CA2008:Do not create tasks without passing a TaskScheduler", Justification = "<Pending>")]
-        private Task<QueryOperationResponse> ContinuePageAsync(QueryOperationResponse response, object entity, string propertyName, CancellationToken cancellationToken)
-        {
-            var continuation = response.GetContinuation();
-            if (continuation != null)
-            {
-                IAsyncResult beginLoadPropertyResult = this.BeginLoadProperty(entity, propertyName, continuation, null, null);
-
-                // Dispose the cancellation registration once the request completes so it is removed
-                // from the (potentially long-lived) token source, otherwise the captured async result
-                // is kept alive for every page, leaking memory (issue #3583).
-                CancellationTokenRegistration registration = cancellationToken.Register(() => this.CancelRequest(beginLoadPropertyResult));
-                var currentTask = Task<QueryOperationResponse>.Factory.FromAsync(beginLoadPropertyResult, this.EndLoadProperty);
-
-                // Schedule the disposal/continuation with CancellationToken.None so it always runs
-                // even when the token is already canceled; otherwise the continuation could be
-                // skipped and the registration would never be disposed (and stay rooted in a
-                // long-lived token source).
-                return currentTask.ContinueWith(
-                    t =>
-                    {
-                        registration.Dispose();
-                        return this.ContinuePageAsync(t.Result, entity, propertyName, cancellationToken);
-                    },
-                    CancellationToken.None,
-                    TaskContinuationOptions.ExecuteSynchronously,
-                    TaskScheduler.Default).Unwrap();
-            }
-
-            var taskSource = new TaskCompletionSource<QueryOperationResponse>();
-            taskSource.SetResult(response);
-            return taskSource.Task;
         }
 
         /// <summary

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/CancellationTokenTests/Tests/CancellationTokenTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/CancellationTokenTests/Tests/CancellationTokenTests.cs
@@ -76,8 +76,8 @@ public class CancellationTokenTests : EndToEndTestBase<CancellationTokenTests.Te
 
         Task response() => _context.SaveChangesAsync(source.Token);
         source.Cancel();
-        var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
-        Assert.Equal("The operation was canceled.", exception.Message);
+        var exception = await Assert.ThrowsAsync<TaskCanceledException>(response);
+        Assert.Equal("A task was canceled.", exception.Message);
 
         // SaveChangesAsync with SaveChangesOptions
         var c2 = new Customer { CustomerId = 22, Name = "customerTwo" };
@@ -87,8 +87,8 @@ public class CancellationTokenTests : EndToEndTestBase<CancellationTokenTests.Te
 
         Task response2() => _context.SaveChangesAsync(SaveChangesOptions.BatchWithIndependentOperations, source.Token);
         source.Cancel();
-        var exception2 = await Assert.ThrowsAsync<OperationCanceledException>(response2);
-        Assert.Equal("The operation was canceled.", exception2.Message);
+        var exception2 = await Assert.ThrowsAsync<TaskCanceledException>(response2);
+        Assert.Equal("A task was canceled.", exception2.Message);
     }
 
     #endregion
@@ -208,8 +208,8 @@ public class CancellationTokenTests : EndToEndTestBase<CancellationTokenTests.Te
 
         Task response() => _context.LoadPropertyAsync(c1, "Orders", source.Token);
         source.Cancel();
-        var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
-        Assert.Equal("The operation was canceled.", exception.Message);
+        var exception = await Assert.ThrowsAsync<TaskCanceledException>(response);
+        Assert.Equal("A task was canceled.", exception.Message);
 
         //Get Entity by DataServiceQuery.ExecuteAsync
         var query = _context.Customers.Expand(c => c.Orders).Where(c => c.CustomerId == 11) as DataServiceQuery<Customer>;
@@ -222,13 +222,13 @@ public class CancellationTokenTests : EndToEndTestBase<CancellationTokenTests.Te
         var continuation = resp.GetContinuation(customer.Orders);
         Task response2() => _context.LoadPropertyAsync(customer, "Orders", continuation, source.Token);
         source.Cancel();
-        var exception2 = await Assert.ThrowsAsync<OperationCanceledException>(response2);
-        Assert.Equal("The operation was canceled.", exception2.Message);
+        var exception2 = await Assert.ThrowsAsync<TaskCanceledException>(response2);
+        Assert.Equal("A task was canceled.", exception2.Message);
 
         Task response3() => _context.LoadPropertyAsync(customer, "Orders", continuation.NextLinkUri, source.Token);
         source.Cancel();
-        var exception3 = await Assert.ThrowsAsync<OperationCanceledException>(response3);
-        Assert.Equal("The operation was canceled.", exception3.Message);
+        var exception3 = await Assert.ThrowsAsync<TaskCanceledException>(response3);
+        Assert.Equal("A task was canceled.", exception3.Message);
     }
 
     #endregion
@@ -291,8 +291,8 @@ public class CancellationTokenTests : EndToEndTestBase<CancellationTokenTests.Te
             });
 
         source.Cancel();
-        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(response);
-        Assert.Equal("The operation was canceled.", exception.Message);
+        var exception = await Assert.ThrowsAsync<TaskCanceledException>(response);
+        Assert.Equal("A task was canceled.", exception.Message);
     }
 
     #endregion

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/BulkUpdateE2ETests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/BulkUpdateE2ETests.cs
@@ -1012,6 +1012,12 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
                     });
             }
 
+            public override Task<IODataResponseMessage> GetResponseAsync(CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return Task.FromResult(GetResponse());
+            }
+
             public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
             {
                 return GetCompletedTask(callback, state);

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DeepInsertE2ETests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DeepInsertE2ETests.cs
@@ -985,6 +985,12 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
                     });
             }
 
+            public override Task<IODataResponseMessage> GetResponseAsync(CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return Task.FromResult(GetResponse());
+            }
+
             public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
             {
                 return GetCompletedTask(callback, state);

--- a/test/UnitTests/Microsoft.OData.Client.Tests/DataServiceActionQuerySingleTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/DataServiceActionQuerySingleTests.cs
@@ -308,18 +308,13 @@ public class DataServiceActionQuerySingleTests
     }
 
     [Fact]
-    public async Task GetValueAsync_UsesBeginEndPattern_ReturnsSingleValue()
+    public async Task GetValueAsync_UsesNativeAsyncPath_ReturnsSingleValue()
     {
         // Arrange
-        var asyncResult = new TestAsyncResult();
         var context = new TestDataServiceContext<int>(new Uri("http://service/"))
         {
-            BeginExecuteFunc = (uri, callback, state, method, single, parameters) =>
-            {
-                callback?.Invoke(asyncResult);
-                return asyncResult;
-            },
-            EndExecuteFunc = (ar) => new[] { 567 }
+            ExecuteAsyncFunc = (uri, method, single, cancellationToken, parameters) =>
+                Task.FromResult<IEnumerable<int>>(new[] { 567 })
         };
 
         var query = new DataServiceActionQuerySingle<int>(
@@ -334,18 +329,13 @@ public class DataServiceActionQuerySingleTests
     }
 
     [Fact]
-    public async Task GetValueAsync_UsesBeginEndPattern_ThrowsInvalidOperationException_WhenNoResultsForNonNullableType()
+    public async Task GetValueAsync_UsesNativeAsyncPath_ThrowsInvalidOperationException_WhenNoResultsForNonNullableType()
     {
         // Arrange
-        var asyncResult = new TestAsyncResult();
         var context = new TestDataServiceContext<int>(new Uri("http://service/"))
         {
-            BeginExecuteFunc = (uri, callback, state, method, single, parameters) =>
-            {
-                callback?.Invoke(asyncResult);
-                return asyncResult;
-            },
-            EndExecuteFunc = (ar) => Enumerable.Empty<int>()
+            ExecuteAsyncFunc = (uri, method, single, cancellationToken, parameters) =>
+                Task.FromResult(Enumerable.Empty<int>())
         };
 
         var query = new DataServiceActionQuerySingle<int>(
@@ -357,18 +347,13 @@ public class DataServiceActionQuerySingleTests
     }
 
     [Fact]
-    public async Task GetValueAsync_UsesBeginEndPattern_Throws_WhenMultipleResults()
+    public async Task GetValueAsync_UsesNativeAsyncPath_Throws_WhenMultipleResults()
     {
         // Arrange
-        var asyncResult = new TestAsyncResult();
         var context = new TestDataServiceContext<int>(new Uri("http://service/"))
         {
-            BeginExecuteFunc = (uri, callback, state, method, single, parameters) =>
-            {
-                callback?.Invoke(asyncResult);
-                return asyncResult;
-            },
-            EndExecuteFunc = (ar) => new[] { 1, 2 }
+            ExecuteAsyncFunc = (uri, method, single, cancellationToken, parameters) =>
+                Task.FromResult<IEnumerable<int>>(new[] { 1, 2 })
         };
 
         var query = new DataServiceActionQuerySingle<int>(
@@ -380,23 +365,40 @@ public class DataServiceActionQuerySingleTests
     }
 
     [Fact]
+    public async Task GetValueAsync_UsesNativeAsyncPath_ReturnsNullForNullableType()
+    {
+        // Arrange
+        var context = new TestDataServiceContext<int?>(new Uri("http://service/"))
+        {
+            ExecuteAsyncFunc = (uri, method, single, cancellationToken, parameters) =>
+                Task.FromResult(Enumerable.Empty<int?>())
+        };
+        var query = new DataServiceActionQuerySingle<int?>(context, "http://service/Action");
+
+        // Act
+        int? result = await query.GetValueAsync();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
     public async Task GetValueAsync_WithCancellationToken_ReturnsExpectedResult()
     {
         // Arrange
-        var asyncResult = new TestAsyncResult();
+        using var cancellationTokenSource = new CancellationTokenSource();
         var context = new TestDataServiceContext<int>(new Uri("http://service/"))
         {
-            BeginExecuteFunc = (uri, callback, state, method, single, parameters) =>
+            ExecuteAsyncFunc = (uri, method, single, cancellationToken, parameters) =>
             {
-                callback?.Invoke(asyncResult);
-                return asyncResult;
-            },
-            EndExecuteFunc = (ar) => new[] { 888 }
+                Assert.Equal(cancellationTokenSource.Token, cancellationToken);
+                return Task.FromResult<IEnumerable<int>>(new[] { 888 });
+            }
         };
         var query = new DataServiceActionQuerySingle<int>(context, "http://service/Action");
 
         // Act
-        var result = await query.GetValueAsync(CancellationToken.None);
+        var result = await query.GetValueAsync(cancellationTokenSource.Token);
 
         // Assert
         Assert.Equal(888, result);
@@ -480,6 +482,7 @@ public class DataServiceActionQuerySingleTests
     private class TestDataServiceContext<T> : DataServiceContext
     {
         public Func<Uri, string, bool, BodyOperationParameter[], IEnumerable<T>> ExecuteFunc { get; set; }
+        public Func<Uri, string, bool, CancellationToken, BodyOperationParameter[], Task<IEnumerable<T>>> ExecuteAsyncFunc { get; set; }
         public Func<Uri, AsyncCallback, object, string, bool, BodyOperationParameter[], IAsyncResult> BeginExecuteFunc { get; set; }
         public Func<IAsyncResult, IEnumerable<T>> EndExecuteFunc { get; set; }
 
@@ -497,6 +500,23 @@ public class DataServiceActionQuerySingleTests
         {
             if (typeof(TElement) == typeof(T) && BeginExecuteFunc != null)
                 return BeginExecuteFunc(requestUri, callback, state, httpMethod, singleResult, operationParameters.Cast<BodyOperationParameter>().ToArray());
+
+            throw new NotImplementedException();
+        }
+
+        public override async Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, string httpMethod, bool singleResult, CancellationToken cancellationToken, params OperationParameter[] operationParameters)
+        {
+            if (typeof(TElement) == typeof(T) && ExecuteAsyncFunc != null)
+            {
+                IEnumerable<T> result = await ExecuteAsyncFunc(
+                    requestUri,
+                    httpMethod,
+                    singleResult,
+                    cancellationToken,
+                    operationParameters.Cast<BodyOperationParameter>().ToArray());
+
+                return (IEnumerable<TElement>)result;
+            }
 
             throw new NotImplementedException();
         }

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/AsyncWasmCompatibilityTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/AsyncWasmCompatibilityTests.cs
@@ -21,8 +21,7 @@ namespace Microsoft.OData.Client.Tests.Serialization
 {
     /// <summary>
     /// Tests for the async-native WASM compatibility path that eliminates Task.Wait() blocking.
-    /// These tests verify that GetResponseAsync, ExecuteAsync, GetAllPagesAsync, and
-    /// EnumerateAllPagesAsync work correctly through the new async pipeline.
+    /// These tests verify that query, paging, stream, and save operations use the native async pipeline.
     /// </summary>
     public class AsyncWasmCompatibilityTests
     {
@@ -37,11 +36,29 @@ namespace Microsoft.OData.Client.Tests.Serialization
         </Key>
         <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
         <Property Name=""Name"" Type=""Edm.String"" />
+        <Property Name=""Photo"" Type=""Edm.Stream"" />
+        <NavigationProperty Name=""Category"" Type=""Test.Category"" />
+        <NavigationProperty Name=""Categories"" Type=""Collection(Test.Category)"" />
+      </EntityType>
+      <EntityType Name=""Category"">
+        <Key>
+          <PropertyRef Name=""Id"" />
+        </Key>
+        <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""Name"" Type=""Edm.String"" />
+      </EntityType>
+      <EntityType Name=""Document"" HasStream=""true"">
+        <Key>
+          <PropertyRef Name=""Id"" />
+        </Key>
+        <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
       </EntityType>
     </Schema>
     <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""Default"">
       <EntityContainer Name=""Container"">
         <EntitySet Name=""Products"" EntityType=""Test.Product"" />
+        <EntitySet Name=""Categories"" EntityType=""Test.Category"" />
+        <EntitySet Name=""Documents"" EntityType=""Test.Document"" />
       </EntityContainer>
     </Schema>
   </edmx:DataServices>
@@ -371,6 +388,201 @@ namespace Microsoft.OData.Client.Tests.Serialization
 
         #endregion
 
+        #region Remaining Async API Tests
+
+        [Fact]
+        public async Task SaveChangesAsync_UpdatesEntity_WithoutUsingApm()
+        {
+            var context = CreateContext();
+            SetupRequestPipeline(context, string.Empty, 204, null);
+            var product = new Product { Id = 1, Name = "Updated" };
+            context.AttachTo("Products", product);
+            context.UpdateObject(product);
+            bool changesSaved = false;
+            context.ChangesSaved += (_, _) => changesSaved = true;
+
+            DataServiceResponse response = await context.SaveChangesAsync();
+
+            ChangeOperationResponse operationResponse = Assert.IsType<ChangeOperationResponse>(Assert.Single(response));
+            Assert.Equal(204, operationResponse.StatusCode);
+            Assert.True(changesSaved);
+        }
+
+        [Fact]
+        public async Task SaveChangesAsync_BatchWithPreCanceledToken_DoesNotUseApm()
+        {
+            var context = CreateContext();
+            SetupRequestPipeline(context, string.Empty);
+            context.AddObject("Products", new Product { Id = 3, Name = "New" });
+            using var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => context.SaveChangesAsync(SaveChangesOptions.BatchWithSingleChangeset, cancellationTokenSource.Token));
+        }
+
+        [Fact]
+        public async Task ExecuteBatchAsync_WithPreCanceledToken_DoesNotUseApm()
+        {
+            var context = CreateContext();
+            SetupRequestPipeline(context, string.Empty);
+            using var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => context.ExecuteBatchAsync(cancellationTokenSource.Token, context.Products));
+        }
+
+        [Fact]
+        public async Task LoadPropertyAsync_LoadsNavigationProperty_WithoutUsingApm()
+        {
+            const string categoryResponse = @"{
+    ""@odata.context"": ""http://localhost:9090/$metadata#Categories/$entity"",
+    ""Id"": 7,
+    ""Name"": ""Hardware""
+}";
+            var context = CreateContext();
+            SetupRequestPipeline(context, categoryResponse);
+            var product = new Product { Id = 1, Name = "Widget" };
+            context.AttachTo("Products", product);
+
+            QueryOperationResponse response = await context.LoadPropertyAsync(product, nameof(Product.Category));
+
+            Assert.NotNull(response);
+            Assert.NotNull(product.Category);
+            Assert.Equal(7, product.Category.Id);
+        }
+
+        [Fact]
+        public async Task LoadPropertyAsync_WithNextLink_LoadsCollection_WithoutUsingApm()
+        {
+            const string categoriesResponse = @"{
+    ""@odata.context"": ""http://localhost:9090/$metadata#Categories"",
+    ""value"": [
+        { ""Id"": 7, ""Name"": ""Hardware"" }
+    ]
+}";
+            var context = CreateContext();
+            SetupRequestPipeline(context, categoriesResponse);
+            var product = new Product { Id = 1, Name = "Widget", Categories = new List<Category>() };
+            context.AttachTo("Products", product);
+
+            QueryOperationResponse response = await context.LoadPropertyAsync(
+                product,
+                nameof(Product.Categories),
+                new Uri($"{ServiceRoot}/Products(1)/Categories?$skip=1"));
+
+            Assert.NotNull(response);
+            Assert.Single(product.Categories);
+        }
+
+        [Fact]
+        public async Task LoadPropertyAllPagesAsync_LoadsContinuations_WithoutUsingApm()
+        {
+            const string firstPageResponse = @"{
+    ""@odata.context"": ""http://localhost:9090/$metadata#Categories"",
+    ""value"": [
+        { ""Id"": 7, ""Name"": ""Hardware"" }
+    ],
+    ""@odata.nextLink"": ""http://localhost:9090/Products(1)/Categories?$skip=1""
+}";
+            const string secondPageResponse = @"{
+    ""@odata.context"": ""http://localhost:9090/$metadata#Categories"",
+    ""value"": [
+        { ""Id"": 8, ""Name"": ""Software"" }
+    ]
+}";
+            int requestCount = 0;
+            var context = CreateContext();
+            context.Configurations.RequestPipeline.OnMessageCreating = args =>
+                new AsyncTestRequestMessage(args, ++requestCount == 1 ? firstPageResponse : secondPageResponse);
+            var product = new Product { Id = 1, Name = "Widget", Categories = new List<Category>() };
+            context.AttachTo("Products", product);
+
+            QueryOperationResponse response = await context.LoadPropertyAllPagesAsync(
+                product,
+                nameof(Product.Categories),
+                CancellationToken.None);
+
+            Assert.NotNull(response);
+            Assert.Equal(2, product.Categories.Count);
+            Assert.Equal(2, requestCount);
+        }
+
+        [Fact]
+        public async Task GetReadStreamAsync_ReturnsStream_WithoutUsingApm()
+        {
+            byte[] payload = Encoding.UTF8.GetBytes("stream content");
+            var context = CreateContext();
+            context.Configurations.RequestPipeline.OnMessageCreating = args =>
+                new AsyncTestRequestMessage(args, payload, 200, "application/octet-stream");
+            var document = new Document { Id = 1 };
+            context.AttachTo("Documents", document);
+            context.GetEntityDescriptor(document).ReadStreamUri = new Uri($"{ServiceRoot}/Documents(1)/$value");
+
+            using DataServiceStreamResponse response = await context.GetReadStreamAsync(
+                document,
+                new DataServiceRequestArgs());
+            using var reader = new StreamReader(response.Stream);
+
+            Assert.Equal("application/octet-stream", response.ContentType);
+            Assert.Equal("stream content", await reader.ReadToEndAsync());
+        }
+
+        [Fact]
+        public async Task GetReadStreamAsync_WithNamedStream_ReturnsStream_WithoutUsingApm()
+        {
+            byte[] payload = Encoding.UTF8.GetBytes("photo content");
+            var context = CreateContext();
+            context.Configurations.RequestPipeline.OnMessageCreating = args =>
+                new AsyncTestRequestMessage(args, payload, 200, "image/png");
+            var product = new Product { Id = 1, Name = "Widget" };
+            context.AttachTo("Products", product);
+            context.GetEntityDescriptor(product).AddStreamInfoIfNotPresent(nameof(Product.Photo)).SelfLink =
+                new Uri($"{ServiceRoot}/Products(1)/Photo");
+
+            using DataServiceStreamResponse response = await context.GetReadStreamAsync(
+                product,
+                nameof(Product.Photo),
+                new DataServiceRequestArgs(),
+                CancellationToken.None);
+            using var reader = new StreamReader(response.Stream);
+
+            Assert.Equal("image/png", response.ContentType);
+            Assert.Equal("photo content", await reader.ReadToEndAsync());
+        }
+
+        [Fact]
+        public async Task BulkUpdateAsync_WithPreCanceledToken_DoesNotUseApm()
+        {
+            var context = CreateContext();
+            SetupRequestPipeline(context, string.Empty);
+            var product = new Product { Id = 1, Name = "Updated" };
+            context.AttachTo("Products", product);
+            context.UpdateObject(product);
+            using var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => context.BulkUpdateAsync(cancellationTokenSource.Token, product));
+        }
+
+        [Fact]
+        public async Task DeepInsertAsync_WithPreCanceledToken_DoesNotUseApm()
+        {
+            var context = CreateContext();
+            SetupRequestPipeline(context, string.Empty);
+            var product = new Product { Id = 3, Name = "New" };
+            context.AddObject("Products", product);
+            using var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => context.DeepInsertAsync(product, cancellationTokenSource.Token));
+        }
+
+        #endregion
+
         #region Helper Methods
 
         private TestContainer CreateContext()
@@ -384,6 +596,12 @@ namespace Microsoft.OData.Client.Tests.Serialization
                 new AsyncTestRequestMessage(args, response);
         }
 
+        private void SetupRequestPipeline(DataServiceContext context, string response, int statusCode, string contentType)
+        {
+            context.Configurations.RequestPipeline.OnMessageCreating = (args) =>
+                new AsyncTestRequestMessage(args, response, statusCode, contentType);
+        }
+
         #endregion
 
         #region Test Types
@@ -393,6 +611,23 @@ namespace Microsoft.OData.Client.Tests.Serialization
         {
             public int Id { get; set; }
             public string Name { get; set; }
+            public DataServiceStreamLink Photo { get; set; }
+            public Category Category { get; set; }
+            public List<Category> Categories { get; set; }
+        }
+
+        [Key("Id")]
+        public class Category
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        [Key("Id")]
+        [HasStream]
+        public class Document
+        {
+            public int Id { get; set; }
         }
 
         private class TestContainer : DataServiceContext
@@ -425,44 +660,61 @@ namespace Microsoft.OData.Client.Tests.Serialization
         /// </summary>
         private class AsyncTestRequestMessage : HttpClientRequestMessage
         {
-            private readonly string _response;
+            private readonly byte[] _response;
+            private readonly int _statusCode;
+            private readonly string _contentType;
 
             public AsyncTestRequestMessage(DataServiceClientRequestMessageArgs args, string response)
+                : this(args, Encoding.UTF8.GetBytes(response), 200, "application/json;charset=utf-8")
+            {
+            }
+
+            public AsyncTestRequestMessage(DataServiceClientRequestMessageArgs args, string response, int statusCode, string contentType = "application/json;charset=utf-8")
+                : this(args, Encoding.UTF8.GetBytes(response), statusCode, contentType)
+            {
+            }
+
+            public AsyncTestRequestMessage(DataServiceClientRequestMessageArgs args, byte[] response, int statusCode, string contentType)
                 : base(args)
             {
                 _response = response;
+                _statusCode = statusCode;
+                _contentType = contentType;
             }
 
             public override IODataResponseMessage GetResponse()
             {
-                return CreateMockResponse();
+                throw new NotSupportedException("Synchronous response APIs are unavailable on WebAssembly.");
             }
 
             public override Task<IODataResponseMessage> GetResponseAsync(CancellationToken cancellationToken)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                return Task.FromResult(GetResponse());
+                return Task.FromResult(CreateMockResponse());
             }
 
             public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
             {
-                var tcs = new TaskCompletionSource<bool>(state);
-                tcs.TrySetResult(true);
-                callback(tcs.Task);
-                return tcs.Task;
+                throw new NotSupportedException("APM response APIs are unavailable on WebAssembly.");
             }
 
             public override IODataResponseMessage EndGetResponse(IAsyncResult asyncResult)
             {
-                return GetResponse();
+                throw new NotSupportedException("APM response APIs are unavailable on WebAssembly.");
             }
 
             private IODataResponseMessage CreateMockResponse()
             {
+                var headers = new Dictionary<string, string>();
+                if (_contentType != null)
+                {
+                    headers.Add("Content-Type", _contentType);
+                }
+
                 return new HttpWebResponseMessage(
-                    new Dictionary<string, string> { { "Content-Type", "application/json;charset=utf-8" } },
-                    200,
-                    () => new MemoryStream(Encoding.UTF8.GetBytes(_response)),
+                    headers,
+                    _statusCode,
+                    () => new MemoryStream(_response),
                     null);
             }
         }

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/AsyncWasmCompatibilityTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Serialization/AsyncWasmCompatibilityTests.cs
@@ -434,6 +434,15 @@ namespace Microsoft.OData.Client.Tests.Serialization
         }
 
         [Fact]
+        public async Task ExecuteBatchAsync_WithEmptyQueries_Throws()
+        {
+            var context = CreateContext();
+
+            await Assert.ThrowsAsync<ArgumentException>(
+                () => context.ExecuteBatchAsync(Array.Empty<DataServiceRequest>()));
+        }
+
+        [Fact]
         public async Task LoadPropertyAsync_LoadsNavigationProperty_WithoutUsingApm()
         {
             const string categoryResponse = @"{
@@ -507,6 +516,21 @@ namespace Microsoft.OData.Client.Tests.Serialization
             Assert.NotNull(response);
             Assert.Equal(2, product.Categories.Count);
             Assert.Equal(2, requestCount);
+        }
+
+        [Fact]
+        public async Task LoadPropertyAsync_WithNullContinuation_Throws()
+        {
+            var context = CreateContext();
+            var product = new Product { Id = 1, Name = "Widget", Categories = new List<Category>() };
+            context.AttachTo("Products", product);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => context.LoadPropertyAsync(
+                    product,
+                    nameof(Product.Categories),
+                    continuation: null,
+                    CancellationToken.None));
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- replace remaining APM-based async wrappers with native task-based implementations
- preserve 9.x action-result and save-event behavior
- add WASM regression coverage that rejects synchronous and Begin/End response APIs
- update bulk-update and deep-insert test messages for native async responses

## Tests
- 648 Microsoft.OData.Client unit tests passed on .NET 10

Fixes #3605