### PR TITLE
Remove legacy contained navigation path handling

### DIFF
--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -3272,17 +3272,7 @@ namespace Microsoft.OData.Edm
                     }
 
                     navigationProperties[navigationProperty] = new EdmPathExpression(paths);
-
-                    // In 7.4.1, FindNavigationTarget expected a binding path that included the path
-                    // to the contained entity set. In 7.4.2 FindNavigationTarget was fixed to work off
-                    // of the path from the contained entity set, but retained the old behavior as well
-                    // for backward compatibility. In the next breaking change we should remove that
-                    // behavior in FindNavigationTarget and remove this special handling of containsTarget
-                    // by always clearing the path.
-                    if (!navigationProperty.ContainsTarget)
-                    {
-                        paths.Clear();
-                    }
+                    paths.Clear();
 
                     lastEntityType = navigationProperty.ToEntityType();
                 }

--- a/src/Microsoft.OData.Edm/Schema/EdmContainedEntitySet.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmContainedEntitySet.cs
@@ -18,8 +18,6 @@ namespace Microsoft.OData.Edm
         private readonly IEdmNavigationSource parentNavigationSource;
         private readonly IEdmNavigationProperty navigationProperty;
         private IEdmPathExpression path;
-        private string fullPath;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmContainedEntitySet"/> class.
         /// </summary>
@@ -77,28 +75,6 @@ namespace Microsoft.OData.Edm
             }
         }
 
-        private string FullNavigationPath
-        {
-            get
-            {
-                if (this.fullPath == null)
-                {
-                    List<string> fullPath = new List<string>();
-                    EdmContainedEntitySet currentSource = this;
-                    while (currentSource != null)
-                    {
-                        fullPath.AddRange(currentSource.NavigationPath.PathSegments);
-                        currentSource = currentSource.ParentNavigationSource as EdmContainedEntitySet;
-                    }
-
-                    fullPath.Reverse();
-                    this.fullPath = new EdmPathExpression(fullPath).Path;
-                }
-
-                return this.fullPath;
-            }
-        }
-
         /// <summary>
         /// Finds the bindings of the navigation property.
         /// </summary>
@@ -144,19 +120,6 @@ namespace Microsoft.OData.Edm
         /// <returns>The entity set that the navigation property targets</returns>
         public override IEdmNavigationSource FindNavigationTarget(IEdmNavigationProperty navigationProperty, IEdmPathExpression bindingPath)
         {
-            // 7.4.1 expected the path to be prefixed with the path to the contained navigation source.
-            // For backward compatibility, if the binding path received starts with the path to this contained resource,
-            // we trim it off and then treat the remainder as the path to the target. This logic should be removed in
-            // the next breaking change as it could be ambiguous in the case that the prefix of the path to the contained
-            // source matches a valid path to the target of the contained source.
-            if (bindingPath != null)
-            {
-                if (bindingPath.Path.Length > this.FullNavigationPath.Length && bindingPath.Path.StartsWith(this.FullNavigationPath, System.StringComparison.Ordinal))
-                {
-                    bindingPath = new EdmPathExpression(bindingPath.Path.Substring(this.FullNavigationPath.Length + 1));
-                }
-            }
-
             IEdmNavigationSource navigationTarget = base.FindNavigationTarget(navigationProperty, bindingPath);
 
             if (navigationTarget is IEdmUnknownEntitySet)

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.cs
@@ -776,48 +776,6 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
 
         }
 
-        // V4 Protocol Spec Chapter 10.9: Collection of Projected Expanded Entities (not contain select)
-        // Sample Request: http://host/service/Employees?$expand=Company
-        // Context Url in Response: http://host/service/$metadata#Employees(Company)
-        [Fact]
-        public void CollectionOfExpandedEntities_Version741AndBefore()
-        {
-            foreach (ODataFormat mimeType in mimeTypes)
-            {
-                // In 7.4.1 and before, this scenario resulted in the same
-                // context Uri as 10.2: http://host/service/$metadata#Employees
-                var writerSettings = new ODataMessageWriterSettings
-                {
-                    //LibraryCompatibility = ODataLibraryCompatibility.Version7_4_1,
-                };
-
-                string payload, contentType;
-                this.WriteAndValidateContextUri(mimeType, model, writerSettings, omWriter =>
-                {
-                    var selectExpandClause = new ODataQueryOptionParser(this.model, this.employeeType, this.employeeSet, new Dictionary<string, string> { { "$expand", "AssociatedCompany" }, { "$select", null } }).ParseSelectAndExpand();
-
-                    omWriter.Settings.ODataUri = new ODataUri()
-                    {
-                        ServiceRoot = this.testServiceRootUri,
-                        SelectAndExpand = selectExpandClause
-                    };
-
-                    var writer = omWriter.CreateODataResourceSetWriter(this.employeeSet, this.employeeType);
-                    var feed = new ODataResourceSet();
-                    feed.Id = new Uri("urn:test");
-                    writer.WriteStart(feed);
-                    writer.WriteEnd();
-                }, string.Format("\"{0}$metadata#Employees(AssociatedCompany())\"", TestBaseUri), out payload, out contentType);
-
-                this.ReadPayload(payload, contentType, model, omReader =>
-                {
-                    var reader = omReader.CreateODataResourceSetReader(this.employeeSet, this.employeeType);
-                    while (reader.Read()) { }
-                    Assert.Equal(ODataReaderState.Completed, reader.State);
-                });
-            }
-        }
-
         // V4 Protocol Spec Chapter 10.10: Projected Expanded Entities (contain select)
         // Sample Request: http://host/service/Employees(0)?$expand=Company($select=CompanyId)
         // Context Url in Response: http://host/service/$metadata#Employees(Company(CompanyId))/$entity

--- a/test/UnitTests/Microsoft.OData.Edm.Tests/Schema/EdmSingletonTests.cs
+++ b/test/UnitTests/Microsoft.OData.Edm.Tests/Schema/EdmSingletonTests.cs
@@ -169,6 +169,7 @@ namespace Microsoft.OData.Edm.Tests.Library
             Assert.True(foundSa2b is IEdmContainedEntitySet);
             var foundSa2bc = foundSa2b.FindNavigationTarget(btocNavProp);
             Assert.Same(sa2bc, foundSa2bc);
+            Assert.True(foundSa2b.FindNavigationTarget(btocNavProp, new EdmPathExpression("a2/b/c")) is IEdmUnknownEntitySet);
             var foundSa2bda1 = foundSa2b.FindNavigationTarget(dtoa1NavProp, new EdmPathExpression("TestNS.dType/a1"));
             Assert.True(foundSa2bda1 is IEdmContainedEntitySet);
             var foundSa2bda1b = foundSa2bda1.FindNavigationTarget(atobNavProp);


### PR DESCRIPTION
Remove the 7.4.1 compatibility behavior that strips a contained navigation source prefix from binding paths. Navigation paths passed to contained sources are now interpreted as relative paths without an ambiguous legacy fallback.

Always reset relative operation entity-set paths after each navigation property, remove the obsolete Version741 compatibility scenario, and verify that legacy prefixed paths no longer resolve navigation targets.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2562.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
