### PR TITLE
Fix quoted delimiters in balanced expressions

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
@@ -1220,11 +1220,11 @@ namespace Microsoft.OData.UriParser
                     this.AdvanceToNextOccurenceOf('\'');
                 }
 
-                if (this.ch == startingCharacter)
+                if (!this.parsingDoubleQuotedString && this.ch == startingCharacter)
                 {
                     currentBracketDepth++;
                 }
-                else if (this.ch == endingCharacter)
+                else if (!this.parsingDoubleQuotedString && this.ch == endingCharacter)
                 {
                     currentBracketDepth--;
                 }
@@ -1269,7 +1269,13 @@ namespace Microsoft.OData.UriParser
 
         private void DoubleQuotedStringCheckpoint()
         {
-            if (this.textPos != 0 && this.Text[this.textPos - 1] != '\\')
+            int precedingBackslashCount = 0;
+            for (int index = this.textPos - 1; index >= 0 && this.Text[index] == '\\'; index--)
+            {
+                precedingBackslashCount++;
+            }
+
+            if (precedingBackslashCount % 2 == 0)
             {
                 this.parsingDoubleQuotedString = !this.parsingDoubleQuotedString;
             }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Query/ODataUriUtilsTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Query/ODataUriUtilsTests.cs
@@ -280,6 +280,36 @@ namespace Microsoft.OData.Tests.Query
             Assert.Equal(new int[] { 1, 2, 3 }, collectionValue.Items.Cast<int>());
         }
 
+        [Theory]
+        [InlineData("[{\"obj\":\"bracket[\"}]")]
+        [InlineData("[{\"obj\":\"bracket]\"}]")]
+        [InlineData("[{\"obj\":\"brackets[]\"}]")]
+        [InlineData("[{\"obj\":\"braces{}\"}]")]
+        [InlineData("[{\"obj\":\"quote \\\"[\\\" remains in the string\"}]")]
+        [InlineData("[{\"obj\":\"quote \\\"{\\\" remains in the string\"}]")]
+        [InlineData("[{\"obj\":\"\\\\\"}]")]
+        [InlineData("[{\"obj\":\"\\\\\",\"items\":[\"[\",\"]\",\"{\",\"}\"]}]")]
+        public void TestCollectionConvertIgnoresDelimitersInsideJsonStrings(string literal)
+        {
+            object collection = ODataUriUtils.ConvertFromUriLiteral(literal, ODataVersion.V4);
+            var collectionValue = Assert.IsType<ODataCollectionValue>(collection);
+
+            Assert.Single(collectionValue.Items);
+        }
+
+        [Theory]
+        [InlineData("['[']", "[")]
+        [InlineData("[']']", "]")]
+        [InlineData("['[[[']", "[[[")]
+        [InlineData("[']]]']", "]]]")]
+        public void TestCollectionConvertIgnoresBracketsInsideSingleQuotedStrings(string literal, string expected)
+        {
+            object collection = ODataUriUtils.ConvertFromUriLiteral(literal, ODataVersion.V4);
+            var collectionValue = Assert.IsType<ODataCollectionValue>(collection);
+
+            Assert.Equal(expected, Assert.Single(collectionValue.Items));
+        }
+
         [Fact]
         public void TestCollectionConvertWithMismatchedBracket()
         {

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
@@ -806,6 +806,65 @@ namespace Microsoft.OData.Tests.UriParser
                 BracketToken("[{complex:value},{complex:value}]"));
         }
 
+        [Theory]
+        [InlineData("[{\"value\":\"[\"}]")]
+        [InlineData("[{\"value\":\"]\"}]")]
+        [InlineData("[{\"value\":\"[]\"}]")]
+        [InlineData("[{\"value\":\"[[[\"}]")]
+        [InlineData("[{\"value\":\"]]]\"}]")]
+        [InlineData("[{\"value\":\"before [ after\"}]")]
+        [InlineData("[{\"value\":\"before ] after\"}]")]
+        [InlineData("[{\"value\":\"quote \\\"[\\\" remains in the string\"}]")]
+        [InlineData("[{\"value\":\"quote \\\"[\\\" and escaped backslash \\\\\"}]")]
+        [InlineData("[{\"value\":\"\\\\\",\"nested\":[1,2,3]}]")]
+        public void BracketsInsideDoubleQuotedStringsDoNotAffectBracketDepth(string expression)
+        {
+            ValidateTokenSequence(expression, BracketToken(expression));
+        }
+
+        [Theory]
+        [InlineData("{\"value\":\"{\"}")]
+        [InlineData("{\"value\":\"}\"}")]
+        [InlineData("{\"value\":\"{}\"}")]
+        [InlineData("{\"value\":\"{{{\"}")]
+        [InlineData("{\"value\":\"}}}\"}")]
+        [InlineData("{\"value\":\"quote \\\"{\\\" remains in the string\"}")]
+        [InlineData("{\"value\":\"\\\\\",\"nested\":{\"id\":1}}")]
+        public void BracesInsideDoubleQuotedStringsDoNotAffectBraceDepth(string expression)
+        {
+            ValidateTokenSequence(expression, BracedToken(expression));
+        }
+
+        [Theory]
+        [InlineData("['[']")]
+        [InlineData("[']']")]
+        [InlineData("['[[[']")]
+        [InlineData("[']]]']")]
+        [InlineData("['before ''['' after']")]
+        public void BracketsInsideSingleQuotedStringsDoNotAffectBracketDepth(string expression)
+        {
+            ValidateTokenSequence(expression, BracketToken(expression));
+        }
+
+        [Theory]
+        [InlineData("{\"value\":'{'}")]
+        [InlineData("{\"value\":'}'}")]
+        [InlineData("{\"value\":'{{{'}")]
+        [InlineData("{\"value\":'}}}'}")]
+        [InlineData("{\"value\":'before ''{'' after'}")]
+        public void BracesInsideSingleQuotedStringsDoNotAffectBraceDepth(string expression)
+        {
+            ValidateTokenSequence(expression, BracedToken(expression));
+        }
+
+        [Theory]
+        [InlineData("[\"missing outer bracket]\"")]
+        [InlineData("{\"value\":\"missing outer brace}\"")]
+        public void DelimitersInsideDoubleQuotedStringsDoNotCloseOuterExpression(string expression)
+        {
+            ValidateLexerException<ODataException>(expression, SRResources.ExpressionLexer_UnbalancedBracketExpression);
+        }
+
         [Fact]
         public void BracketedExpressionsCanHaveCrazyStuffInsideStringLiteral()
         {
@@ -972,6 +1031,40 @@ namespace Microsoft.OData.Tests.UriParser
             // TODO: the state of the lexer is weird right now, see note in AdvanceThroughBalancedParentheticalExpression.
 
             Assert.Equal("next", lexer.NextToken().Span.ToString());
+        }
+
+        [Theory]
+        [InlineData("(\"(\")next")]
+        [InlineData("(\")\")next")]
+        [InlineData("(\"(((\")next")]
+        [InlineData("(\") ))\")next")]
+        [InlineData("(\"quote \\\"(\\\" remains in the string\")next")]
+        [InlineData("(\"\\\\\", nested(value))next")]
+        [InlineData("('(')next")]
+        [InlineData("(')')next")]
+        [InlineData("('(((')next")]
+        [InlineData("(')))')next")]
+        [InlineData("('before ''('' after')next")]
+        public void ParenthesesInsideQuotedStringsDoNotAffectParenthesisDepth(string expression)
+        {
+            ExpressionLexer lexer = new ExpressionLexer(expression, moveToFirstToken: true, useSemicolonDelimiter: true, parsingFunctionParameters: false);
+
+            string result = lexer.AdvanceThroughBalancedParentheticalExpression();
+
+            Assert.Equal(expression.Substring(0, expression.Length - 4), result);
+            Assert.Equal("next", lexer.NextToken().Span.ToString());
+        }
+
+        [Theory]
+        [InlineData("(\"missing outer parenthesis )\"")]
+        [InlineData("('missing outer parenthesis )'")]
+        public void ParenthesesInsideQuotedStringsDoNotCloseOuterExpression(string expression)
+        {
+            ExpressionLexer lexer = new ExpressionLexer(expression, moveToFirstToken: true, useSemicolonDelimiter: true, parsingFunctionParameters: false);
+
+            Action parse = () => lexer.AdvanceThroughBalancedParentheticalExpression();
+
+            parse.Throws<ODataException>(SRResources.ExpressionLexer_UnbalancedBracketExpression);
         }
 
         private char FindMatchingChar(UnicodeCategory category)


### PR DESCRIPTION
Ignore parentheses, brackets, and braces while the expression lexer is inside a double-quoted string. This prevents JSON string content from changing the nesting depth and triggering false unbalanced-expression errors.

Count consecutive backslashes before quotes so escaped quotes and escaped backslashes update string state correctly. Add regression coverage for single- and double-quoted strings, repeated delimiters, nested values, escape sequences, public URI literal conversion, and genuinely unbalanced outer expressions.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
