### PR TITLE
Add quoted delimiter regression coverage

### DIFF
--- a/test/UnitTests/Microsoft.OData.Core.Tests/Query/ODataUriUtilsTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Query/ODataUriUtilsTests.cs
@@ -280,6 +280,36 @@ namespace Microsoft.OData.Tests.Query
             Assert.Equal(new int[] { 1, 2, 3 }, collectionValue.Items.Cast<int>());
         }
 
+        [Theory]
+        [InlineData("[{\"obj\":\"bracket[\"}]")]
+        [InlineData("[{\"obj\":\"bracket]\"}]")]
+        [InlineData("[{\"obj\":\"brackets[]\"}]")]
+        [InlineData("[{\"obj\":\"braces{}\"}]")]
+        [InlineData("[{\"obj\":\"quote \\\"[\\\" remains in the string\"}]")]
+        [InlineData("[{\"obj\":\"quote \\\"{\\\" remains in the string\"}]")]
+        [InlineData("[{\"obj\":\"\\\\\"}]")]
+        [InlineData("[{\"obj\":\"\\\\\",\"items\":[\"[\",\"]\",\"{\",\"}\"]}]")]
+        public void TestCollectionConvertIgnoresDelimitersInsideJsonStrings(string literal)
+        {
+            object collection = ODataUriUtils.ConvertFromUriLiteral(literal, ODataVersion.V4);
+            var collectionValue = Assert.IsType<ODataCollectionValue>(collection);
+
+            Assert.Single(collectionValue.Items);
+        }
+
+        [Theory]
+        [InlineData("['[']", "[")]
+        [InlineData("[']']", "]")]
+        [InlineData("['[[[']", "[[[")]
+        [InlineData("[']]]']", "]]]")]
+        public void TestCollectionConvertIgnoresBracketsInsideSingleQuotedStrings(string literal, string expected)
+        {
+            object collection = ODataUriUtils.ConvertFromUriLiteral(literal, ODataVersion.V4);
+            var collectionValue = Assert.IsType<ODataCollectionValue>(collection);
+
+            Assert.Equal(expected, Assert.Single(collectionValue.Items));
+        }
+
         [Fact]
         public void TestCollectionConvertWithMismatchedBracket()
         {

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
@@ -879,6 +879,48 @@ namespace Microsoft.OData.Tests.UriParser
                 CloseBracketToken);
         }
 
+        [Theory]
+        [InlineData("\"[\"")]
+        [InlineData("\"]\"")]
+        [InlineData("\"{\"")]
+        [InlineData("\"}\"")]
+        [InlineData("\"[[[\"")]
+        [InlineData("\"]]]\"")]
+        [InlineData("\"quote \\\"[\\\" remains in the string\"")]
+        [InlineData("\"quote \\\"{\\\" remains in the string\"")]
+        [InlineData("\"\\\\\"")]
+        public void DoubleQuotedStringsWithDelimitersAreTokenizedAsSingleTokens(string literal)
+        {
+            string expression = $"[{{\"value\":{literal}}}]";
+
+            ValidateTokenSequence(this.model, expression,
+                OpenBracketToken,
+                    OpenBraceToken,
+                        StringToken("\"value\""),
+                        ColonToken,
+                        StringToken(literal),
+                    CloseBraceToken,
+                CloseBracketToken);
+        }
+
+        [Theory]
+        [InlineData("'['")]
+        [InlineData("']'")]
+        [InlineData("'{'")]
+        [InlineData("'}'")]
+        [InlineData("'[[['")]
+        [InlineData("']]]'")]
+        [InlineData("'before ''['' after'")]
+        public void SingleQuotedStringsWithDelimitersAreTokenizedAsSingleTokens(string literal)
+        {
+            string expression = $"[{literal}]";
+
+            ValidateTokenSequence(this.model, expression,
+                OpenBracketToken,
+                    StringToken(literal),
+                CloseBracketToken);
+        }
+
         [Fact]
         public void BracketedExpressionsCanHaveCrazyStuffInsideStringLiteral()
         {


### PR DESCRIPTION
Cover collection URI conversion when JSON and OData strings contain unmatched brackets or braces. Add direct lexer token-sequence tests for repeated delimiters, escaped quotes, escaped backslashes, and nested structured values.

These tests document that the redesigned dev-9.x tokenizer already handles issue #2737 without a production-code change.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
